### PR TITLE
fix(agents-api): Disable tool retrieval (for now)

### DIFF
--- a/agents-api/agents_api/models/agent/create_tools.py
+++ b/agents-api/agents_api/models/agent/create_tools.py
@@ -31,7 +31,7 @@ def create_tools_query(
     functions_input: list[list] = []
 
     for function, embedding in zip(functions, embeddings):
-        parameters = function.parameters.model_dump_json()
+        parameters = function.parameters.model_dump()
         functions_input.append(
             [
                 str(agent_id),

--- a/agents-api/agents_api/models/entry/proc_mem_context.py
+++ b/agents-api/agents_api/models/entry/proc_mem_context.py
@@ -133,17 +133,24 @@ def proc_mem_context_query(
         # Search for tools
         ?[role, name, content, token_count, created_at, index] :=
             *_input{{agent_id, tool_query}},
-            ~agent_functions:embedding_space {{
+            # ~agent_functions:embedding_space {{
+            #     agent_id,
+            #     name: fn_name,
+            #     description,
+            #     parameters,
+            #     updated_at: created_at |
+            #     query: tool_query,
+            #     k: $k_tools,
+            #     ef: 128,
+            #     radius: $tools_radius,
+            #     bind_distance: distance,
+            # }},
+            *agent_functions {{
                 agent_id,
                 name: fn_name,
                 description,
                 parameters,
-                updated_at: created_at |
-                query: tool_query,
-                k: $k_tools,
-                ef: 128,
-                radius: $tools_radius,
-                bind_distance: distance,
+                updated_at: created_at,
             }},
 
             role = "system",


### PR DESCRIPTION
Signed-off-by: Diwank Singh Tomer <diwank.singh@gmail.com>


<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit be5373c8e98ea719eb9feb1eda838e1a59b28dcc.  | 
|--------|--------|

### Summary:
This PR modifies the `create_tools_query` function in `create_tools.py` to change the way parameters are dumped, and updates the `proc_mem_context_query` function in `proc_mem_context.py` to disable the tool retrieval functionality.

**Key points**:
- Modified `create_tools.py` to replace `model_dump_json()` with `model_dump()` in the `create_tools_query` function.
- Updated `proc_mem_context.py` to comment out the tool retrieval section and replace it with a simpler query in the `proc_mem_context_query` function.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
