### PR TITLE
fix(agents-api): Remove unnecessary 'type' property from tool type definition

### DIFF
--- a/agents-api/agents_api/autogen/Tools.py
+++ b/agents-api/agents_api/autogen/Tools.py
@@ -33,10 +33,6 @@ class CreateToolRequest(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
     )
-    type: Literal["function", "integration", "system", "api_call"] = "function"
-    """
-    Whether this tool is a `function`, `api_call`, `system` etc. (Only `function` tool supported right now)
-    """
     name: Annotated[str, Field(max_length=40, pattern="^[^\\W0-9]\\w*$")]
     """
     Name of the tool (must be unique for this agent and a valid python identifier string )
@@ -168,10 +164,6 @@ class NamedToolChoice(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
     )
-    type: Literal["function", "integration", "system", "api_call"]
-    """
-    Whether this tool is a `function`, `api_call`, `system` etc. (Only `function` tool supported right now)
-    """
     function: FunctionCallOption | None = None
 
 
@@ -183,10 +175,6 @@ class PatchToolRequest(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
     )
-    type: Literal["function", "integration", "system", "api_call"] = "function"
-    """
-    Whether this tool is a `function`, `api_call`, `system` etc. (Only `function` tool supported right now)
-    """
     name: Annotated[str | None, Field(None, max_length=40, pattern="^[^\\W0-9]\\w*$")]
     """
     Name of the tool (must be unique for this agent and a valid python identifier string )
@@ -247,10 +235,6 @@ class Tool(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
     )
-    type: Literal["function", "integration", "system", "api_call"] = "function"
-    """
-    Whether this tool is a `function`, `api_call`, `system` etc. (Only `function` tool supported right now)
-    """
     name: Annotated[str, Field(max_length=40, pattern="^[^\\W0-9]\\w*$")]
     """
     Name of the tool (must be unique for this agent and a valid python identifier string )
@@ -291,10 +275,6 @@ class UpdateToolRequest(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
     )
-    type: Literal["function", "integration", "system", "api_call"] = "function"
-    """
-    Whether this tool is a `function`, `api_call`, `system` etc. (Only `function` tool supported right now)
-    """
     name: Annotated[str, Field(max_length=40, pattern="^[^\\W0-9]\\w*$")]
     """
     Name of the tool (must be unique for this agent and a valid python identifier string )
@@ -308,17 +288,6 @@ class UpdateToolRequest(BaseModel):
 
 
 class ChosenFunctionCall(ChosenToolCall):
-    model_config = ConfigDict(
-        populate_by_name=True,
-    )
-    type: Literal["function"] = "function"
-    function: FunctionCallOption
-    """
-    The function to call
-    """
-
-
-class NamedFunctionChoice(NamedToolChoice):
     model_config = ConfigDict(
         populate_by_name=True,
     )

--- a/typespec/tools/models.tsp
+++ b/typespec/tools/models.tsp
@@ -74,9 +74,6 @@ model SystemDef {
 
 // TODO: We should use this model for all tools, not just functions and discriminate on the type
 model Tool {
-    /** Whether this tool is a `function`, `api_call`, `system` etc. (Only `function` tool supported right now) */
-    type: ToolType = ToolType.function;
-
     /** Name of the tool (must be unique for this agent and a valid python identifier string )*/
     name: validPythonIdentifier;
 
@@ -95,22 +92,11 @@ model FunctionCallOption {
     name: string;
 }
 
-@discriminator("type")
 model NamedToolChoice {
-    /** Whether this tool is a `function`, `api_call`, `system` etc. (Only `function` tool supported right now) */
-    type: ToolType;
-
     function?: FunctionCallOption;
     integration?: never; // TODO: Implement
     system?: never; // TODO: Implement
     api_call?: never; // TODO: Implement
-}
-
-model NamedFunctionChoice extends NamedToolChoice {
-    type: ToolType.function;
-
-    /** The function to call */
-    function: FunctionCallOption;
 }
 
 model ToolResponse {


### PR DESCRIPTION
Signed-off-by: Diwank Singh Tomer <diwank.singh@gmail.com>

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removed 'type' property from tool classes and added computed 'type' property using a function in `Tools.py`, `openapi_model.py`, and `tasks.py`.
> 
>   - **Behavior**:
>     - Removed `type` property from `CreateToolRequest`, `NamedToolChoice`, `PatchToolRequest`, `Tool`, and `UpdateToolRequest` in `Tools.py`.
>     - Added computed `type` property to `TaskTool`, `Tool`, `UpdateToolRequest`, and `PatchToolRequest` in `openapi_model.py`.
>     - Updated `task_to_spec()` in `tasks.py` to use computed `type` property.
>   - **Misc**:
>     - Removed `type` property from `Tool` and `NamedToolChoice` in `models.tsp`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 289e87eff9a220b2c4430959f989cca471e36cf9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->