### PR TITLE
fix: Set metadata to an empty dict by default

### DIFF
--- a/agents-api/agents_api/activities/types.py
+++ b/agents-api/agents_api/activities/types.py
@@ -25,10 +25,12 @@ class ChatML(BaseModel):
     token_count: Optional[int] = None
 
 
-class BaseTask(BaseModel): ...
+class BaseTask(BaseModel):
+    ...
 
 
-class BaseTaskArgs(BaseModel): ...
+class BaseTaskArgs(BaseModel):
+    ...
 
 
 class AddPrinciplesTaskArgs(BaseTaskArgs):

--- a/agents-api/agents_api/clients/worker/types.py
+++ b/agents-api/agents_api/clients/worker/types.py
@@ -25,10 +25,12 @@ class ChatML(BaseModel):
     token_count: Optional[int] = None
 
 
-class BaseTask(BaseModel): ...
+class BaseTask(BaseModel):
+    ...
 
 
-class BaseTaskArgs(BaseModel): ...
+class BaseTaskArgs(BaseModel):
+    ...
 
 
 class MemoryManagementTaskArgs(BaseTaskArgs):

--- a/agents-api/agents_api/models/agent/patch_agent.py
+++ b/agents-api/agents_api/models/agent/patch_agent.py
@@ -26,7 +26,7 @@ def patch_agent_query(
     """
     # Construct the query for updating agent information in the database.
     # Agent update query
-    metadata = update_data.pop("metadata", {})
+    metadata = update_data.pop("metadata", {}) or {}
     agent_update_cols, agent_update_vals = cozo_process_mutate_data(
         {
             **{k: v for k, v in update_data.items() if v is not None},

--- a/agents-api/agents_api/models/session/patch_session.py
+++ b/agents-api/agents_api/models/session/patch_session.py
@@ -45,7 +45,7 @@ def patch_session_query(
     :assert some
     """
 
-    metadata = update_data.pop("metadata", {})
+    metadata = update_data.pop("metadata", {}) or {}
 
     session_update_cols, session_update_vals = cozo_process_mutate_data(
         {k: v for k, v in update_data.items() if v is not None}

--- a/agents-api/agents_api/models/user/patch_user.py
+++ b/agents-api/agents_api/models/user/patch_user.py
@@ -24,7 +24,7 @@ Returns:
 
 def patch_user_query(developer_id: UUID, user_id: UUID, **update_data) -> pd.DataFrame:
     # Prepare data for mutation by filtering out None values and adding system-generated fields.
-    metadata = update_data.pop("metadata", {})
+    metadata = update_data.pop("metadata", {}) or {}
     user_update_cols, user_update_vals = cozo_process_mutate_data(
         {
             **{k: v for k, v in update_data.items() if v is not None},


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 72160ab5880663646e519e6155dcefc23c825591.  | 
|--------|--------|

### Summary:
This PR ensures that the `metadata` field in `patch_agent_query`, `patch_session_query`, and `patch_user_query` functions defaults to an empty dictionary if it's not provided or if its value is `None`.

**Key points**:
- Modified `patch_agent_query` in `patch_agent.py` to set `metadata` to an empty dictionary if not provided or if its value is `None`.
- Applied similar changes to `patch_session_query` in `patch_session.py` and `patch_user_query` in `patch_user.py`.
- No changes were made to `types.py` in `activities` and `worker` directories.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
