### PR TITLE
fix(agents-api): Fixes in entry model and message content for function calling

### DIFF
--- a/agents-api/agents_api/common/protocol/entries.py
+++ b/agents-api/agents_api/common/protocol/entries.py
@@ -1,14 +1,13 @@
 from datetime import datetime
 import json
-from typing import Literal, Union
+from typing import Literal
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, Field, computed_field, validator
 from agents_api.autogen.openapi_model import Role
 
 EntrySource = Literal["api_request", "api_response", "internal", "summarizer"]
 Tokenizer = Literal["character_count"]
-Content = Union[str, dict]
 
 
 class Entry(BaseModel):
@@ -17,7 +16,7 @@ class Entry(BaseModel):
     source: EntrySource = Field(default="api_request")
     role: Role
     name: str | None = None
-    content: Content
+    content: str
     tokenizer: str = Field(default="character_count")
     created_at: float = Field(default_factory=lambda: datetime.utcnow().timestamp())
     timestamp: float = Field(default_factory=lambda: datetime.utcnow().timestamp())

--- a/agents-api/agents_api/routers/sessions/session.py
+++ b/agents-api/agents_api/routers/sessions/session.py
@@ -61,10 +61,11 @@ class BaseSession:
         # Unpack tool calls if present
         if not message.content and message.tool_calls:
             role = "function_call"
-            content = message.tool_calls[0].function
-
+            function_call = message.tool_calls[0].function.model_dump()
+            content = json.dumps(function_call)
             # FIXME: what?? why is this happening?? could be a bug in the model api
-            content = content[content.index("{", 1) :]
+            # this is only a hack for samantha-1-turbo
+            # content = content[content.index("{", 1) :]
         elif not message.content:
             raise ValueError("No content in response")
 


### PR DESCRIPTION
function calling patch

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 79b6cfc410b001aac2228e19ad47b7c13b9c8b57.  | 
|--------|--------|

### Summary:
This PR modifies the `Content` type in `entries.py` and adjusts function call handling in `session.py`.

**Key points**:
- Changed `Content` type from `Union[str, dict]` to `str` in `entries.py`
- Modified function call handling in `session.py` to dump function into a JSON string
- Left a commented out hack for a specific model in `session.py` untouched


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
