### PR TITLE
fix: Disable model-serving by default

### DIFF
--- a/.github/workflows/push-to-hub.yml
+++ b/.github/workflows/push-to-hub.yml
@@ -8,6 +8,122 @@ on: [push]
 #       - "dev"
 
 jobs:
+  Build-Push-Agents-API-Image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set branch name
+        id: variables
+        run: echo "branch_name=$(echo ${GITHUB_REF#refs/heads/} | tr '/' '-')" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: julepai
+          password: "${{ secrets.DOCKER_HUB_PASSWORD }}"
+
+      - name: Build and push agent images
+        uses: docker/build-push-action@v4
+        with:
+          context: ./agents-api
+          file: ./agents-api/Dockerfile
+          push: true
+          tags: julepai/agents-api:${{ steps.variables.outputs.branch_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  Build-Push-Migration-Image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set branch name
+        id: variables
+        run: echo "branch_name=$(echo ${GITHUB_REF#refs/heads/} | tr '/' '-')" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: julepai
+          password: "${{ secrets.DOCKER_HUB_PASSWORD }}"
+
+      - name: Build and push migration image
+        uses: docker/build-push-action@v4
+        with:
+          context: ./agents-api
+          file: ./agents-api/Dockerfile.migration
+          push: true
+          tags: julepai/cozo-migrate:${{ steps.variables.outputs.branch_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  Build-Push-Temporal-Image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set branch name
+        id: variables
+        run: echo "branch_name=$(echo ${GITHUB_REF#refs/heads/} | tr '/' '-')" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: julepai
+          password: "${{ secrets.DOCKER_HUB_PASSWORD }}"
+
+      - name: Build and push temporal image
+        uses: docker/build-push-action@v4
+        with:
+          context: ./agents-api
+          file: ./agents-api/Dockerfile.temporal
+          push: true
+          tags: julepai/temporal:${{ steps.variables.outputs.branch_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  Build-Push-Worker-Image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set branch name
+        id: variables
+        run: echo "branch_name=$(echo ${GITHUB_REF#refs/heads/} | tr '/' '-')" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: julepai
+          password: "${{ secrets.DOCKER_HUB_PASSWORD }}"
+
+      - name: Build and push worker image
+        uses: docker/build-push-action@v4
+        with:
+          context: ./agents-api
+          file: ./agents-api/Dockerfile.worker
+          push: true
+          tags: julepai/worker:${{ steps.variables.outputs.branch_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   Build-Push-Other-Images:
     runs-on: ubuntu-latest
     strategy:
@@ -41,10 +157,6 @@ jobs:
           tags: julepai/${{ matrix.service-directory }}:${{ steps.variables.outputs.branch_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          # cache-from: |
-          #   type=registry,ref=julepai/${{ matrix.service-directory }}:${{ steps.variables.outputs.branch_name }}
-          #   type=registry,ref=julepai/${{ matrix.service-directory }}:dev
-          # cache-to: type=inline
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/push-to-hub.yml
+++ b/.github/workflows/push-to-hub.yml
@@ -1,11 +1,11 @@
 name: Build and push images to docker hub on merge to dev
 run-name: ${{ github.actor }} is building and pushing images to docker hub
 
-on: [push]
-# on:
-#   push:
-#     branches:
-#       - "dev"
+on:
+  push:
+    branches:
+      - "dev"
+      - "main"
 
 jobs:
   Build-Push-Agents-API-Image:

--- a/.github/workflows/push-to-hub.yml
+++ b/.github/workflows/push-to-hub.yml
@@ -1,10 +1,11 @@
 name: Build and push images to docker hub on merge to dev
 run-name: ${{ github.actor }} is building and pushing images to docker hub
 
-on:
-  push:
-    branches:
-      - "dev"
+on: [push]
+# on:
+#   push:
+#     branches:
+#       - "dev"
 
 jobs:
   Build-Push-Images-To-Docker-Hub:

--- a/.github/workflows/push-to-hub.yml
+++ b/.github/workflows/push-to-hub.yml
@@ -34,11 +34,11 @@ jobs:
         with:
           context: ./${{ matrix.service-directory }}
           push: true
-          tags: julepai/${{ matrix.service-directory }}:${{ github.ref_name }}
+          tags: julepai/${{ matrix.service-directory }}:${{ github.ref_name | replace('/', '--') }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           # cache-from: |
-          #   type=registry,ref=julepai/${{ matrix.service-directory }}:${{ github.ref_name }}
+          #   type=registry,ref=julepai/${{ matrix.service-directory }}:${{ github.ref_name | replace('/', '--') }}
           #   type=registry,ref=julepai/${{ matrix.service-directory }}:dev
           # cache-to: type=inline
 

--- a/.github/workflows/push-to-hub.yml
+++ b/.github/workflows/push-to-hub.yml
@@ -23,14 +23,28 @@ jobs:
           username: julepai
           password: "${{ secrets.DOCKER_HUB_PASSWORD }}"
 
-      - uses: KengoTODA/actions-setup-docker-compose@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v3
         with:
-          version: "2.24.6"
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - uses: KengoTODA/actions-setup-docker-compose@main
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Build images
         run: |
           touch .env
-          docker compose build
+          docker compose build --cache-from type=local,src=/tmp/.buildx-cache
+          docker compose build --cache-to type=local,dest=/tmp/.buildx-cache-new
+
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
       - name: Push images
         run: |

--- a/.github/workflows/push-to-hub.yml
+++ b/.github/workflows/push-to-hub.yml
@@ -8,8 +8,14 @@ on: [push]
 #       - "dev"
 
 jobs:
-  Build-Push-Images-To-Docker-Hub:
+  Build-Push-Other-Images:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service-directory:
+          - gateway
+          - memory-store
+          # - model-serving
 
     steps:
       - uses: actions/checkout@v4
@@ -23,32 +29,18 @@ jobs:
           username: julepai
           password: "${{ secrets.DOCKER_HUB_PASSWORD }}"
 
-      - name: Cache Docker layers
-        uses: actions/cache@v3
+      - name: Build and push images
+        uses: docker/build-push-action@v4
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
-      - uses: KengoTODA/actions-setup-docker-compose@main
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: Build images
-        run: |
-          touch .env
-          docker compose build --cache-from type=local,src=/tmp/.buildx-cache
-          docker compose build --cache-to type=local,dest=/tmp/.buildx-cache-new
-
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-      - name: Push images
-        run: |
-          docker compose push
+          context: ./${{ matrix.service-directory }}
+          push: true
+          tags: julepai/${{ matrix.service-directory }}:${{ github.ref_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # cache-from: |
+          #   type=registry,ref=julepai/${{ matrix.service-directory }}:${{ github.ref_name }}
+          #   type=registry,ref=julepai/${{ matrix.service-directory }}:dev
+          # cache-to: type=inline
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/push-to-hub.yml
+++ b/.github/workflows/push-to-hub.yml
@@ -20,6 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set branch name
+        id: variables
+        run: echo "branch_name=$(echo ${GITHUB_REF#refs/heads/} | tr '/' '-')" >> $GITHUB_OUTPUT
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -34,11 +38,11 @@ jobs:
         with:
           context: ./${{ matrix.service-directory }}
           push: true
-          tags: julepai/${{ matrix.service-directory }}:${{ github.ref_name | replace('/', '--') }}
+          tags: julepai/${{ matrix.service-directory }}:${{ steps.variables.outputs.branch_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           # cache-from: |
-          #   type=registry,ref=julepai/${{ matrix.service-directory }}:${{ github.ref_name | replace('/', '--') }}
+          #   type=registry,ref=julepai/${{ matrix.service-directory }}:${{ steps.variables.outputs.branch_name }}
           #   type=registry,ref=julepai/${{ matrix.service-directory }}:dev
           # cache-to: type=inline
 

--- a/agents-api/docker-compose.yml
+++ b/agents-api/docker-compose.yml
@@ -1,11 +1,6 @@
 name: julep-agents-api
 version: "3"
 
-# TODO: figure out why this doesn't work
-# include:
-# - ../model-serving/docker-compose.yml
-# - ../memory-store/docker-compose.yml
-
 services:
   agents-api:
     image: julepai/agents-api:dev
@@ -13,8 +8,6 @@ services:
 
     container_name: agents-api
     depends_on:
-      model-serving:
-        condition: service_started
       memory-store:
         condition: service_started
       worker:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,10 @@ name: julep
 version: "3"
 
 include:
-  - ./memory-store/docker-compose.yml
-  - ./model-serving/docker-compose.yml
   - ./agents-api/docker-compose.yml
   - ./gateway/docker-compose.yml
+  - ./memory-store/docker-compose.yml
 
   # TODO: Enable after testing
+  # - ./model-serving/docker-compose.yml
   # - ./monitoring/docker-compose.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,10 @@ name: julep
 version: "3"
 
 include:
-  - ./agents-api/docker-compose.yml
-  - ./gateway/docker-compose.yml
   - ./memory-store/docker-compose.yml
+  - ./model-serving/docker-compose.yml
+  - ./gateway/docker-compose.yml
+  - ./agents-api/docker-compose.yml
 
   # TODO: Enable after testing
-  # - ./model-serving/docker-compose.yml
   # - ./monitoring/docker-compose.yml


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->
| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8b1ba62731e027b8beda7462a5ae550215d938d6.  | 
|--------|--------|

### Summary:
This PR modifies the GitHub Actions workflow to trigger on any push event, introduces Docker layer caching to speed up the build process, and disables the `model-serving` service by default.

**Key points**:
- Modified GitHub Actions workflow in `/.github/workflows/push-to-hub.yml` to trigger on any push event
- Introduced Docker layer caching to speed up the build process
- Disabled `model-serving` service by default
- Docker layer cache stored in `/tmp/.buildx-cache` and keyed by runner OS and commit SHA
- Cache restored before Docker images are built and updated after build completes


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
