### PR TITLE
fix(llm-proxy): Update docker image to main-v1.46.2

### DIFF
--- a/llm-proxy/docker-compose.yml
+++ b/llm-proxy/docker-compose.yml
@@ -2,7 +2,7 @@ name: julep-llm-proxy
 
 services:
   litellm:
-    image: ghcr.io/berriai/litellm:main-stable
+    image: ghcr.io/berriai/litellm-database:main-v1.46.2
     volumes:
       - ./litellm-config.yaml:/app/config.yaml
       - .keys:/app/.keys


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7ff770e5f62427cb7d888884c0e893bf04410c9d  | 
|--------|--------|

fix(llm-proxy): update Docker image to main-v1.46.2

### Summary:
Update `litellm` service image in `docker-compose.yml` to `main-v1.46.2`.

**Key points**:
- **Docker Image Update**:
  - Updates `litellm` service image in `docker-compose.yml` from `ghcr.io/berriai/litellm:main-stable` to `ghcr.io/berriai/litellm-database:main-v1.46.2`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->