### PR TITLE
feat: Add an explicit platform declaration to the services in deploy/docker-compose.yml

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -46,20 +46,13 @@ services:
       - DTYPE=float16
       - MODEL_ID=BAAI/llm-embedder
 
-    image: ghcr.io/huggingface/text-embeddings-inference:1.0
+    image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.0
     platform: linux/x86_64
     ports:
       - "8082:80"
     shm_size: "2gb"
     volumes:
       - ~/.cache/huggingface/hub:/data
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
     env_file:
       - .env
 
@@ -68,21 +61,13 @@ services:
     environment:
       - DTYPE=float16
       - MODEL_ID=BAAI/bge-m3
-
-    image: ghcr.io/huggingface/text-embeddings-inference:1.0
+    image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.0
     platform: linux/x86_64
     ports:
       - "8083:80"
     volumes:
       - ~/.cache/huggingface/hub:/data
     shm_size: "2gb"
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
     env_file:
       - .env
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,9 +1,9 @@
 name: julep-api
-version: "3"
 
 services:
   memory-store:
     image: julepai/memory-store:dev
+    platform: linux/x86_64
     environment:
       - COZO_AUTH_TOKEN=${COZO_AUTH_TOKEN}
       - COZO_PORT=9070
@@ -16,6 +16,7 @@ services:
 
   agents-api:
     image: julepai/agents-api:dev
+    platform: linux/x86_64
     container_name: julep-agents-api
     depends_on:
       memory-store:
@@ -29,6 +30,7 @@ services:
 
   worker:
     image: julepai/worker:dev
+    platform: linux/x86_64
     container_name: julep-worker
     depends_on:
       text-embeddings-inference:
@@ -45,6 +47,7 @@ services:
       - MODEL_ID=BAAI/llm-embedder
 
     image: ghcr.io/huggingface/text-embeddings-inference:1.0
+    platform: linux/x86_64
     ports:
       - "8082:80"
     shm_size: "2gb"
@@ -67,6 +70,7 @@ services:
       - MODEL_ID=BAAI/bge-m3
 
     image: ghcr.io/huggingface/text-embeddings-inference:1.0
+    platform: linux/x86_64
     ports:
       - "8083:80"
     volumes:
@@ -84,6 +88,7 @@ services:
 
   temporal:
     image: julepai/temporal:dev
+    platform: linux/x86_64
     container_name: julep-temporal
     ports:
       - 7233:7233
@@ -99,6 +104,7 @@ services:
     env_file:
       - .env
     image: julepai/cozo-migrate:dev
+    platform: linux/x86_64
     container_name: julep-cozo-migrate
     depends_on:
       memory-store:


### PR DESCRIPTION
For supporting macs and other arm based environments

<!--
ELLIPSIS_HIDDEN
-->
----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f1781783ae16c322472b84969df4716c0af1a312  | 
|--------|

### Summary:
This PR adds an explicit `linux/x86_64` platform declaration to all services in `deploy/docker-compose.yml`, updates image tags, and removes GPU-specific configurations to ensure compatibility with Macs and other ARM-based systems.

**Key points**:
- Added `platform: linux/x86_64` to all services in `deploy/docker-compose.yml`.
- Ensures compatibility with Macs and other ARM-based environments.
- Updated image tags from `1.0` to `cpu-1.0` for `text-embeddings-inference` services.
- Removed GPU-specific deployment configurations from `text-embeddings-inference` services.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
