### PR TITLE
fix: Bake on release as well

### DIFF
--- a/.github/workflows/bake-push-to-hub.yml
+++ b/.github/workflows/bake-push-to-hub.yml
@@ -7,7 +7,9 @@ on:
       - "dev"
     tags:
       - "v*"
-
+  release:
+    types: [published]
+    
 jobs:
   Bake-Push-Images:
     runs-on: ubuntu-latest

--- a/.github/workflows/changelog-ci.yml
+++ b/.github/workflows/changelog-ci.yml
@@ -1,21 +1,24 @@
-name: Changelog CI
+name: Changelog on release
 
-# TODO: This is currently not working. Need to fix it
 on:
-  pull_request:
-    types: [ opened, synchronize ]
+  release:
+    types: [published]
 
 jobs:
-  build:
+  changelog:
     runs-on: ubuntu-latest
 
     steps:
       # Checks-out your repository
-      - uses: actions/checkout@v2
-
-      - name: Run Changelog CI
-        uses: saadmk11/changelog-ci@v1.1.2
+      - uses: actions/checkout@v4
         with:
-          changelog_filename: CHANGELOG.md
-          # config_file: changelog-ci-config.json
+          fetch-depth: 0
+          ref: dev
+
+      # Generate changelog from release notes
+      - uses: rhysd/changelog-from-release/action@v3
+        with:
+          file: CHANGELOG.md
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          pull_request: true
+      


### PR DESCRIPTION
- **feat: Add changelog from release notes**
- **fix: Bake on release as well**

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance workflows to bake images on release and generate changelogs from release notes.
> 
>   - **Workflows**:
>     - Update `.github/workflows/bake-push-to-hub.yml` to trigger on `release` events in addition to `push` to `dev` and tags `v*`.
>     - Update `.github/workflows/changelog-ci.yml` to trigger on `release` events and generate changelog from release notes using `rhysd/changelog-from-release/action@v3`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for a7731d2f957719f1a8c59b274504cfe733aee71c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->