### PR TITLE
feat(agents-api): Add some LiteLLM exceptions to the list of non-retryable errors

### DIFF
--- a/agents-api/agents_api/common/exceptions/tasks.py
+++ b/agents-api/agents_api/common/exceptions/tasks.py
@@ -14,6 +14,7 @@ import fastapi
 import httpx
 import jinja2
 import jsonschema.exceptions
+import litellm
 import pydantic
 import requests
 import temporalio.exceptions
@@ -70,10 +71,12 @@ NON_RETRYABLE_ERROR_TYPES = [
     pydantic.ValidationError,
     requests.exceptions.InvalidURL,
     requests.exceptions.MissingSchema,
+    #
     # Box exceptions
     box.exceptions.BoxKeyError,
     box.exceptions.BoxTypeError,
     box.exceptions.BoxValueError,
+    #
     # Beartype exceptions
     beartype.roar.BeartypeException,
     beartype.roar.BeartypeDecorException,
@@ -88,6 +91,14 @@ NON_RETRYABLE_ERROR_TYPES = [
     beartype.roar.BeartypeCallHintReturnViolation,
     beartype.roar.BeartypeDecorHintParamDefaultViolation,
     beartype.roar.BeartypeDoorHintViolation,
+    #
+    # LiteLLM exceptions
+    litellm.exceptions.NotFoundError,
+    litellm.exceptions.InvalidRequestError,
+    litellm.exceptions.AuthenticationError,
+    litellm.exceptions.ServiceUnavailableError,
+    litellm.exceptions.OpenAIError,
+    litellm.exceptions.APIError,
 ]
 
 


### PR DESCRIPTION
Added the following exceptions:

- `litellm.exceptions.NotFoundError`.
- `litellm.exceptions.InvalidRequestError`.
- `litellm.exceptions.AuthenticationError`.
- `litellm.exceptions.ServiceUnavailableError`.
- `litellm.exceptions.OpenAIError`.
- `litellm.exceptions.APIError`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add LiteLLM exceptions to non-retryable errors in `tasks.py`.
> 
>   - **Exceptions**:
>     - Added `litellm.exceptions.NotFoundError`, `InvalidRequestError`, `AuthenticationError`, `ServiceUnavailableError`, `OpenAIError`, and `APIError` to `NON_RETRYABLE_ERROR_TYPES` in `tasks.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 018360cfe4c489b62de1b6ee3eaea2cb7e3e92b4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->