### PR TITLE
fix: Convert messages content to JSON

### DIFF
--- a/agents-api/agents_api/common/protocol/entries.py
+++ b/agents-api/agents_api/common/protocol/entries.py
@@ -49,6 +49,7 @@ class Entry(BaseModel):
                     # TODO: how to calc token count for images?
                     if isinstance(part, ChatMLTextContentPart):
                         text += part.text
+                content_length = len(text)
 
             # Divide the content length by 3.5 to estimate token count based on character count.
             return int(content_length // 3.5)

--- a/agents-api/agents_api/common/utils/messages.py
+++ b/agents-api/agents_api/common/utils/messages.py
@@ -1,0 +1,23 @@
+import json
+from agents_api.autogen.openapi_model import (
+    ChatMLTextContentPart,
+    ChatMLImageContentPart,
+)
+
+
+def content_to_json(content: str | list[ChatMLTextContentPart] | list[ChatMLImageContentPart] | dict):
+    result = []
+    if isinstance(content, str):
+        result = [{"type": "text", "text": content}]
+    elif isinstance(content, list):
+        for part in content:
+            m = {"type": part.type, part.type: None}
+            if isinstance(part, ChatMLTextContentPart):
+                m[part.type] = part.text
+            elif isinstance(part, ChatMLImageContentPart):
+                m[part.type] = part.image_url.model_dump()
+            result.append(m)
+    elif isinstance(content, dict):
+        result = [{"type": "text", "text": json.dumps(content, indent=4)}]
+
+    return result

--- a/agents-api/agents_api/common/utils/messages.py
+++ b/agents-api/agents_api/common/utils/messages.py
@@ -5,7 +5,9 @@ from agents_api.autogen.openapi_model import (
 )
 
 
-def content_to_json(content: str | list[ChatMLTextContentPart] | list[ChatMLImageContentPart] | dict):
+def content_to_json(
+    content: str | list[ChatMLTextContentPart] | list[ChatMLImageContentPart] | dict,
+):
     result = []
     if isinstance(content, str):
         result = [{"type": "text", "text": content}]

--- a/agents-api/agents_api/models/entry/add_entries.py
+++ b/agents-api/agents_api/models/entry/add_entries.py
@@ -4,10 +4,8 @@ from beartype import beartype
 
 from ...common.protocol.entries import Entry
 from ..utils import cozo_query
-from ...common.utils import json
 from ...common.utils.datetime import utcnow
 from ...common.utils.messages import content_to_json
-from agents_api.autogen.openapi_model import ChatMLTextContentPart
 
 
 @cozo_query

--- a/agents-api/agents_api/models/entry/add_entries.py
+++ b/agents-api/agents_api/models/entry/add_entries.py
@@ -6,6 +6,8 @@ from ...common.protocol.entries import Entry
 from ..utils import cozo_query
 from ...common.utils import json
 from ...common.utils.datetime import utcnow
+from ...common.utils.messages import content_to_json
+from agents_api.autogen.openapi_model import ChatMLTextContentPart
 
 
 @cozo_query
@@ -27,15 +29,9 @@ def add_entries_query(entries: list[Entry]) -> tuple[str, dict]:
         role = e.role
 
         # Convert the content of each entry to list of text parts if it is a string or a dictionary.
-        content: list = []
-        if isinstance(e.content, str):
-            content = [{"type": "text", "text": e.content}]
-
-        elif isinstance(e.content, dict):
-            content = [{"type": "text", "text": json.dumps(e.content, indent=4)}]
-
         # Append entries with non-empty content to the list for database insertion.
-        if e.content:
+        content = content_to_json(e.content)
+        if content:
             entries_lst.append(
                 [
                     str(e.id),

--- a/agents-api/agents_api/models/entry/entries_summarization.py
+++ b/agents-api/agents_api/models/entry/entries_summarization.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 
 from ...common.protocol.entries import Entry
+from ...common.utils.messages import content_to_json
 from ..utils import cozo_query
 
 
@@ -94,7 +95,7 @@ def entries_summarization_query(
             new_entry.source,
             new_entry.role,
             new_entry.name or "",
-            new_entry.content,
+            content_to_json(new_entry.content),
             new_entry.token_count,
             new_entry.tokenizer,
             new_entry.created_at,


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->
| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 664b93b374dc0e5868fb44597ebb0e92dfe2a963  | 
|--------|--------|

### Summary:
Introduced a new utility function `content_to_json` to standardize content conversion across modules and fixed content length calculation.

**Key points**:
- Added `content_to_json` in `/agents-api/agents_api/common/utils/messages.py`.
- Utilized `content_to_json` in `/agents-api/agents_api/models/entry/add_entries.py` and `/agents-api/agents_api/models/entry/entries_summarization.py`.
- Fixed `content_length` calculation in `/agents-api/agents_api/common/protocol/entries.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
