### PR TITLE
feat(sdks/ts): Add runtime validations for TS SDK

### DIFF
--- a/sdks/ts/package.json
+++ b/sdks/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@julep/sdk",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Julep is a platform for creating agents with long-term memory",
   "keywords": [
     "julep-ai",

--- a/sdks/ts/src/check.ts
+++ b/sdks/ts/src/check.ts
@@ -1,9 +1,0 @@
-import typia, { tags } from "typia";
-
-export const check = typia.createIs<IMember>();
-
-interface IMember {
-  id: string & tags.Format<"uuid">;
-  email: string & tags.Format<"email">;
-  age: number & tags.ExclusiveMinimum<19> & tags.Maximum<100>;
-}

--- a/sdks/ts/src/client.ts
+++ b/sdks/ts/src/client.ts
@@ -1,5 +1,7 @@
 import { OpenAI } from "openai";
 import { Chat, Completions } from "openai/resources/index";
+import typia, { tags } from "typia";
+
 import { AgentsManager } from "./managers/agent";
 import { UsersManager } from "./managers/user";
 import { DocsManager } from "./managers/doc";
@@ -12,7 +14,7 @@ import { patchCreate } from "./utils/openaiPatch";
 
 interface ClientOptions {
   apiKey?: string;
-  baseUrl?: string;
+  baseUrl?: string & tags.Format<"uri">;
 }
 
 /**
@@ -30,10 +32,12 @@ export class Client {
    * @param {string} [options.baseUrl=JULEP_API_URL] - Base URL for the Julep API. Defaults to the JULEP_API_URL environment variable or "https://api-alpha.julep.ai/api" if not provided.
    * @throws {Error} Throws an error if both apiKey and baseUrl are not provided and not set as environment variables.
    */
-  constructor({
-    apiKey = JULEP_API_KEY,
-    baseUrl = JULEP_API_URL || "https://api-alpha.julep.ai/api",
-  }: ClientOptions = {}) {
+  constructor(options: ClientOptions = {}) {
+    const {
+      apiKey = JULEP_API_KEY,
+      baseUrl = JULEP_API_URL || "https://api-alpha.julep.ai/api",
+    } = typia.assert<ClientOptions>(options);
+
     if (!apiKey || !baseUrl) {
       throw new Error(
         "apiKey and baseUrl must be provided or set as environment variables",

--- a/sdks/ts/src/managers/base.ts
+++ b/sdks/ts/src/managers/base.ts
@@ -1,3 +1,5 @@
+import typia from "typia";
+
 import { JulepApiClient } from "../api/JulepApiClient";
 
 /**
@@ -9,5 +11,7 @@ export class BaseManager {
    * Constructs a new instance of BaseManager.
    * @param apiClient The JulepApiClient instance used for API interactions.
    */
-  constructor(public apiClient: JulepApiClient) {}
+  constructor(public apiClient: JulepApiClient) {
+    typia.assertGuard<JulepApiClient>(apiClient);
+  }
 }

--- a/sdks/ts/src/managers/doc.ts
+++ b/sdks/ts/src/managers/doc.ts
@@ -1,7 +1,8 @@
-import type { Doc, ResourceCreatedResponse, CreateDoc } from "../api";
+import typia, { tags } from "typia";
+
+import { type Doc, type ResourceCreatedResponse, type CreateDoc } from "../api";
 
 import { invariant } from "../utils/invariant";
-import { isValidUuid4 } from "../utils/isValidUuid4";
 import { xor } from "../utils/xor";
 
 import { BaseManager } from "./base";
@@ -19,24 +20,39 @@ export class DocsManager extends BaseManager {
    * @returns {Promise<Object>} The retrieved documents.
    * @throws {Error} If neither agentId nor userId is provided.
    */
-  async get({
-    agentId,
-    userId,
-    limit = 100,
-    offset = 0,
-  }: {
-    userId?: string;
-    agentId?: string;
-    limit?: number;
-    offset?: number;
-  }) {
+  async get(
+    options: {
+      agentId?: string & tags.Format<"uuid">;
+      userId?: string & tags.Format<"uuid">;
+      limit?: number &
+        tags.Type<"uint32"> &
+        tags.Minimum<1> &
+        tags.Maximum<1000>;
+      offset?: number & tags.Type<"uint32"> & tags.Minimum<0>;
+    } = {},
+  ): Promise<
+    | ReturnType<typeof this.apiClient.default.getAgentDocs>
+    | ReturnType<typeof this.apiClient.default.getUserDocs>
+  > {
+    const {
+      agentId,
+      userId,
+      limit = 100,
+      offset = 0,
+    } = typia.assert<{
+      agentId?: string & tags.Format<"uuid">;
+      userId?: string & tags.Format<"uuid">;
+      limit?: number &
+        tags.Type<"uint32"> &
+        tags.Minimum<1> &
+        tags.Maximum<1000>;
+      offset?: number & tags.Type<"uint32"> & tags.Minimum<0>;
+    }>(options);
+
     invariant(
       xor(agentId, userId),
       "Only one of agentId or userId must be given",
     );
-    agentId &&
-      invariant(isValidUuid4(agentId), "agentId must be a valid UUID v4");
-    userId && invariant(isValidUuid4(userId), "userId must be a valid UUID v4");
 
     if (agentId) {
       return await this.apiClient.default.getAgentDocs({
@@ -71,28 +87,41 @@ export class DocsManager extends BaseManager {
    * @returns {Promise<Array<Doc>>} The list of filtered documents.
    * @throws {Error} If neither agentId nor userId is provided.
    */
-  async list({
-    agentId,
-    userId,
-    limit = 100,
-    offset = 0,
-    metadataFilter = {},
-  }: {
-    agentId?: string;
-    userId?: string;
-    limit?: number;
-    offset?: number;
-    metadataFilter?: { [key: string]: any };
-  } = {}): Promise<Array<Doc>> {
+  async list(
+    options: {
+      agentId?: string & tags.Format<"uuid">;
+      userId?: string & tags.Format<"uuid">;
+      limit?: number &
+        tags.Type<"uint32"> &
+        tags.Minimum<1> &
+        tags.Maximum<1000>;
+      offset?: number & tags.Type<"uint32"> & tags.Minimum<0>;
+      metadataFilter?: { [key: string]: any };
+    } = {},
+  ): Promise<Array<Doc>> {
+    const {
+      agentId,
+      userId,
+      limit = 100,
+      offset = 0,
+      metadataFilter = {},
+    } = typia.assert<{
+      agentId?: string & tags.Format<"uuid">;
+      userId?: string & tags.Format<"uuid">;
+      limit?: number &
+        tags.Type<"uint32"> &
+        tags.Minimum<1> &
+        tags.Maximum<1000>;
+      offset?: number & tags.Type<"uint32"> & tags.Minimum<0>;
+      metadataFilter?: { [key: string]: any };
+    }>(options);
+
     const metadataFilterString: string = JSON.stringify(metadataFilter);
 
     invariant(
       xor(agentId, userId),
       "Only one of agentId or userId must be given",
     );
-    agentId &&
-      invariant(isValidUuid4(agentId), "agentId must be a valid UUID v4");
-    userId && invariant(isValidUuid4(userId), "userId must be a valid UUID v4");
 
     if (agentId) {
       const result = await this.apiClient.default.getAgentDocs({
@@ -130,22 +159,21 @@ export class DocsManager extends BaseManager {
    * @returns {Promise<Doc>} The created document.
    * @throws {Error} If neither agentId nor userId is provided.
    */
-  async create({
-    agentId,
-    userId,
-    doc,
-  }: {
-    agentId?: string;
-    userId?: string;
+  async create(options: {
+    agentId?: string & tags.Format<"uuid">;
+    userId?: string & tags.Format<"uuid">;
     doc: CreateDoc;
   }): Promise<Doc> {
+    const { agentId, userId, doc } = typia.assert<{
+      agentId?: string & tags.Format<"uuid">;
+      userId?: string & tags.Format<"uuid">;
+      doc: CreateDoc;
+    }>(options);
+
     invariant(
       xor(agentId, userId),
       "Only one of agentId or userId must be given",
     );
-    agentId &&
-      invariant(isValidUuid4(agentId), "agentId must be a valid UUID v4");
-    userId && invariant(isValidUuid4(userId), "userId must be a valid UUID v4");
 
     if (agentId) {
       const result: ResourceCreatedResponse =
@@ -183,22 +211,21 @@ export class DocsManager extends BaseManager {
    * @returns {Promise<void>} A promise that resolves when the document is successfully deleted.
    * @throws {Error} If neither agentId nor userId is provided.
    */
-  async delete({
-    agentId,
-    userId,
-    docId,
-  }: {
-    agentId?: string;
-    userId?: string;
+  async delete(options: {
+    agentId?: string & tags.Format<"uuid">;
+    userId?: string & tags.Format<"uuid">;
     docId: string;
   }): Promise<void> {
+    const { agentId, userId, docId } = typia.assert<{
+      agentId?: string & tags.Format<"uuid">;
+      userId?: string & tags.Format<"uuid">;
+      docId: string;
+    }>(options);
+
     invariant(
       xor(agentId, userId),
       "Only one of agentId or userId must be given",
     );
-    agentId &&
-      invariant(isValidUuid4(agentId), "agentId must be a valid UUID v4");
-    userId && invariant(isValidUuid4(userId), "userId must be a valid UUID v4");
 
     if (agentId) {
       await this.apiClient.default.deleteAgentDoc({ agentId, docId });

--- a/sdks/ts/src/managers/memory.ts
+++ b/sdks/ts/src/managers/memory.ts
@@ -1,8 +1,8 @@
+import typia, { tags } from "typia";
+
 import { Memory } from "../api";
 
 import { BaseManager } from "./base";
-import { invariant } from "../utils/invariant";
-import { isValidUuid4 } from "../utils/isValidUuid4";
 
 export class MemoriesManager extends BaseManager {
   /**
@@ -18,23 +18,29 @@ export class MemoriesManager extends BaseManager {
    * @param {number} [offset=0] - The offset for pagination. Optional.
    * @returns {Promise<Memory[]>} A promise that resolves to an array of Memory objects.
    */
-  async list({
-    agentId,
-    query,
-    userId,
-    limit = 100,
-    offset = 0,
-  }: {
-    agentId: string;
+  async list(options: {
+    agentId: string & tags.Format<"uuid">;
     query: string;
-    userId?: string;
-    limit?: number;
-    offset?: number;
+    userId?: string & tags.Format<"uuid">;
+    limit?: number & tags.Type<"uint32"> & tags.Minimum<1> & tags.Maximum<1000>;
+    offset?: number & tags.Type<"uint32"> & tags.Minimum<0>;
   }): Promise<Memory[]> {
-    // Validates that the agentId is a valid UUID v4 format.
-    invariant(isValidUuid4(agentId), "agentId must be a valid UUID v4");
-    // Validates that the userId, if provided, is a valid UUID v4 format.
-    userId && invariant(isValidUuid4(userId), "userId must be a valid UUID v4");
+    const {
+      agentId,
+      query,
+      userId,
+      limit = 100,
+      offset = 0,
+    } = typia.assert<{
+      agentId: string & tags.Format<"uuid">;
+      query: string;
+      userId?: string & tags.Format<"uuid">;
+      limit?: number &
+        tags.Type<"uint32"> &
+        tags.Minimum<1> &
+        tags.Maximum<1000>;
+      offset?: number & tags.Type<"uint32"> & tags.Minimum<0>;
+    }>(options);
 
     const response = await this.apiClient.default.getAgentMemories({
       agentId,

--- a/sdks/ts/src/managers/tool.ts
+++ b/sdks/ts/src/managers/tool.ts
@@ -1,3 +1,5 @@
+import typia, { tags } from "typia";
+
 // ToolsManager class manages tool-related operations such as listing, creating, updating, and deleting tools.
 import {
   Tool,
@@ -10,15 +12,25 @@ import { BaseManager } from "./base";
 
 export class ToolsManager extends BaseManager {
   async list(
-    agentId: string,
-    {
-      limit = 10,
-      offset = 0,
-    }: {
-      limit?: number;
-      offset?: number;
+    agentId: string & tags.Format<"uuid">,
+    options: {
+      limit?: number &
+        tags.Type<"uint32"> &
+        tags.Minimum<1> &
+        tags.Maximum<1000>;
+      offset?: number & tags.Type<"uint32"> & tags.Minimum<0>;
     } = {},
   ): Promise<Array<Tool>> {
+    typia.assertGuard<string & tags.Format<"uuid">>(agentId);
+
+    const { limit = 10, offset = 0 } = typia.assert<{
+      limit?: number &
+        tags.Type<"uint32"> &
+        tags.Minimum<1> &
+        tags.Maximum<1000>;
+      offset?: number & tags.Type<"uint32"> & tags.Minimum<0>;
+    }>(options);
+
     // Lists tools associated with a given agent. Allows pagination through `limit` and `offset` parameters.
     const result = await this.apiClient.default.getAgentTools({
       agentId,
@@ -29,16 +41,21 @@ export class ToolsManager extends BaseManager {
     return result.items || [];
   }
 
-  async create({
-    agentId,
-    tool,
-  }: {
-    agentId: string;
+  async create(options: {
+    agentId: string & tags.Format<"uuid">;
     tool: {
       type: "function" | "webhook";
       function: FunctionDef;
     };
   }): Promise<Tool> {
+    const { agentId, tool } = typia.assert<{
+      agentId: string & tags.Format<"uuid">;
+      tool: {
+        type: "function" | "webhook";
+        function: FunctionDef;
+      };
+    }>(options);
+
     // Creates a new tool for the specified agent. The `tool` parameter must include the tool type and function definition.
     const result: ResourceCreatedResponse =
       await this.apiClient.default.createAgentTool({
@@ -52,17 +69,19 @@ export class ToolsManager extends BaseManager {
   }
 
   async update(
-    {
-      agentId,
-      toolId,
-      tool,
-    }: {
-      agentId: string;
-      toolId: string;
+    options: {
+      agentId: string & tags.Format<"uuid">;
+      toolId: string & tags.Format<"uuid">;
       tool: UpdateToolRequest;
     },
     overwrite = false,
   ): Promise<Tool> {
+    const { agentId, toolId, tool } = typia.assert<{
+      agentId: string & tags.Format<"uuid">;
+      toolId: string & tags.Format<"uuid">;
+      tool: UpdateToolRequest;
+    }>(options);
+
     // Updates an existing tool. If `overwrite` is true, it replaces the existing tool with the new one; otherwise, it patches the tool with the provided changes.
     if (overwrite) {
       const result = await this.apiClient.default.updateAgentTool({
@@ -83,13 +102,15 @@ export class ToolsManager extends BaseManager {
     }
   }
 
-  async delete({
-    agentId,
-    toolId,
-  }: {
-    agentId: string;
-    toolId: string;
+  async delete(options: {
+    agentId: string & tags.Format<"uuid">;
+    toolId: string & tags.Format<"uuid">;
   }): Promise<void> {
+    const { agentId, toolId } = typia.assert<{
+      agentId: string & tags.Format<"uuid">;
+      toolId: string & tags.Format<"uuid">;
+    }>(options);
+
     // Deletes a specified tool from an agent.
     await this.apiClient.default.deleteAgentTool({ agentId, toolId });
   }

--- a/sdks/ts/src/utils/requestConstructor.ts
+++ b/sdks/ts/src/utils/requestConstructor.ts
@@ -1,10 +1,9 @@
 // Utility functions for constructing and handling API requests.
-import type { OpenAPIConfig } from "../api";
-
-import type { ApiRequestOptions } from "../api/core/ApiRequestOptions";
-
 import { isPlainObject, mapKeys, camelCase } from "lodash";
+import typia from "typia";
 
+import { type OpenAPIConfig } from "../api";
+import { type ApiRequestOptions } from "../api/core/ApiRequestOptions";
 import { AxiosHttpRequest } from "../api/core/AxiosHttpRequest";
 import { CancelablePromise } from "../api/core/CancelablePromise";
 
@@ -14,11 +13,14 @@ const camelCaseify = (responseBody: any) =>
 
 export class CustomHttpRequest extends AxiosHttpRequest {
   constructor(config: OpenAPIConfig) {
+    typia.assertGuard<OpenAPIConfig>(config);
     super(config);
   }
 
   // Overrides the base request method to apply additional processing on the response, such as camelCasing keys and handling collections.
   public override request<T>(options: ApiRequestOptions): CancelablePromise<T> {
+    typia.assertGuard<ApiRequestOptions>(options);
+
     const cancelableResponse = super.request(options);
 
     return new CancelablePromise<T>((resolve, reject, onCancel) => {


### PR DESCRIPTION
- feat(sdks/ts): Add runtime validations for TS SDK
- version(sdks/ts): Bump to 0.3.8

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8232a85bfaeb295acf3519fadb474b3eedb6a734  | 
|--------|--------|

### Summary:
Added runtime validations using `typia` for various classes and methods in the TypeScript SDK and bumped version to 0.3.8.

**Key points**:
- **Added** runtime validations using `typia` in `sdks/ts/src/client.ts`, `sdks/ts/src/managers/agent.ts`, `sdks/ts/src/managers/base.ts`, `sdks/ts/src/managers/doc.ts`, `sdks/ts/src/managers/memory.ts`, `sdks/ts/src/managers/session.ts`, `sdks/ts/src/managers/tool.ts`, `sdks/ts/src/managers/user.ts`, and `sdks/ts/src/utils/requestConstructor.ts`.
- **Removed** `sdks/ts/src/check.ts`.
- **Updated** `Client` constructor to validate `ClientOptions`.
- **Updated** `AgentsManager`, `DocsManager`, `MemoriesManager`, `SessionsManager`, `ToolsManager`, and `UsersManager` methods to validate input parameters.
- **Bumped** version to 0.3.8 in `sdks/ts/package.json`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->