### PR TITLE
fix: Merge agent and user metadata

### DIFF
--- a/agents-api/agents_api/activities/types.py
+++ b/agents-api/agents_api/activities/types.py
@@ -25,12 +25,10 @@ class ChatML(BaseModel):
     token_count: Optional[int] = None
 
 
-class BaseTask(BaseModel):
-    ...
+class BaseTask(BaseModel): ...
 
 
-class BaseTaskArgs(BaseModel):
-    ...
+class BaseTaskArgs(BaseModel): ...
 
 
 class AddPrinciplesTaskArgs(BaseTaskArgs):

--- a/agents-api/agents_api/clients/worker/types.py
+++ b/agents-api/agents_api/clients/worker/types.py
@@ -25,12 +25,10 @@ class ChatML(BaseModel):
     token_count: Optional[int] = None
 
 
-class BaseTask(BaseModel):
-    ...
+class BaseTask(BaseModel): ...
 
 
-class BaseTaskArgs(BaseModel):
-    ...
+class BaseTaskArgs(BaseModel): ...
 
 
 class MemoryManagementTaskArgs(BaseTaskArgs):


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 0ae5d0e072c619d44eb7f188c5f2912f444f19db.  | 
|--------|--------|

### Summary:
This PR modifies the `patch_agent_query` and `patch_user_query` functions to extract, merge, and update `metadata` for agents and users.

**Key points**:
- Added `metadata` field extraction from `update_data` in `patch_agent_query` and `patch_user_query` functions.
- Merged new `metadata` with existing one in the database using `concat` function.
- Included updated `metadata` in the update query for both agents and users.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
