### PR TITLE
fix: Handle prompt too big error

### DIFF
--- a/agents-api/agents_api/web.py
+++ b/agents-api/agents_api/web.py
@@ -11,6 +11,7 @@ from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.exceptions import RequestValidationError
 from agents_api.common.exceptions import BaseCommonException
+from agents_api.exceptions import PromptTooBigError
 from pycozo.client import QueryException
 from temporalio.service import RPCError
 
@@ -96,7 +97,7 @@ app.include_router(jobs.router)
 @app.exception_handler(RPCError)
 async def validation_error_handler(request: Request, exc: RPCError):
     return JSONResponse(
-        status_code=400,
+        status_code=status.HTTP_400_BAD_REQUEST,
         content={
             "error": {"message": "job not found or invalid", "code": exc.status.name}
         },
@@ -107,6 +108,14 @@ async def validation_error_handler(request: Request, exc: RPCError):
 async def session_not_found_error_handler(request: Request, exc: BaseCommonException):
     return JSONResponse(
         status_code=exc.http_code,
+        content={"error": {"message": str(exc)}},
+    )
+
+
+@app.exception_handler(PromptTooBigError)
+async def prompt_too_big_error(request: Request, exc: PromptTooBigError):
+    return JSONResponse(
+        status_code=status.HTTP_400_BAD_REQUEST,
         content={"error": {"message": str(exc)}},
     )
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 92c888af72ac3685d36bd00aa6c1b458105597c7  | 
|--------|--------|

### Summary:
Added an exception handler for `PromptTooBigError` in `agents-api/agents_api/web.py` that returns a 400 status code and an error message.

**Key points**:
- Added `PromptTooBigError` import in `agents-api/agents_api/web.py`.
- Registered a new exception handler for `PromptTooBigError` in `agents-api/agents_api/web.py`.
- The handler returns a 400 status code and an error message when `PromptTooBigError` is raised.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->