### PR TITLE
Fix create agent tool

### DIFF
--- a/agents-api/agents_api/routers/agents/create_agent_tool.py
+++ b/agents-api/agents_api/routers/agents/create_agent_tool.py
@@ -27,4 +27,4 @@ async def create_agent_tool(
         data=[data],
     )[0]
 
-    return ResourceCreatedResponse(id=tool.id, created_at=tool.created_at)
+    return ResourceCreatedResponse(id=tool.id, created_at=tool.created_at, jobs=[])


### PR DESCRIPTION
- Added ``jobs=[]`` to the ``ResourceCreatedResponse``'s parameters that's returned from the ``create_agent_tool`` method in ``agents-api/agents_api/routers/agents/create_agent_tool.py``.