### PR TITLE
fix(agents-api): fix fn calling and local deployment

### DIFF
--- a/agents-api/agents_api/routers/sessions/session.py
+++ b/agents-api/agents_api/routers/sessions/session.py
@@ -190,7 +190,8 @@ class BaseSession:
         # Ref: https://github.com/openai/openai-cookbook/blob/main/examples/How_to_call_functions_with_chat_models.ipynb
         if not message.content and message.tool_calls:
             role = "function_call"
-            content = message.tool_calls[0].function.model_dump()
+            function_call = message.tool_calls[0].function.model_dump()
+            content = json.dumps(function_call)
 
         elif not message.content:
             raise ValueError("No content in response")

--- a/agents-api/agents_api/routers/sessions/session.py
+++ b/agents-api/agents_api/routers/sessions/session.py
@@ -190,8 +190,7 @@ class BaseSession:
         # Ref: https://github.com/openai/openai-cookbook/blob/main/examples/How_to_call_functions_with_chat_models.ipynb
         if not message.content and message.tool_calls:
             role = "function_call"
-            function_call = message.tool_calls[0].function.model_dump()
-            content = json.dumps(function_call)
+            content = message.tool_calls[0].function.model_dump_json()
 
         elif not message.content:
             raise ValueError("No content in response")

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - cozo_data:/data
     env_file:
       - .env
+    ports:
+      - "9070:9070"
 
   agents-api:
     image: julepai/agents-api:dev
@@ -77,6 +79,9 @@ services:
     container_name: julep-temporal
     ports:
       - 7233:7233
+    build:
+      context: .
+      dockerfile: Dockerfile.temporal
     volumes:
       - temporal_data:/home/temporal
     env_file:


### PR DESCRIPTION
- added `json.dumps()` when role was function_call
- added port for cozo

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f52f8141d0240fc1be89178178fffbbd3d3bf7b3  | 
|--------|--------|

### Summary:
This PR fixes function call serialization in the agents API and adds a port configuration for local deployment in Docker.

**Key points**:
- Updated `agents-api/agents_api/routers/sessions/session.py` to use `json.dumps()` for serializing function call data when the role is `function_call`. - Modified `deploy/docker-compose.yml` to add port `9070:9070` for the `memory-store` service, facilitating necessary network configurations.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
