### PR TITLE
hotfix: Apply a temp hotfix for sessions.chat

### DIFF
--- a/agents-api/agents_api/models/entry/get_history.py
+++ b/agents-api/agents_api/models/entry/get_history.py
@@ -42,6 +42,9 @@ T = TypeVar("T")
             }
             for r in d.pop("relations")
         ],
+        # TODO: Remove this once we sort the entries in the cozo query
+        # Sort entries by created_at
+        "entries": sorted(d.pop("entries"), key=lambda entry: entry["created_at"]),
         **d,
     },
 )

--- a/agents-api/agents_api/routers/sessions/chat.py
+++ b/agents-api/agents_api/routers/sessions/chat.py
@@ -72,6 +72,17 @@ async def chat(
         # messages = messages[-settings["max_tokens"] :]
         raise NotImplementedError("Truncation is not yet implemented")
 
+    # FIXME: Hotfix for datetime not serializable. Needs investigation
+    messages = [
+        msg.model_dump() if hasattr(msg, "model_dump") else msg
+        for msg in messages
+    ]
+
+    messages = [
+        dict(role=m["role"], content=m["content"], user=m.get("user"))
+        for m in messages
+    ]
+
     # Get the response from the model
     model_response = await litellm.acompletion(
         messages=messages,

--- a/agents-api/agents_api/routers/sessions/chat.py
+++ b/agents-api/agents_api/routers/sessions/chat.py
@@ -101,6 +101,12 @@ async def chat(
             for msg in new_messages
         ]
 
+        # Add the response to the new entries
+        new_entries.append(
+            CreateEntryRequest.from_model_input(
+                model=settings["model"], **model_response.choices[0].model_dump()['message'], source="api_response"
+            )
+        )
         background_tasks.add_task(
             create_entries,
             developer_id=developer.id,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 90228aba3862e09be0a6c9720b74771d4668f84c  | 
|--------|--------|

fix: temporary hotfix for datetime serialization in chat messages

### Summary:
Applies a temporary hotfix for datetime serialization in `chat.py` and sorts entries by `created_at` in `get_history.py`.

**Key points**:
- **Hotfix in `chat.py`**: Temporary fix for non-serializable datetime objects by converting messages to dictionaries with `role`, `content`, and `user` fields.
- **Sorting in `get_history.py`**: Sorts entries by `created_at` to ensure correct order.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->