### PR TITLE
fix: Convert UUID to str

### DIFF
--- a/agents-api/agents_api/models/agent/patch_agent.py
+++ b/agents-api/agents_api/models/agent/patch_agent.py
@@ -52,7 +52,7 @@ def patch_agent_query(
     settings_cols, settings_vals = cozo_process_mutate_data(
         {
             **default_settings,
-            "agent_id": agent_id,
+            "agent_id": str(agent_id),
         }
     )
 


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit e0e7390651478af1dd24b156517204448782650f.  | 
|--------|--------|

### Summary:
This PR modifies the `patch_agent_query` function in `/agents-api/agents_api/models/agent/patch_agent.py` to convert `agent_id` from UUID to string before processing.

**Key points**:
- Modified `patch_agent_query` function in `/agents-api/agents_api/models/agent/patch_agent.py`.
- Converted `agent_id` from UUID to string before processing with `cozo_process_mutate_data` function.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
