### PR TITLE
fix: Change log-step to a jinja template rather than a simpleeval expression

### DIFF
--- a/agents-api/agents_api/activities/task_steps/get_value_step.py
+++ b/agents-api/agents_api/activities/task_steps/get_value_step.py
@@ -1,4 +1,3 @@
-
 from beartype import beartype
 from temporalio import activity
 

--- a/agents-api/agents_api/activities/task_steps/log_step.py
+++ b/agents-api/agents_api/activities/task_steps/log_step.py
@@ -18,7 +18,9 @@ async def log_step(context: StepContext) -> StepOutcome:
         assert isinstance(context.current_step, LogStep)
 
         template: str = context.current_step.log
-        output = await render_template(template, context.model_dump(), skip_vars=["developer_id"])
+        output = await render_template(
+            template, context.model_dump(), skip_vars=["developer_id"]
+        )
 
         result = StepOutcome(output=output)
         return result

--- a/agents-api/agents_api/activities/task_steps/log_step.py
+++ b/agents-api/agents_api/activities/task_steps/log_step.py
@@ -6,8 +6,8 @@ from ...common.protocol.tasks import (
     StepContext,
     StepOutcome,
 )
+from ...common.utils.template import render_template
 from ...env import testing
-from .base_evaluate import base_evaluate
 
 
 @beartype
@@ -17,8 +17,8 @@ async def log_step(context: StepContext) -> StepOutcome:
     try:
         assert isinstance(context.current_step, LogStep)
 
-        expr: str = context.current_step.log
-        output = await base_evaluate(expr, context.model_dump())
+        template: str = context.current_step.log
+        output = await render_template(template, context.model_dump(), skip_vars=["developer_id"])
 
         result = StepOutcome(output=output)
         return result

--- a/agents-api/tests/test_execution_workflow.py
+++ b/agents-api/tests/test_execution_workflow.py
@@ -407,7 +407,7 @@ async def _(
                 "other_workflow": [
                     # Testing that we can access the input
                     {"evaluate": {"hello": '_["test"]'}},
-                    {"log": '_["hell"]'},  # <--- The "hell" key does not exist
+                    {"log": '{{_["hello"]}}'},  # <--- The "hell" key does not exist
                 ],
                 "main": [
                     # Testing that we can access the input
@@ -422,7 +422,7 @@ async def _(
     )
 
     async with patch_testing_temporal() as (_, mock_run_task_execution_workflow):
-        with raises(BaseException):
+        # with raises(BaseException):
             execution, handle = await start_execution(
                 developer_id=developer_id,
                 task_id=task.id,

--- a/agents-api/tests/test_execution_workflow.py
+++ b/agents-api/tests/test_execution_workflow.py
@@ -407,7 +407,9 @@ async def _(
                 "other_workflow": [
                     # Testing that we can access the input
                     {"evaluate": {"hello": '_["test"]'}},
-                    {"log": '{{_["hello"]}}'},  # <--- The "hell" key does not exist
+                    {
+                        "log": '{{_["hell"].strip()}}'
+                    },  # <--- The "hell" key does not exist
                 ],
                 "main": [
                     # Testing that we can access the input
@@ -422,7 +424,7 @@ async def _(
     )
 
     async with patch_testing_temporal() as (_, mock_run_task_execution_workflow):
-        # with raises(BaseException):
+        with raises(BaseException):
             execution, handle = await start_execution(
                 developer_id=developer_id,
                 task_id=task.id,


### PR DESCRIPTION
Signed-off-by: Diwank Singh Tomer <diwank.singh@gmail.com>

<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit df220b4fa3df891fcd1ecc0f9264a78364c9f0d9  | 
|--------|--------|

### Summary:
The PR updates the `log_step` function to use Jinja templates for log rendering, replacing simpleeval expressions, and adjusts a test case accordingly.

**Key points**:
- Update `log_step` function to use Jinja templates for log rendering.
- Replace simpleeval expressions with Jinja templates.
- Modify test case to use Jinja syntax for log expressions.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->