### PR TITLE
fix: Display agent instructions

### DIFF
--- a/agents-api/agents_api/models/agent/get_agent.py
+++ b/agents-api/agents_api/models/agent/get_agent.py
@@ -38,6 +38,7 @@ def get_agent_query(
             updated_at,
             metadata,
             default_settings,
+            instructions,
         ] := input[id, developer_id],
             *agents {
                 developer_id,
@@ -48,6 +49,7 @@ def get_agent_query(
                 created_at,
                 updated_at,
                 metadata,
+                instructions,
             },
             *agent_default_settings {
                 agent_id: id,

--- a/agents-api/agents_api/models/agent/list_agents.py
+++ b/agents-api/agents_api/models/agent/list_agents.py
@@ -49,6 +49,7 @@ def list_agents_query(
             created_at,
             updated_at,
             metadata,
+            instructions,
         ] := input[developer_id],
             *agents {{
                 developer_id,
@@ -59,6 +60,7 @@ def list_agents_query(
                 created_at,
                 updated_at,
                 metadata,
+                instructions,
             }},
             {metadata_filter_str}
         


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 809dacb49bced7ccb72a158d7b4c89f22037d09f.  | 
|--------|--------|

### Summary:
This PR adds the 'instructions' field to the agent data fetched by the 'get_agent_query' and 'list_agents_query' functions in the 'agents_api' module.

**Key points**:
- Added 'instructions' field to the output of 'get_agent_query' function in '/agents-api/agents_api/models/agent/get_agent.py'.
- Added 'instructions' field to the output of 'list_agents_query' function in '/agents-api/agents_api/models/agent/list_agents.py'.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
