### PR TITLE
fix: Get PostgreSQL settings via env vars

### DIFF
--- a/scheduler/docker-compose.yml
+++ b/scheduler/docker-compose.yml
@@ -6,9 +6,9 @@ services:
       temporal-db:
         condition: service_started
     environment:
-      - DB=postgres12
-      - DB_PORT=5432
-      - DB_HOST=temporal-db
+      - DB=${TEMPORAL_POSTGRES_DB:-postgres12}
+      - DB_PORT=${TEMPORAL_POSTGRES_PORT:-5432}
+      - DB_HOST=${TEMPORAL_POSTGRES_HOST:-temporal-db}
       - POSTGRES_USER=${TEMPORAL_POSTGRES_USER:-temporal}
       - POSTGRES_PWD=${TEMPORAL_POSTGRES_PASSWORD}
       - POSTGRES_SEEDS=temporal-db


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT].
> Update PostgreSQL settings in `scheduler/docker-compose.yml` to use environment variables for dynamic configuration..
> .
>   - **Environment Variables**:.
>     - Updated `DB`, `DB_PORT`, and `DB_HOST` in `scheduler/docker-compose.yml` to use environment variables `TEMPORAL_POSTGRES_DB`, `TEMPORAL_POSTGRES_PORT`, and `TEMPORAL_POSTGRES_HOST` with default values..
>   - **Configuration**:.
>     - Allows dynamic configuration of PostgreSQL settings via environment variables, enhancing flexibility..
> .
> <sup>This description was created by </sup><img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173&link=https%3A%2F%2Fellipsis.dev"><sup> for 1b87f6b757e4d18dba0d3fdc40a14ccaff978bb5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->