### PR TITLE
fix: Add exception handler for litellm API error

### DIFF
--- a/agents-api/agents_api/web.py
+++ b/agents-api/agents_api/web.py
@@ -14,6 +14,7 @@ from agents_api.common.exceptions import BaseCommonException
 from agents_api.exceptions import PromptTooBigError
 from pycozo.client import QueryException
 from temporalio.service import RPCError
+from litellm.exceptions import APIError
 
 from agents_api.dependencies.auth import get_api_key
 from agents_api.env import sentry_dsn
@@ -116,6 +117,14 @@ async def session_not_found_error_handler(request: Request, exc: BaseCommonExcep
 async def prompt_too_big_error(request: Request, exc: PromptTooBigError):
     return JSONResponse(
         status_code=status.HTTP_400_BAD_REQUEST,
+        content={"error": {"message": str(exc)}},
+    )
+
+
+@app.exception_handler(APIError)
+async def litellm_api_error(request: Request, exc: APIError):
+    return JSONResponse(
+        status_code=status.HTTP_502_BAD_GATEWAY,
         content={"error": {"message": str(exc)}},
     )
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit cf5ced25d7659fc65cc010e423d3811157878a5f  | 
|--------|--------|

### Summary:
Added exception handler for `litellm.exceptions.APIError` in `agents-api/agents_api/web.py` to return a 502 Bad Gateway error with the error message.

**Key points**:
- Added `litellm.exceptions.APIError` exception handler in `agents-api/agents_api/web.py`.
- Returns a 502 Bad Gateway error with the error message when `APIError` is raised.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->