### PR TITLE
fix(agents-api): Fix prompt render, codec and task execution

### DIFF
--- a/agents-api/agents_api/dependencies/developer_id.py
+++ b/agents-api/agents_api/dependencies/developer_id.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from fastapi import Header
 
 from ..common.protocol.developers import Developer
-from ..env import multi_tenant_mode
+from ..env import multi_tenant_mode, testing
 from ..models.developer.get_developer import get_developer, verify_developer
 from .exceptions import InvalidHeaderFormat
 
@@ -13,9 +13,6 @@ async def get_developer_id(
     x_developer_id: Annotated[UUID | None, Header(include_in_schema=False)] = None,
 ) -> UUID:
     if not multi_tenant_mode:
-        assert (
-            not x_developer_id
-        ), "X-Developer-Id header not allowed in multi-tenant mode"
         return UUID("00000000-0000-0000-0000-000000000000")
 
     if not x_developer_id:

--- a/agents-api/agents_api/models/agent/delete_agent.py
+++ b/agents-api/agents_api/models/agent/delete_agent.py
@@ -28,8 +28,8 @@ T = TypeVar("T")
 @rewrap_exceptions(
     {
         lambda e: isinstance(e, QueryException)
-        and "asserted to return some results, but returned none"
-        in str(e): lambda *_: HTTPException(
+        and "Developer does not own resource"
+        in e.resp["display"]: lambda *_: HTTPException(
             detail="developer not found or doesnt own resource", status_code=404
         ),
         QueryException: partialclass(HTTPException, status_code=400),

--- a/agents-api/agents_api/models/agent/get_agent.py
+++ b/agents-api/agents_api/models/agent/get_agent.py
@@ -24,12 +24,12 @@ T = TypeVar("T")
     {
         lambda e: isinstance(e, QueryException)
         and "Developer not found" in str(e): lambda *_: HTTPException(
-            detail="developer does not exist", status_code=403
+            detail="Developer does not exist", status_code=403
         ),
         lambda e: isinstance(e, QueryException)
-        and "asserted to return some results, but returned none"
-        in str(e): lambda *_: HTTPException(
-            detail="developer doesnt own resource", status_code=404
+        and "Developer does not own resource"
+        in e.resp["display"]: lambda *_: HTTPException(
+            detail="Developer does not own resource", status_code=404
         ),
         QueryException: partialclass(HTTPException, status_code=400),
         ValidationError: partialclass(HTTPException, status_code=400),

--- a/agents-api/agents_api/models/user/get_user.py
+++ b/agents-api/agents_api/models/user/get_user.py
@@ -27,8 +27,8 @@ T = TypeVar("T")
             detail="developer does not exist", status_code=403
         ),
         lambda e: isinstance(e, QueryException)
-        and "asserted to return some results, but returned none"
-        in str(e): lambda *_: HTTPException(
+        and "Developer does not own resource"
+        in e.resp["display"]: lambda *_: HTTPException(
             detail="developer doesnt own resource", status_code=404
         ),
         QueryException: partialclass(HTTPException, status_code=400),

--- a/agents-api/agents_api/worker/codec.py
+++ b/agents-api/agents_api/worker/codec.py
@@ -4,7 +4,6 @@
 ###       The codec is used to serialize/deserialize the data
 ###       But this code is quite brittle. Be careful when changing it
 
-
 import dataclasses
 import logging
 import pickle
@@ -82,12 +81,16 @@ class PydanticEncodingPayloadConverter(EncodingPayloadConverter):
     b_encoding = encoding.encode()
 
     def to_payload(self, value: Any) -> Optional[Payload]:
-        return Payload(
-            metadata={
-                "encoding": self.b_encoding,
-            },
-            data=serialize(value),
-        )
+        try:
+            return Payload(
+                metadata={
+                    "encoding": self.b_encoding,
+                },
+                data=serialize(value),
+            )
+        except Exception as e:
+            logging.warning(f"WARNING: Could not encode {value}: {e}")
+            return None
 
     def from_payload(self, payload: Payload, type_hint: Optional[Type] = None) -> Any:
         assert payload.metadata["encoding"] == self.b_encoding

--- a/agents-api/agents_api/workflows/task_execution.py
+++ b/agents-api/agents_api/workflows/task_execution.py
@@ -167,7 +167,9 @@ class TaskExecutionWorkflow:
                 )
 
             except Exception as e:
-                await transition(state, context, type="error", output=dict(error=e))
+                await transition(
+                    state, context, type="error", output=dict(error=str(e))
+                )
                 raise ApplicationError(f"Activity {activity} threw error: {e}") from e
 
         # ---
@@ -376,6 +378,7 @@ class TaskExecutionWorkflow:
             ):
                 await transition(
                     state,
+                    context,
                     output=output,
                     type=yield_transition_type,
                     next=yield_next_target,

--- a/agents-api/pyproject.toml
+++ b/agents-api/pyproject.toml
@@ -99,5 +99,5 @@ datamodel-codegen \
   --disable-timestamp"""
 
 [tool.poe.tasks.test]
-env = { AGENTS_API_TESTING = "true" }
+env = { AGENTS_API_TESTING = "true", PYTHONPATH = "{PYTHONPATH}:." }
 cmd = "ward test"

--- a/agents-api/tests/test_execution_workflow.py
+++ b/agents-api/tests/test_execution_workflow.py
@@ -707,6 +707,7 @@ async def _(
             mock_run_task_execution_workflow.assert_called_once()
 
             result = await handle.result()
+            result = result["choices"][0]["message"]
             assert result["content"] == "Hello, world!"
             assert result["role"] == "assistant"
 


### PR DESCRIPTION
Signed-off-by: Diwank Tomer <diwank@julep.ai>

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 19c0f1372b39f637fc101ce453c07126cb6886f9  | 
|--------|--------|

### Summary:
This PR refactors template rendering, improves exception handling, and updates test configurations in the agents-api module.

**Key points**:
- `agents-api/agents_api/common/utils/template.py`: Replaced `render_template_chatml` and `render_template_parts` with `render_template_nested` to handle nested lists/dicts.
- `agents-api/agents_api/dependencies/developer_id.py`: Removed assertion for `x_developer_id` in non-multi-tenant mode.
- `agents-api/agents_api/models/agent/delete_agent.py`: Updated exception handling for `QueryException` to check `e.resp["display"]`.
- `agents-api/agents_api/models/agent/get_agent.py`: Similar exception handling update as `delete_agent.py`.
- `agents-api/agents_api/models/user/get_user.py`: Similar exception handling update as `delete_agent.py`.
- `agents-api/agents_api/worker/codec.py`: Added logging for encoding errors in `PydanticEncodingPayloadConverter`.
- `agents-api/agents_api/workflows/task_execution.py`: Improved error handling in `run` function by converting exceptions to strings.
- `agents-api/pyproject.toml`: Added `PYTHONPATH` to test environment variables.
- `agents-api/tests/fixtures.py`: Adjusted test fixtures to respect `multi_tenant_mode`.
- `agents-api/tests/test_execution_workflow.py`: Updated test to check for `choices` in `result`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->