### PR TITLE
chore: Disable all the routes except of tasks and agents

### DIFF
--- a/agents-api/agents_api/routers/agents/update_agent.py
+++ b/agents-api/agents_api/routers/agents/update_agent.py
@@ -23,15 +23,17 @@ async def update_agent(
     x_developer_id: Annotated[UUID4, Depends(get_developer_id)],
 ) -> ResourceUpdatedResponse:
     try:
-        updated_agent = update_agent_query(
-            agent_id=agent_id,
-            developer_id=x_developer_id,
-            name=request.name,
-            about=request.about,
-            model=request.model,
-            default_settings=request.default_settings,
-            metadata=request.metadata,
-            instructions=request.instructions,
+        _, updated_agent = next(
+            update_agent_query(
+                agent_id=agent_id,
+                developer_id=x_developer_id,
+                name=request.name,
+                about=request.about,
+                model=request.model,
+                default_settings=request.default_settings,
+                metadata=request.metadata,
+                instructions=request.instructions,
+            ).iterrows()
         )
         return ResourceUpdatedResponse(**updated_agent)
     except AgentNotFoundError as e:

--- a/agents-api/agents_api/web.py
+++ b/agents-api/agents_api/web.py
@@ -90,9 +90,9 @@ app.add_middleware(
 register_exceptions(app)
 
 app.include_router(agents.router)
-app.include_router(sessions.router)
-app.include_router(users.router)
-app.include_router(jobs.router)
+# app.include_router(sessions.router)
+# app.include_router(users.router)
+# app.include_router(jobs.router)
 app.include_router(tasks.router)
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit a1da3e6dce19dc50c5434f99e8c9c39aadfb5174  | 
|--------|--------|

### Summary:
Disabled all routes except for `tasks` and `agents`, and updated the `update_agent` function to use `next` on the query result.

**Key points**:
- Commented out `include_router` lines for `sessions`, `users`, and `jobs` in `agents-api/agents_api/web.py` to disable these routes.
- Modified `update_agent` function in `agents-api/agents_api/routers/agents/update_agent.py` to use `next` on the result of `update_agent_query` to get the updated agent details.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->