### PR TITLE
Fix Issue #500: "agents-api: create-or-update session throws 'Internal Server Error'"

### DIFF
--- a/agents-api/agents_api/models/session/create_or_update_session.py
+++ b/agents-api/agents_api/models/session/create_or_update_session.py
@@ -62,7 +62,6 @@ def create_or_update_session(
         raise ValueError("Only one of 'agent' or 'agents' should be provided.")
 
     agents = agents or ([agent] if agent else [])
-    assert len(agents) > 0, "At least one agent must be provided."
 
     # Users are zero or more, so we default to an empty list if not provided.
     if not (user or users):

--- a/agents-api/agents_api/routers/sessions/create_or_update_session.py
+++ b/agents-api/agents_api/routers/sessions/create_or_update_session.py
@@ -11,7 +11,7 @@ from ...autogen.openapi_model import (
 )
 from ...dependencies.developer_id import get_developer_id
 from ...models.session.create_or_update_session import (
-    create_or_update_session as create_session_query,
+    create_or_update_session as create_or_update_session_query,
 )
 from .router import router
 
@@ -22,7 +22,7 @@ async def create_or_update_session(
     session_id: UUID,
     data: CreateOrUpdateSessionRequest,
 ) -> ResourceCreatedResponse:
-    session = create_session_query(
+    session = create_or_update_session_query(
         developer_id=x_developer_id,
         session_id=session_id,
         data=data,
@@ -30,5 +30,5 @@ async def create_or_update_session(
 
     return ResourceCreatedResponse(
         id=session.id,
-        created_at=session.created_at,
+        created_at=session.updated_at,
     )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 67bfc1e92d6e4fc8a6210714af65d0fc03ef423a  | 
|--------|--------|

fix: resolve 'Internal Server Error' in create_or_update_session

### Summary:
Fixes 'Internal Server Error' in `create_or_update_session` by removing agent assertion, renaming function, and correcting response attribute.

**Key points**:
- **Behavior**:
  - Removes assertion `assert len(agents) > 0` in `create_or_update_session.py` to allow zero agents.
  - Corrects response attribute from `created_at` to `updated_at` in `create_or_update_session()` in `create_or_update_session.py`.
- **Renames**:
  - Renames `create_session_query` to `create_or_update_session_query` in `create_or_update_session.py` and `create_or_update_session.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->