### PR TITLE
fix: Convert IDs to UUID before passing to query executing functions

### DIFF
--- a/agents-api/agents_api/routers/agents/routers.py
+++ b/agents-api/agents_api/routers/agents/routers.py
@@ -1,7 +1,7 @@
 import json
 from json import JSONDecodeError
 from typing import Annotated
-from uuid import uuid4
+from uuid import uuid4, UUID
 
 from agents_api.autogen.openapi_model import ContentItem
 from agents_api.model_registry import validate_configuration
@@ -234,7 +234,7 @@ async def create_agent(
         ).model_dump(),
         metadata=request.metadata or {},
     )
-    new_agent_id = resp["agent_id"][0]
+    new_agent_id = UUID(resp["agent_id"][0], version=4)
     docs = request.docs or []
     job_ids = [uuid4()] * len(docs)
     for job_id, doc in zip(job_ids, docs):

--- a/agents-api/agents_api/routers/users/routers.py
+++ b/agents-api/agents_api/routers/users/routers.py
@@ -1,7 +1,7 @@
 import json
 from json import JSONDecodeError
 from typing import Annotated
-from uuid import uuid4
+from uuid import uuid4, UUID
 
 from agents_api.autogen.openapi_model import ContentItem
 from fastapi import APIRouter, HTTPException, status, Depends
@@ -185,7 +185,7 @@ async def create_user(
         metadata=request.metadata or {},
     )
 
-    new_user_id = resp["user_id"][0]
+    new_user_id = UUID(resp["user_id"][0], version=4)
     docs = request.docs or []
     job_ids = [uuid4()] * len(docs)
     for job_id, doc in zip(job_ids, docs):


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 3a3a23bca168ad7d00927b60bd8fe323cac346ef  | 
|--------|--------|

### Summary:
This PR updates the agents and users routers to convert IDs from strings to properly formatted UUIDs, ensuring consistent ID handling across the application.

**Key points**:
- Updated `agents-api/agents_api/routers/agents/routers.py` and `agents-api/agents_api/routers/users/routers.py`.
- Converted agent and user IDs from strings to UUIDs using `UUID(resp["agent_id"][0], version=4)` and `UUID(resp["user_id"][0], version=4)`.
- Ensured IDs are properly formatted as UUIDs for consistent handling across the application.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
