### PR TITLE
fix: Raise agent not found error on assertion failure

### DIFF
--- a/agents-api/agents_api/routers/agents/routers.py
+++ b/agents-api/agents_api/routers/agents/routers.py
@@ -133,7 +133,7 @@ async def update_agent(
             detail="Agent not found",
         )
     except QueryException as e:
-        if e.code == "transact::assertion_failure":
+        if e.code in ("transact::assertion_failure", "eval::assert_some_failure"):
             raise AgentNotFoundError(x_developer_id, agent_id)
 
         raise

--- a/agents-api/agents_api/routers/sessions/routers.py
+++ b/agents-api/agents_api/routers/sessions/routers.py
@@ -161,6 +161,12 @@ async def update_session(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Session not found",
         )
+    except QueryException as e:
+        # the code is not so informative now, but it may be a good solution in the future
+        if e.code in ("transact::assertion_failure", "eval::assert_some_failure"):
+            raise SessionNotFoundError(x_developer_id, session_id)
+
+        raise
 
 
 @router.patch("/sessions/{session_id}", tags=["sessions"])
@@ -186,6 +192,12 @@ async def patch_session(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Session not found",
         )
+    except QueryException as e:
+        # the code is not so informative now, but it may be a good solution in the future
+        if e.code in ("transact::assertion_failure", "eval::assert_some_failure"):
+            raise SessionNotFoundError(x_developer_id, session_id)
+
+        raise
 
 
 @router.get("/sessions/{session_id}/suggestions", tags=["sessions"])

--- a/agents-api/agents_api/routers/users/routers.py
+++ b/agents-api/agents_api/routers/users/routers.py
@@ -108,7 +108,7 @@ async def update_user(
         )
     except QueryException as e:
         # the code is not so informative now, but it may be a good solution in the future
-        if e.code == "transact::assertion_failure":
+        if e.code in ("transact::assertion_failure", "eval::assert_some_failure"):
             raise UserNotFoundError(x_developer_id, user_id)
 
         raise


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->
| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit d9bbee196fd7aa664aeb4ad17fb8fd9c8f743eee.  | 
|--------|--------|

### Summary:
This PR updates the error handling in `update_agent`, `update_session`, and `update_user` functions to raise specific NotFoundErrors for `eval::assert_some_failure` exception code.

**Key points**:
- Updated the `update_agent` function in `/agents-api/agents_api/routers/agents/routers.py`.
- Updated error handling in `update_session` function in `/agents-api/agents_api/routers/sessions/routers.py`.
- Updated error handling in `update_user` function in `/agents-api/agents_api/routers/users/routers.py`.
- Now, `AgentNotFoundError`, `SessionNotFoundError`, and `UserNotFoundError` will be raised for `eval::assert_some_failure` exception code as well.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
