### PR TITLE
feat: Add changelog from release notes

### DIFF
--- a/.github/workflows/changelog-ci.yml
+++ b/.github/workflows/changelog-ci.yml
@@ -1,21 +1,24 @@
-name: Changelog CI
+name: Changelog on release
 
-# TODO: This is currently not working. Need to fix it
 on:
-  pull_request:
-    types: [ opened, synchronize ]
+  release:
+    types: [published]
 
 jobs:
-  build:
+  changelog:
     runs-on: ubuntu-latest
 
     steps:
       # Checks-out your repository
-      - uses: actions/checkout@v2
-
-      - name: Run Changelog CI
-        uses: saadmk11/changelog-ci@v1.1.2
+      - uses: actions/checkout@v4
         with:
-          changelog_filename: CHANGELOG.md
-          # config_file: changelog-ci-config.json
+          fetch-depth: 0
+          ref: dev
+
+      # Generate changelog from release notes
+      - uses: rhysd/changelog-from-release/action@v3
+        with:
+          file: CHANGELOG.md
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          pull_request: true
+      


### PR DESCRIPTION
Signed-off-by: Diwank Singh Tomer <diwank.singh@gmail.com>

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update GitHub Actions workflow to generate changelog from release notes on release event.
> 
>   - **Workflow Changes**:
>     - Renames workflow from `Changelog CI` to `Changelog on release` in `.github/workflows/changelog-ci.yml`.
>     - Changes trigger from `pull_request` to `release` with type `published`.
>   - **Actions**:
>     - Updates `actions/checkout` from `v2` to `v4` with `fetch-depth: 0` and `ref: dev`.
>     - Replaces `saadmk11/changelog-ci@v1.1.2` with `rhysd/changelog-from-release/action@v3` to generate changelog from release notes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for c609595c44dad4c764f26fdbe98fa3ef9f9c6256. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->