### PR TITLE
fix: run build

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Build TypeScript SDK
         run: |
           cd sdks/ts
-          # npm run build
+          npm run build
 
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:


### PR DESCRIPTION
closes #193 

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5d08ad0d558c549d801d2f57d8e96945ce894f46.  | 
|--------|--------|

### Summary:
This PR enables the build step for the TypeScript SDK in the GitHub Actions workflow by uncommenting the `npm run build` command in the `lint-and-format.yml` file.

**Key points**:
- Uncommented `npm run build` command in the `lint-and-format.yml` workflow file.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
