### PR TITLE
Automated translation of README.md (GitHub action)

### DIFF
--- a/.github/workflows/translate-readme.yml
+++ b/.github/workflows/translate-readme.yml
@@ -1,0 +1,36 @@
+name: Translate README
+
+on:
+  push:
+    paths:
+      - "README.md"
+
+jobs:
+  translate:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install googletrans==4.0.0-rc1
+
+    - name: Run translation script
+      run: |
+        python translate_readme.py
+
+    - name: Commit changes
+      run: |
+        git config --local user.name "GitHub Actions"
+        git config --local user.email "actions@github.com"
+        git add README-CN.md README-JP.md README-FR.md
+        git commit -m "Automated translation of README.md"
+        git push

--- a/.github/workflows/translate-readme.yml
+++ b/.github/workflows/translate-readme.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install googletrans==4.0.0-rc1
+        pip install markdown-it-py deep-translator
 
     - name: Run translation script
       run: python ./scripts/translate_readme.py

--- a/.github/workflows/translate-readme.yml
+++ b/.github/workflows/translate-readme.yml
@@ -24,8 +24,7 @@ jobs:
         pip install googletrans==4.0.0-rc1
 
     - name: Run translation script
-      run: |
-        python translate_readme.py
+      run: python ./scripts/translate_readme.py
 
     - name: Commit changes
       run: |

--- a/README-CN.md
+++ b/README-CN.md
@@ -30,7 +30,26 @@ Get your API key [here](https://dashboard-dev.julep.ai).While we are in beta, yo
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 <details>
 <summary><h3>📖 Table of Contents</h3></summary>
-[Introduction](#introduction)[Quick Example](#quick-example)[Key Features](#key-features)[Why Julep vs. LangChain?](#why-julep-vs-langchain)[Different Use Cases](#different-use-cases)[Different Form Factor](#different-form-factor)[In Summary](#in-summary)[Installation](#installation)[Python Quick Start 🐍](#python-quick-start-)[Step 1: Create an Agent](#step-1-create-an-agent)[Step 2: Create a Task that generates a story and comic strip](#step-2-create-a-task-that-generates-a-story-and-comic-strip)[Step 3: Execute the Task](#step-3-execute-the-task)[Step 4: Chat with the Agent](#step-4-chat-with-the-agent)[Node.js Quick Start 🟩](#nodejs-quick-start-)[Step 1: Create an Agent](#step-1-create-an-agent-1)[Step 2: Create a Task that generates a story and comic strip](#step-2-create-a-task-that-generates-a-story-and-comic-strip-1)[Step 3: Execute the Task](#step-3-execute-the-task-1)[Step 4: Chat with the Agent](#step-4-chat-with-the-agent-1)[组件](#compone（新台币）[Mental Model](#mental-model)[Concepts](#concepts)[Understanding Tasks](#understanding-tasks)[Types of Workflow Steps](#types-of-workflow-steps)[Advanced Features](#advanced-features)[Adding Tools to Agents](#adding-tools-to-agents)[Managing Sessions and Users](#managing-sessions-and-users)[Document Integration and Search](#document-integration-and-search)[Integrations](#integrations)[Brave Search](#brave-search)[BrowserBase](#browserbase)[Email](#email)[Spider](#spider)[Weather](#weather)[Wikipedia](#wikipedia)[SDK Reference](#sdk-reference)[API Reference](#api-reference)</details>
+
+- [Optional: Define the input schema for the task](#optional-define-the-input-schema-for-the-task)
+- [Define the tools that the agent can use](#define-the-tools-that-the-agent-can-use)
+- [Special variables:](#special-variables)
+- [- inputs: for accessing the input to the task](#--inputs-for-accessing-the-input-to-the-task)
+- [- outputs: for accessing the output of previous steps](#--outputs-for-accessing-the-output-of-previous-steps)
+- [- _: for accessing the output of the previous step](#--_-for-accessing-the-output-of-the-previous-step)
+- [Define the main workflow](#define-the-main-workflow)
+- [Evaluate the search queries using a simple python expression](#evaluate-the-search-queries-using-a-simple-python-expression)
+- [Run the web search in parallel for each query](#run-the-web-search-in-parallel-for-each-query)
+- [Collect the results from the web search](#collect-the-results-from-the-web-search)
+- [Summarize the results](#summarize-the-results)
+- [Send the summary to Discord](#send-the-summary-to-discord)
+- [🛠️ Add an image generation tool (DALL·E) to the agent](#-add-an-image-generation-tool-dall%C2%B7e-to-the-agent)
+- [Create a task that takes an idea and creates a story and a 4-panel comic strip](#create-a-task-that-takes-an-idea-and-creates-a-story-and-a-4-panel-comic-strip)
+- [Step 1: Generate a story and outline into 4 panels](#step-1-generate-a-story-and-outline-into-4-panels)
+- [Step 2: Extract the小组描述和故事evaluate:](#step-2-extract-the%E5%B0%8F%E7%BB%84%E6%8F%8F%E8%BF%B0%E5%92%8C%E6%95%85%E4%BA%8Bevaluate)
+    - [Step 3: Execute the Task](#step-3-execute-the-task)
+
+</details>
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 介绍Julep 是一个用于创建 AI 代理的平台，这些代理可以记住过去的互动并执行复杂的任务。它提供长期记忆并管理多步骤流程。Julep 支持创建多步骤任务，包括决策、循环、并行处理以及与众多外部工具和 API 的集成。虽然许多人工智能应用程序仅限于简单、线性的提示链和 API 调用，并且分支很少，但 Julep 可以处理更复杂的场景。它支持：复杂、多步骤的流程动态决策并行执行[!TIP]
 Imagine you want to build an AI agent that can do more than just answer simple questions—it needs to handle complex tasks, remember past interactions, and maybe even use other tools or APIs. That's where Julep comes in.快速示例想象一下一个可以执行以下操作的研究 AI 代理：选一个话题，针对该主题提出 100 个搜索查询，同时进行这些网页搜索，总结结果，将摘要发送至 DiscordIn Julep, this would be a single task under <b>80 lines of code</b> and run <b>fully managed</b> all on its own. All of the steps are executed on Julep's own servers and you don't need to lift a finger. Here's a working example:name: Research Agent

--- a/README-CN.md
+++ b/README-CN.md
@@ -1,691 +1,523 @@
-<sup>[English](README.md) | 中文 | [日本語](README-JP.md)</sup>
-
-<div align="center">
-    <img src="https://socialify.git.ci/julep-ai/julep/image?description=1&descriptionEditable=Build%20AI%20agents%20and%20workflows%20with%20a%20simple%20API&font=Source%20Code%20Pro&logo=https%3A%2F%2Fraw.githubusercontent.com%2Fjulep-ai%2Fjulep%2Fdev%2F.github%2Fjulep-logo.svg&owner=1&pattern=Solid&stargazers=1&theme=Auto" alt="julep" width="640" height="320" />
+<sup>English | [中文翻译](https://github.com/julep-ai/julep/blob/dev/README-CN.md) | [日本語翻訳](https://github.com/julep-ai/julep/blob/dev/README-JP.md)</sup><div align="center">
+ <img src="https://socialify.git.ci/julep-ai/julep/image?description=1&descriptionEditable=API%20for%20AI%20agents%20and%20multi-step%20tasks&forks=1&name=1&owner=1&pattern=Solid&stargazers=1&font=Source%20Code%20Pro&logo=https%3A%2F%2Fraw.githubusercontent.com%2Fjulep-ai%2Fjulep%2Fdev%2F.github%2Fjulep-logo.svg&theme=Auto" alt="julep" width="640" height="320" />
 </div>
-
 <p align="center">
   <br />
-  <a href="https://docs.julep.ai" rel="dofollow"><strong>探索文档</strong></a>
+  <a href="https://docs.julep.ai" rel="dofollow"><strong>Explore Docs</strong></a>
   ·
   <a href="https://discord.com/invite/JTSBGRZrzj" rel="dofollow">Discord</a>
   ·
   <a href="https://x.com/julep_ai" rel="dofollow">𝕏</a>
   ·
-  <a href="https://www.linkedin.com/company/julep-ai" rel="dofollow">领英</a>
+  <a href="https://www.linkedin.com/company/julep-ai" rel="dofollow">LinkedIn</a>
 </p>
-
-
 <p align="center">
-    <a href="https://www.npmjs.com/package/@julep/sdk"><img src="https://img.shields.io/npm/v/%40julep%2Fsdk?style=social&amp;logo=npm&amp;link=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2F%40julep%2Fsdk" alt="NPM 版本"></a>
+    <a href="https://www.npmjs.com/package/@julep/sdk"><img src="https://img.shields.io/npm/v/%40julep%2Fsdk?style=social&amp;logo=npm&amp;link=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2F%40julep%2Fsdk" alt="NPM Version"></a>
     <span>&nbsp;</span>
-    <a href="https://pypi.org/project/julep"><img src="https://img.shields.io/pypi/v/julep?style=social&amp;logo=python&amp;label=PyPI&amp;link=https%3A%2F%2Fpypi.org%2Fproject%2Fjulep" alt="PyPI - 版本"></a>
+    <a href="https://pypi.org/project/julep"><img src="https://img.shields.io/pypi/v/julep?style=social&amp;logo=python&amp;label=PyPI&amp;link=https%3A%2F%2Fpypi.org%2Fproject%2Fjulep" alt="PyPI - Version"></a>
     <span>&nbsp;</span>
-    <a href="https://hub.docker.com/u/julepai"><img src="https://img.shields.io/docker/v/julepai/agents-api?sort=semver&amp;style=social&amp;logo=docker&amp;link=https%3A%2F%2Fhub.docker.com%2Fu%2Fjulepai" alt="Docker 镜像版本"></a>
+    <a href="https://hub.docker.com/u/julepai"><img src="https://img.shields.io/docker/v/julepai/agents-api?sort=semver&amp;style=social&amp;logo=docker&amp;link=https%3A%2F%2Fhub.docker.com%2Fu%2Fjulepai" alt="Docker Image Version"></a>
     <span>&nbsp;</span>
-    <a href="https://choosealicense.com/licenses/apache/"><img src="https://img.shields.io/github/license/julep-ai/julep" alt="GitHub 许可证"></a>
+    <a href="https://choosealicense.com/licenses/apache/"><img src="https://img.shields.io/github/license/julep-ai/julep" alt="GitHub License"></a>
 </p>
-
-*****
-
-> [!TIP]
-> 👨‍💻 来参加 devfest.ai 活动？加入我们的 [Discord](https://discord.com/invite/JTSBGRZrzj) 并查看下方详情。
-
-<details>
-<summary><b>🌟 贡献者和 DevFest.AI 参与者：</b></summary>
-
-## 🌟 诚邀贡献者！
-
-我们很高兴欢迎新的贡献者加入 Julep 项目！我们创建了几个"适合新手的问题"来帮助您入门。以下是您可以贡献的方式：
-
-1. 查看我们的 [CONTRIBUTING.md](CONTRIBUTING.md) 文件，了解如何贡献的指南。
-2. 浏览我们的[适合新手的问题](https://github.com/julep-ai/julep/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)，找到一个您感兴趣的任务。
-3. 如果您有任何问题或需要帮助，请随时在我们的 [Discord](https://discord.com/invite/JTSBGRZrzj) 频道上联系我们。
-
-您的贡献，无论大小，对我们都很宝贵。让我们一起创造令人惊叹的东西吧！🚀
-
-### 🎉 DevFest.AI 2024年10月
-
-激动人心的消息！我们将在整个2024年10月参与 DevFest.AI 活动！🗓️
-
-- 在此活动期间为 Julep 做出贡献，有机会赢得超棒的 Julep 周边和礼品！🎁
-- 加入来自世界各地的开发者，为 AI 仓库做出贡献并参与精彩的活动。
-- 非常感谢 DevFest.AI 组织这个fantastic的活动！
-
-> [!TIP]
-> 准备好加入这场盛会了吗？**[发推文开始参与](https://twitter.com/intent/tweet?text=Pumped%20to%20be%20participating%20in%20%40devfestai%20with%20%40julep_ai%20building%20%23ai%20%23agents%20%23workflows%20Let's%20gooo!%20https%3A%2F%2Fgit.new%2Fjulep)**，让我们开始编码吧！🖥️
-
-![Julep DevFest.AI](https://media.giphy.com/media/YjyUeyotft6epaMHtU/giphy.gif)
-
-</details>
-
+[!NOTE]
+👨‍💻 Here for the devfest.ai event? Join our [Discord](https://discord.com/invite/JTSBGRZrzj) and check out the details below.<details>
+<summary><b>🌟 Contributors and DevFest.AI Participants</b> (Click to expand)</summary>
+🌟 招募贡献者！我们很高兴欢迎新贡献者加入 Julep 项目！我们创建了几个“好的第一个问题”来帮助您入门。以下是您可以做出贡献的方式：Check out our [CONTRIBUTING.md](CONTRIBUTING.md) file for guidelines on how to contribute.Browse our [good first issues](https://github.com/julep-ai/julep/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) to find a task that interests you.If you have any questions or need help, don't hesitate to reach out on our [Discord](https://discord.com/invite/JTSBGRZrzj) channel.您的贡献，无论大小，对我们来说都是宝贵的。让我们一起创造一些了不起的东西！🚀🎉 DevFest.AI 2024 年 10 月令人兴奋的消息！我们将参加 2024 年 10 月的 DevFest.AI！🗓️在本次活动期间为 Julep 做出贡献，就有机会赢得超棒的 Julep 商品和赃物！🎁与来自世界各地的开发人员一起为 AI 资源库做出贡献并参与精彩的活动。非常感谢 DevFest.AI 组织这次精彩的活动！[!TIP]
+Ready to join the fun? **[Tweet that you are participating](https://twitter.com/intent/tweet?text=Pumped%20to%20be%20participating%20in%20%40devfestai%20with%20%40julep_ai%20building%20%23ai%20%23agents%20%23workflows%20Let's%20gooo!%20https%3A%2F%2Fgit.new%2Fjulep)** and let's get coding! 🖥️[!NOTE]
+Get your API key [here](https://dashboard-dev.julep.ai).While we are in beta, you can also reach out on [Discord](https://discord.com/invite/JTSBGRZrzj) to get rate limits lifted on your API key.![Julep DevFest.AI](https://media.giphy.com/media/YjyUeyotft6epaMHtU/giphy.gif)</details>
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 <details>
 <summary><h3>📖 Table of Contents</h3></summary>
-
-- [简介](#%E7%AE%80%E4%BB%8B)
-- [特性](#%E7%89%B9%E6%80%A7)
-- [安装](#%E5%AE%89%E8%A3%85)
-- [快速入门指南](#%E5%BF%AB%E9%80%9F%E5%85%A5%E9%97%A8%E6%8C%87%E5%8D%97)
-  - [步骤 1：导入 Julep](#%E6%AD%A5%E9%AA%A4-1%E5%AF%BC%E5%85%A5-julep)
-  - [步骤 2：初始化代理](#%E6%AD%A5%E9%AA%A4-2%E5%88%9D%E5%A7%8B%E5%8C%96%E4%BB%A3%E7%90%86)
-  - [步骤 3：与代理聊天](#%E6%AD%A5%E9%AA%A4-3%E4%B8%8E%E4%BB%A3%E7%90%86%E8%81%8A%E5%A4%A9)
-  - [步骤 4：创建多步骤任务](#%E6%AD%A5%E9%AA%A4-4%E5%88%9B%E5%BB%BA%E5%A4%9A%E6%AD%A5%E9%AA%A4%E4%BB%BB%E5%8A%A1)
-  - [步骤 5：执行任务](#%E6%AD%A5%E9%AA%A4-5%E6%89%A7%E8%A1%8C%E4%BB%BB%E5%8A%A1)
-- [概念](#%E6%A6%82%E5%BF%B5)
-  - [代理](#%E4%BB%A3%E7%90%86)
-  - [用户](#%E7%94%A8%E6%88%B7)
-  - [会话](#%E4%BC%9A%E8%AF%9D)
-  - [任务](#%E4%BB%BB%E5%8A%A1)
-  - [工具](#%E5%B7%A5%E5%85%B7)
-  - [文档](#%E6%96%87%E6%A1%A3)
-  - [执行](#%E6%89%A7%E8%A1%8C)
-- [理解任务](#%E7%90%86%E8%A7%A3%E4%BB%BB%E5%8A%A1)
-  - [工作流步骤类型](#%E5%B7%A5%E4%BD%9C%E6%B5%81%E6%AD%A5%E9%AA%A4%E7%B1%BB%E5%9E%8B)
-- [高级功能](#%E9%AB%98%E7%BA%A7%E5%8A%9F%E8%83%BD)
-  - [为代理添加工具](#%E4%B8%BA%E4%BB%A3%E7%90%86%E6%B7%BB%E5%8A%A0%E5%B7%A5%E5%85%B7)
-  - [管理会话和用户](#%E7%AE%A1%E7%90%86%E4%BC%9A%E8%AF%9D%E5%92%8C%E7%94%A8%E6%88%B7)
-  - [文档集成和搜索](#%E6%96%87%E6%A1%A3%E9%9B%86%E6%88%90%E5%92%8C%E6%90%9C%E7%B4%A2)
-- [SDK 参考](#sdk-%E5%8F%82%E8%80%83)
-- [API 参考](#api-%E5%8F%82%E8%80%83)
-- [示例和教程](#%E7%A4%BA%E4%BE%8B%E5%92%8C%E6%95%99%E7%A8%8B)
-- [贡献](#%E8%B4%A1%E7%8C%AE)
-- [支持和社区](#%E6%94%AF%E6%8C%81%E5%92%8C%E7%A4%BE%E5%8C%BA)
-- [许可证](#%E8%AE%B8%E5%8F%AF%E8%AF%81)
-- [致谢](#%E8%87%B4%E8%B0%A2)
-
-</details>
+[Introduction](#introduction)[Quick Example](#quick-example)[Key Features](#key-features)[Why Julep vs. LangChain?](#why-julep-vs-langchain)[Different Use Cases](#different-use-cases)[Different Form Factor](#different-form-factor)[In Summary](#in-summary)[Installation](#installation)[Python Quick Start 🐍](#python-quick-start-)[Step 1: Create an Agent](#step-1-create-an-agent)[Step 2: Create a Task that generates a story and comic strip](#step-2-create-a-task-that-generates-a-story-and-comic-strip)[Step 3: Execute the Task](#step-3-execute-the-task)[Step 4: Chat with the Agent](#step-4-chat-with-the-agent)[Node.js Quick Start 🟩](#nodejs-quick-start-)[Step 1: Create an Agent](#step-1-create-an-agent-1)[Step 2: Create a Task that generates a story and comic strip](#step-2-create-a-task-that-generates-a-story-and-comic-strip-1)[Step 3: Execute the Task](#step-3-execute-the-task-1)[Step 4: Chat with the Agent](#step-4-chat-with-the-agent-1)[组件](#compone（新台币）[Mental Model](#mental-model)[Concepts](#concepts)[Understanding Tasks](#understanding-tasks)[Types of Workflow Steps](#types-of-workflow-steps)[Advanced Features](#advanced-features)[Adding Tools to Agents](#adding-tools-to-agents)[Managing Sessions and Users](#managing-sessions-and-users)[Document Integration and Search](#document-integration-and-search)[Integrations](#integrations)[Brave Search](#brave-search)[BrowserBase](#browserbase)[Email](#email)[Spider](#spider)[Weather](#weather)[Wikipedia](#wikipedia)[SDK Reference](#sdk-reference)[API Reference](#api-reference)</details>
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+介绍Julep 是一个用于创建 AI 代理的平台，这些代理可以记住过去的互动并执行复杂的任务。它提供长期记忆并管理多步骤流程。Julep 支持创建多步骤任务，包括决策、循环、并行处理以及与众多外部工具和 API 的集成。虽然许多人工智能应用程序仅限于简单、线性的提示链和 API 调用，并且分支很少，但 Julep 可以处理更复杂的场景。它支持：复杂、多步骤的流程动态决策并行执行[!TIP]
+Imagine you want to build an AI agent that can do more than just answer simple questions—it needs to handle complex tasks, remember past interactions, and maybe even use other tools or APIs. That's where Julep comes in.快速示例想象一下一个可以执行以下操作的研究 AI 代理：选一个话题，针对该主题提出 100 个搜索查询，同时进行这些网页搜索，总结结果，将摘要发送至 DiscordIn Julep, this would be a single task under <b>80 lines of code</b> and run <b>fully managed</b> all on its own. All of the steps are executed on Julep's own servers and you don't need to lift a finger. Here's a working example:name: Research Agent
 
-## 简介
+# Optional: Define the input schema for the task
+input_schema:
+  type: object
+  properties:
+    topic:
+      type: string
+      description: The main topic to research
 
-Julep 是一个开源平台，用于创建具有可定制工作流的持久 AI 代理。它提供了开发、管理和部署 AI 驱动应用程序的工具，注重灵活性和易用性。
+# Define the tools that the agent can use
+tools:
+- name: web_search
+  type: integration
+  integration:
+    provider: brave
+    setup:
+      api_key: "YOUR_BRAVE_API_KEY"
 
-使用 Julep，您可以：
-- 快速开发能够在多次交互中保持上下文和状态的 AI 代理
-- 设计和执行针对您的 AI 代理定制的复杂工作流
-- 无缝集成各种工具和 API 到您的 AI 工作流中
-- 轻松管理持久会话和用户交互
+- name: discord_webhook
+  type: api_call
+  api_call:
+    url: "YOUR_DISCORD_WEBHOOK_URL"
+    method: POST
+    headers:
+      Content-Type: application/json
 
-无论您是在开发聊天机器人、自动化任务，还是构建复杂的 AI 助手，Julep 都能为您提供所需的灵活性和功能，帮助您快速高效地将想法转化为现实。
+# Special variables:
+# - inputs: for accessing the input to the task
+# - outputs: for accessing the output of previous steps
+# - _: for accessing the output of the previous step
 
-<!-- TODO: 添加一个屏幕录像 -->
+# Define the main workflow
+main:
+- prompt:
+    - role: system
+      content: >-
+        You are a research assistant.
+        Generate 100 diverse search queries related to the topic:
+        {{inputs[0].topic}}
 
-<details>
-<summary>这里有一个简单的 Python 示例：</summary>
+        Write one query per line.
+  unwrap: true
 
-<!-- TODO: 在 README 中添加展示任务执行过程的 gif -->
+# Evaluate the search queries using a simple python expression
+- evaluate:
+    search_queries: "_.split('\n')"
 
-<pre><code class="language-python">
-from julep import Julep, AsyncJulep
+# Run the web search in parallel for each query
+- over: "_.search_queries"
+  map:
+    tool: web_search
+    arguments:
+      query: "_"
+  parallelism: 100
 
-# 🔑 初始化 Julep 客户端
-#     或者使用 AsyncJulep 进行异步操作
-client = Julep(api_key="your_api_key")
+# Collect the results from the web search
+- evaluate:
+    results: "'\n'.join([item.result for item in _])"
 
-##################
-## 🤖 代理 🤖 ##
-##################
+# Summarize the results
+- prompt:
+    - role: system
+      content: >
+        You are a research summarizer. Create a comprehensive summary of the following research results on the topic {{inputs[0].topic}}.
+        The summary should be well-structured, informative, and highlight key findings and insights:
+        {{_.results}}
+  unwrap: true
 
-# 创建一个研究代理
+# Send the summary to Discord
+- tool: discord_webhook
+  arguments:
+    content: >
+      **Research Summary for {{inputs[0].topic}}**
+
+      {{_}}
+[!TIP]
+Julep is really useful when you want to build AI agents that can maintain context and state over long-term interactions. It's great for designing complex, multi-step workflows and integrating various tools and APIs directly into your agent's processes.在这个例子中，Julep 将自动管理并行执行，重试失败的步骤，重新发送 API 请求，并保持任务可靠运行直到完成。主要特点🧠 **Persistent AI Agents**: Remember context and information over long-term interactions.💾 **Stateful Sessions**: Keep track of past interactions for personalized responses.🔄 **Multi-Step Tasks**: Build complex, multi-step processes with loops and decision-making.⏳ **Task Management**: Handle long-running tasks that can run indefinitely.🛠️ **Built-in Tools**: Use built-in tools and external APIs in your tasks.🔧 **Self-Healing**: Julep will automatically retry failed steps, resend messages, and generally keep your tasks running smoothly.📚 **RAG**: Use Julep's document store to build a system for retrievi并使用您自己的数据。Julep 非常适合需要超越简单的提示响应模型的 AI 用例的应用程序。为什么选择 Julep 而不是 LangChain？不同的用例可以将 LangChain 和 Julep 视为 AI 开发堆栈中具有不同重点的工具。LangChain 非常适合创建提示序列和管理与 AI 模型的交互。它拥有庞大的生态系统，包含大量预构建的集成，如果您想快速启动和运行某些功能，这会非常方便。LangChain 非常适合涉及线性提示链和 API 调用的简单用例。另一方面，Julep 更注重构建持久的 AI 代理，这些代理可以在长期交互​​中记住事物。当您需要涉及多个步骤、决策以及在代理流程中直接与各种工具或 API 集成的复杂任务时，它会大放异彩。它从头开始设计，以管理持久会话和复杂任务。如果您想构建一个需要执行以下操作的复杂 AI 助手，请使用 Julep：跟踪几天或几周内的用户互动。执行计划任务，例如发送每日摘要或监控数据源。根据之前的互动或存储的数据做出决策。作为其任务的一部分，与多个外部服务进行交互。然后 Julep 提供支持所有这些的基础设施，而无需您从头开始构建。不同的外形尺寸Julep is a **platform** that includes a language for describing tasks, a server for running those tasks, and an SDK for interacting with the platform. To build something with Julep, you write a description of the task in `YAML`, and then run the task in the cloud.Julep 专为繁重、多步骤和长时间运行的任务而设计，并且对任务的复杂程度没有限制。LangChain is a **library** that includes a few tools and a framework for building linear chains of prompts and tools. To build something with LangChain, you typically write Python code that configures and runs the model chains you want to use.对于涉及线性提示和 API 调用链的简单用例，LangChain 可能足够并且能够更快地实现。总之当您需要在无状态或短期环境中管理 AI 模型交互和提示序列时，请使用 LangChain。当您需要一个具有高级任务功能、持久会话和复杂任务管理的状态代理的强大框架时，请选择 Julep。安装To get started with Julep, install it using [npm](https://www.npmjs.com/package/@julep/sdk) or [pip](https://pypi.org/project/julep/):npm install @julep/sdk
+或者pip install julep
+[!NOTE]
+Get your API key [here](https://dashboard-dev.julep.ai).While we are in beta, you can also reach out on [Discord](https://discord.com/invite/JTSBGRZrzj) to get rate limits lifted on your API key.[!TIP]
+💻 Are you a _show me the code!™_ kind of person? We have created a ton of cookbooks for you to get started with. **Check out the [cookbooks](https://github.com/julep-ai/julep/tree/dev/cookbooks)** to browse through examples.💡 There's also lots of ideas that you can build on top of Julep. **Check out the [list of ideas](https://github.com/julep-ai/julep/tree/dev/cookbooks/IDEAS.md)** to get some inspiration.Python 快速入门🐍步骤 1：创建代理import yaml
+from julep import Julep # or AsyncJulep
+
+client = Julep(api_key="your_julep_api_key")
+
 agent = client.agents.create(
-    name="研究代理",
-    model="claude-3.5-sonnet",
-    about="您是一个设计用于处理研究查询的研究代理。",
+    name="Storytelling Agent",
+    model="gpt-4o",
+    about="You are a creative storytelling agent that can craft engaging stories and generate comic panels based on ideas.",
 )
 
-# 🔍 为代理添加工具
+# 🛠️ Add an image generation tool (DALL·E) to the agent
 client.agents.tools.create(
     agent_id=agent.id,
-    name="web_search",  # 应该是有效的 Python 变量名
-    description="使用此工具进行研究查询。",
-    integration={
-        "provider": "brave",
-        "method": "search",
-        "setup": {
-            "api_key": "your_brave_api_key",
-        },
-    },
-)
-
-#################
-## 💬 聊天 💬 ##
-#################
-
-# 与代理开始交互式聊天会话
-session = client.sessions.create(
-    agent_id=agent.id,
-    context_overflow="adaptive",  # 🧠 Julep 将在需要时动态计算上下文窗口
-)
-
-# 🔄 聊天循环
-while (user_input := input("您：")) != "退出":
-    response = client.sessions.chat(
-        session_id=session.id,
-        message=user_input,
-    )
-
-    print("代理：", response.choices[0].message.content)
-
-
-#################
-## 📋 任务 📋 ##
-#################
-
-# 为代理创建一个周期性研究任务
-task = client.tasks.create(
-    agent_id=agent.id,
-    name="研究任务",
-    description="每24小时研究给定的主题。",
-    #
-    # 🛠️ 任务特定工具
-    tools=[
-        {
-            "name": "send_email",
-            "description": "向用户发送包含结果的电子邮件。",
-            "api_call": {
-                "method": "post",
-                "url": "https://api.sendgrid.com/v3/mail/send",
-                "headers": {"Authorization": "Bearer YOUR_SENDGRID_API_KEY"},
-            },
-        }
-    ],
-    #
-    # 🔢 任务主要步骤
-    main=[
-        #
-        # 步骤 1：研究主题
-        {
-            # `_`（下划线）变量指向上一步的输出
-            # 这里，它指向用户输入的主题
-            "prompt": "查找主题 '{{_.topic}}' 并总结结果。",
-            "tools": [{"ref": {"name": "web_search"}}],  # 🔍 使用代理的网络搜索工具
-            "unwrap": True,
-        },
-        #
-        # 步骤 2：发送包含研究结果的电子邮件
-        {
-            "tool": "send_email",
-            "arguments": {
-                "subject": "研究结果",
-                "body": "'以下是今天的研究结果：' + _.content",
-                "to": "inputs[0].email",  # 引用用户输入的电子邮件
-            },
-        },
-        #
-        # 步骤 3：等待 24 小时后重复
-        {"sleep": "24 * 60 * 60"},
-    ],
-)
-
-# 🚀 启动周期性任务
-client.executions.create(task_id=task.id, input={"topic": "Python"})
-
-# 🔁 这将每 24 小时运行一次任务，
-#    研究 "Python" 主题，并
-#    将结果发送到用户的电子邮件
-</code></pre>
-</details>
-
-## 特性
-
-Julep 简化了构建具有可定制工作流的持久 AI 代理的过程。主要特性包括：
-
-- **持久 AI 代理**：创建和管理能够在多次交互中保持上下文的 AI 代理。
-- **可定制工作流**：使用任务（Tasks）设计复杂的多步骤 AI 工作流。
-- **工具集成**：无缝集成各种工具和 API 到您的 AI 工作流中。
-- **文档管理**：高效管理和搜索代理的文档。
-- **会话管理**：处理持久会话以实现连续交互。
-- **灵活执行**：支持工作流中的并行处理、条件逻辑和错误处理。
-
-## 安装
-
-要开始使用 Julep，请使用 [npm](https://www.npmjs.com/package/@julep/sdk) 或 [pip](https://pypi.org/project/julep/) 安装：
-
-```bash
-npm install @julep/sdk
-```
-
-或
-
-```bash
-pip install julep
-```
-
-> [!TIP]
-> 在测试阶段，您可以通过 [Discord](https://discord.com/invite/JTSBGRZrzj) 获取 API 密钥。
-
-## 快速入门指南
-
-### 步骤 1：导入 Julep
-
-首先，将 Julep SDK 导入到您的项目中：
-
-```javascript
-const Julep = require('@julep/sdk');
-```
-
-或
-
-```python
-from julep import AsyncJulep
-```
-
-### 步骤 2：初始化代理
-
-使用基本设置创建一个新代理：
-
-```javascript
-const julep = new Julep({ apiKey: 'your-api-key' });
-
-const agent = await julep.agents.create({
-  name: '研究助手',
-  model: 'gpt-4-turbo',
-  about: "您是一个创意讲故事代理，能够根据想法创作引人入胜的故事并生成漫画面板。",
-});
-```
-
-或
-
-```python
-client = AsyncJulep(api_key="your_api_key")
-
-agent = await client.agents.create(
-    name="讲故事代理",
-    model="gpt-4-turbo",
-    about="您是一个创意讲故事代理，能够根据想法创作引人入胜的故事并生成漫画面板。",
-)
-```
-
-### 步骤 3：与代理聊天
-
-与代理开始交互式聊天会话：
-
-```javascript
-const session = await julep.sessions.create({
-  agentId: agent.id,
-}); 
-
-// 向代理发送消息
-const response = await julep.sessions.chat({
-  sessionId: session.id,
-  message: '你好，能给我讲个故事吗？',
-});
-
-console.log(response);
-```
-
-或
-
-```python
-session = await client.sessions.create(agent_id=agent.id)
-
-# 向代理发送消息
-response = await client.sessions.chat(
-    session_id=session.id,
-    message="你好，能给我讲个故事吗？",
-)
-
-print(response)
-```
-
-### 步骤 4：创建多步骤任务
-
-让我们定义一个多步骤任务，根据输入的想法创建故事并生成分镜漫画：
-
-```python
-# 🛠️ 为代理添加图像生成工具（DALL·E）
-await client.agents.tools.create(
-    agent_id=agent.id,
     name="image_generator",
-    description="使用此工具根据描述生成图像。",
+    description="Use this tool to generate images based on descriptions.",
     integration={
         "provider": "dalle",
         "method": "generate_image",
         "setup": {
-            "api_key": "your_dalle_api_key",
+            "api_key": "your_openai_api_key",
         },
     },
 )
+步骤 2：创建生成故事和漫画的任务让我们定义一个多步骤任务来创建一个故事并根据输入的想法生成面板漫画：# 📋 Task
+# Create a task that takes an idea and creates a story and a 4-panel comic strip
+task_yaml = """
+name: Story and Comic Creator
+description: Create a story based on an idea and generate a 4-panel comic strip illustrating the story.
 
-# 📋 任务
-# 创建一个任务，接受一个想法并创建故事和 4 格漫画
-task = await client.tasks.create(
+main:
+  # Step 1: Generate a story and outline into 4 panels
+  - prompt:
+      - role: system
+        content: You are {{agent.name}}. {{agent.about}}
+      - role: user
+        content: >
+          Based on the idea '{{_.idea}}', write a short story suitable for a 4-panel comic strip.
+          Provide the story and a numbered list of 4 brief descriptions for each panel illustrating key moments in the story.
+    unwrap: true
+
+  # Step 2: Extract the小组描述和故事evaluate:
+  story: _.split('1. ')[0].strip()
+  panels: re.findall(r'\\d+\\.\\s*(.*?)(?=\\d+\\.\\s*|$)', _)步骤 3：使用图像生成器工具为每个面板生成图像foreach:
+  in: _.panels
+  do:
+    tool: image_generator
+    arguments:
+      description: _步骤 4：为故事想一个吸引人的标题迅速的：role: system
+content: You are {{agent.name}}. {{agent.about}}role: user
+content: >
+  Based on the story below, generate a catchy title.Story: {{outputs[1].story}}
+unwrap: true步骤 5：返回故事、生成的图像和标题return:
+  title: outputs[3]
+  story: outputs[1].story
+  comic_panels: "[output.image.url for output in outputs[2]]"
+"""task = client.tasks.create(
     agent_id=agent.id,
-    name="故事和漫画创作器",
-    description="根据一个想法创作故事并生成 4 格漫画来说明故事。",
-    main=[
-        # 步骤 1：生成故事并将其概括为 4 个面板
-        {
-            "prompt": [
-                {
-                    "role": "system",
-                    "content": "您是 {{agent.name}}。{{agent.about}}"
-                },
-                {
-                    "role": "user",
-                    "content": (
-                        "基于想法 '{{_.idea}}'，写一个适合 4 格漫画的短故事。"
-                        "提供故事和一个编号列表，包含 4 个简短描述，每个描述对应一个面板，说明故事中的关键时刻。"
-                    ),
-                },
-            ],
-            "unwrap": True,
-        },
-        # 步骤 2：提取面板描述和故事
-        {
-            "evaluate": {
-                "story": "_.split('1. ')[0].strip()",
-                "panels": "re.findall(r'\\d+\\.\\s*(.*?)(?=\\d+\\.\\s*|$)', _)",
-            }
-        },
-        # 步骤 3：使用图像生成器工具为每个面板生成图像
-        {
-            "foreach": {
-                "in": "_.panels",
-                "do": {
-                    "tool": "image_generator",
-                    "arguments": {
-                        "description": "_",
-                    },
-                },
-            },
-        },
-        # 步骤 4：为故事生成一个吸引人的标题
-        {
-            "prompt": [
-                {
-                    "role": "system",
-                    "content": "您是 {{agent.name}}。{{agent.about}}"
-                },
-                {
-                    "role": "user",
-                    "content": "根据以下故事，生成一个吸引人的标题。\n\n故事：{{outputs[1].story}}",
-                },
-            ],
-            "unwrap": True,
-        },
-        # 步骤 5：返回故事、生成的图像和标题
-        {
-            "return": {
-                "title": "outputs[3]",
-                "story": "outputs[1].story",
-                "comic_panels": "[output.image.url for output in outputs[2]]",
-            }
-        },
-    ],
+    **yaml.safe_load(task_yaml)
 )
-```
-
-> [!TIP]
-> Node.js 版本的代码类似。
-
-### 步骤 5：执行任务
+### Step 3: Execute the Task
 
 ```python
-# 🚀 执行任务，输入一个想法
-execution = await client.executions.create(
+# 🚀 Execute the task with an input idea
+execution = client.executions.create(
     task_id=task.id,
-    input={"idea": "一只学会飞翔的猫"}
+    input={"idea": "A cat who learns to fly"}
 )
 
-# 🎉 观看故事和漫画面板的生成过程
-await client.executions.stream(execution_id=execution.id)
-```
+# 🎉 Watch as the story and comic panels are generated
+for transition in client.executions.transitions.stream(execution_id=execution.id):
+    print(transition)
 
-这个例子展示了如何创建一个带有自定义工具的代理，定义一个复杂的多步骤任务，并执行它以生成创意输出。
+# 📦 Once the execution is finished, retrieve the results
+result = client.executions.get(execution_id=execution.id)
+步骤 4：与代理聊天开始与代理进行交互式聊天会话：session = client.sessions.create(agent_id=agent.id)
 
-<!-- TODO: 在 README 中添加展示任务执行过程的 gif -->
+# 💬 Send messages to the agent
+while (message := input("Enter a message: ")) != "quit":
+    response = client.sessions.chat(
+        session_id=session.id,
+        message=message,
+    )
 
+    print(response)
+[!TIP]
+You can find the full python example [here](example.py).Node.js 快速入门🟩步骤 1：创建代理import { Julep } from '@julep/sdk';
+import yaml from 'js-yaml';
+
+const client = new Julep({ apiKey: 'your_julep_api_key' });
+
+async function createAgent() {
+  const agent = await client.agents.create({
+    name: "Storytelling Agent",
+    model: "gpt-4",
+    about: "You are a creative storytelling agent that can craft engaging stories and generate comic panels based on ideas.",
+  });
+
+  // 🛠️ Add an image generation tool (DALL·E) to the agent
+  await client.agents.tools.create(agent.id, {
+    name: "image_generator",
+    description: "Use this tool to generate images based on descriptions.",
+    integration: {
+      provider: "dalle",
+      method: "generate_image",
+      setup: {
+        api_key: "your_openai_api_key",
+      },
+    },
+  });
+
+  return agent;
+}
+步骤 2：创建生成故事和漫画的任务const taskYaml = `
+name: Story and Comic Creator
+description: Create a story based on an idea and generate a 4-panel comic strip illustrating the story.
+
+main:
+  # Step 1: Generate a story and outline into 4 panels
+  - prompt:
+      - role: system
+        content: You are {{agent.name}}. {{agent.about}}
+      - role: user
+        content: >
+          Based on the idea '{{_.idea}}', write a short story suitable for a 4-panel comic strip.
+          Provide the story and a numbered list of 4 brief descriptions for each panel illustrating key moments in the story.
+    unwrap: true
+
+  # Step 2: Extract the panel descriptions and story
+  - evaluate:
+      story: _.split('1. ')[0].trim()
+      panels: _.match(/\\d+\\.\\s*(.*?)(?=\\d+\\.\\s*|$)/g)
+
+  # Step 3: Generate images for each panel using the image generator tool
+  - foreach:
+      in: _.panels
+      do:
+        tool: image_generator
+        arguments:
+          description: _
+
+  # Step 4: Generate a catchy title for the story
+  - prompt:
+      - role: system
+        content: You are {{agent.name}}. {{agent.about}}
+      - role: user
+        content: >
+          Based on the story below, generate a catchy title.
+
+          Story: {{outputs[1].story}}
+    unwrap: true
+
+  # Step 5: Return the story, the generated images, and the title
+  - return:
+      title: outputs[3]
+      story: outputs[1].story
+      comic_panels: outputs[2].map(output => output.image.url)
+`;
+
+async function createTask(agent) {
+  const task = await client.tasks.create(agent.id, yaml.load(taskYaml));
+  return task;
+}
+步骤 3：执行任务async function executeTask(task) {
+  const execution = await client.executions.create(task.id, {
+    input: { idea: "A cat who learns to fly" }
+  });
+
+  // 🎉 Watch as the story and comic panels are generated
+  for await (const transition of client.executions.transitions.stream(execution.id)) {
+    console.log(transition);
+  }
+
+  // 📦 Once the execution is finished, retrieve the results
+  const result = await client.executions.get(execution.id);
+  return result;
+}
+步骤 4：与代理聊天async function chatWithAgent(agent) {
+  const session = await client.sessions.create({ agent_id: agent.id });
+
+  // 💬Send messages to the agent
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+  });const chat = async () => {
+    rl.question("Enter a message (or 'quit' to exit): ", async (message) => {
+      if (message.toLowerCase() === 'quit') {
+        rl.close();
+        return;
+      }  const response = await client.sessions.chat(session.id, { message });
+  console.log(response);
+  chat();
+});
+};chat();
+}// Run the example
+async function runExample() {
+  const agent = await createAgent();
+  const task = await createTask(agent);
+  const result = await executeTask(task);
+  console.log("Task Result:", result);
+  await chatWithAgent(agent);
+}运行示例()。捕获(控制台.错误);
 > [!TIP]
-> 您可以在[这里](example.ts)找到另一个 Node.js 示例，或在[这里](example.py)找到 Python 示例。
+> You can find the full Node.js example [here](example.js).
 
-## 概念
+## Components
 
-Julep 建立在几个关键的技术组件之上，这些组件协同工作以创建强大的 AI 工作流：
+Julep is made up of the following components:
 
-### 代理
-由大型语言模型（LLM）支持的 AI 实体，执行任务并与用户交互。代理是 Julep 的核心功能单元。
+- **Julep Platform**: The Julep platform is a cloud service that runs your workflows. It includes a language for describing workflows, a server for running those workflows, and an SDK for interacting with the platform.
+- **Julep SDKs**: Julep SDKs are a set of libraries for building workflows. There are SDKs for Python and JavaScript, with more on the way.
+- **Julep API**: The Julep API is a RESTful API that you can use to interact with the Julep platform.
 
-```mermaid
-graph TD
-    Agent[代理] --> LLM[大型语言模型]
-    Agent --> Tasks[任务]
-    Agent --> Users[用户]
-    Tasks --> Tools[工具]
-```
+### Mental Model
 
-### 用户
-与代理交互的实体。用户可以与会话关联，并拥有自己的元数据，允许个性化交互。
+<div align="center">
+  <img src="https://github.com/user-attachments/assets/38420b5d-9342-4c8d-bae9-b47c28ae45af" height="360" />
+</div>
 
-```mermaid
-graph LR
-    User[用户] --> Sessions[会话]
-    Sessions --> Agents[代理]
-    Sessions --> Metadata[元数据]
-```
+Think of Julep as a platform that combines both client-side and server-side components to help you build advanced AI agents. Here's how to visualize it:
 
-### 会话
-代理和用户之间的有状态交互。会话在多次交换中保持上下文，可以配置不同的行为，包括上下文管理和溢出处理。
+1. **Your Application Code:**
+   - You use the Julep SDK in your application to define agents, tasks, and workflows.
+   - The SDK provides functions and classes that make it easy to set up and manage these components.
 
-```mermaid
-graph LR
-    Sessions[会话] --> Agents[代理]
-    Sessions --> Users[用户]
-    Sessions --> ContextManagement[上下文管理]
-    Sessions --> OverflowHandling[溢出处理]
-```
+2. **Julep Backend Service:**
+   - The SDK communicates with the Julep backend over the network.
+   - The backend handles execution of tasks, maintains session state, stores documents, and orchestrates workflows.
 
-### 任务
-代理可以执行的多步骤、程序化工作流。任务定义复杂操作，可以包括各种类型的步骤，如提示、工具调用和条件逻辑。
+3. **Integration with Tools and APIs:**
+   - Within your workflows, you can integrate external tools and services.
+   - The backend facilitates these integrations, so your agents can, for example, perform web searches, access databases, or call third-party APIs.
+
+In simpler terms:
+- Julep is a platform for building stateful AI agents.
+- You use the SDK (like a toolkit) in your code to define what your agents do.
+- The backend service (which you can think of as the engine) runs these definitions, manages state, and handles complexity.
+
+## Concepts
+
+Julep is built on several key technical components that work together to create powerful AI workflows:
 
 ```mermaid
 graph TD
-    Tasks[任务] --> Steps[工作流步骤]
-    Steps --> Prompt[提示]
-    Steps --> ToolCalls[工具调用]
-    Steps --> ConditionalLogic[条件逻辑]
-```
+    User[User] ==> Session[Session]
+    Session --> Agent[Agent]
+    Agent --> Tasks[Tasks]
+    Agent --> LLM[Large Language Model]
+    Tasks --> Tools[Tools]
+    Agent --> Documents[Documents]
+    Documents --> VectorDB[Vector Database]
+    Tasks --> Executions[Executions]
 
-### 工具
-扩展代理能力的集成。工具可以是用户定义的函数、系统工具或第三方 API 集成。它们允许代理执行超出文本生成的操作。
+    classDef client fill:#9ff,stroke:#333,stroke-width:1px;
+    class User client;
 
-```mermaid
-graph LR
-    Tools[工具] --> UserDefinedFunctions[用户定义函数]
-    Tools --> SystemTools[系统工具]
-    Tools --> ThirdPartyAPIs[第三方 API]
-```
-
-### 文档
-可以与代理或用户关联的文本或数据对象。文档被向量化并存储在向量数据库中，在代理交互期间实现语义搜索和检索。
-
-```mermaid
-graph LR
-    Documents[文档] --> VectorDatabase[向量数据库]
-    Documents --> SemanticSearch[语义搜索]
-    Documents --> AgentsOrUsers[代理或用户]
-```
-
-### 执行
-已经用特定输入启动的任务实例。执行有自己的生命周期和状态机，允许监控、管理和恢复长时间运行的进程。
-
-```mermaid
-graph LR
-    Executions[执行] --> Tasks[任务]
-    Executions --> Lifecycle[生命周期]
-    Executions --> Monitoring[监控]
-    Executions --> Management[管理]
-    Executions --> Resumption[恢复]
-```
-
-有关这些概念及其交互的更详细解释，请参阅我们的[概念文档](https://github.com/julep-ai/julep/blob/dev/docs/julep-concepts.md)。
-
-## 理解任务
-
-任务是 Julep 工作流系统的核心。它们允许您定义复杂的多步骤 AI 工作流，供您的代理执行。以下是任务组件的简要概述：
-
-- **名称和描述**：每个任务都有唯一的名称和描述，便于识别。
-- **主要步骤**：任务的核心，定义了要执行的操作序列。
-- **工具**：可选的集成，在任务执行期间扩展代理的能力。
-
-### 工作流步骤类型
-
-Julep 中的任务可以包含各种类型的步骤：
-
-1. **提示**：向 AI 模型发送消息并接收响应。
-   ```python
-   {"prompt": "分析以下数据：{{data}}"}
-   ```
-
-2. **工具调用**：执行集成的工具或 API。
-   ```python
-   {"tool": "web_search", "arguments": {"query": "最新 AI 发展"}}
-   ```
-
-3. **评估**：执行计算或操作数据。
-   ```python
-   {"evaluate": {"average_score": "sum(scores) / len(scores)"}}
-   ```
-
-4. **条件逻辑**：基于条件执行步骤。
-   ```python
-   {"if": "score > 0.8", "then": [...], "else": [...]}
-   ```
-
-5. **循环**：遍历数据或重复步骤。
-   ```python
-   {"foreach": {"in": "data_list", "do": [...]}}
-   ```
-
-| 步骤类型 | 描述 | 输入 |
-|---------|------|------|
-| **提示** | 向 AI 模型发送消息并接收响应。 | 提示文本或模板 |
-| **工具调用** | 执行集成的工具或 API。 | 工具名称和参数 |
-| **评估** | 执行计算或操作数据。 | 要评估的表达式或变量 |
-| **等待输入** | 暂停工作流直到收到输入。 | 任何所需的用户或系统输入 |
-| **日志** | 记录指定的值或消息。 | 要记录的消息或值 |
-| **嵌入** | 将文本嵌入到特定格式或系统中。 | 要嵌入的文本或内容 |
-| **搜索** | 基于查询执行文档搜索。 | 搜索查询 |
-| **获取** | 从键值存储中检索值。 | 键标识符 |
-| **设置** | 在键值存储中为键分配值。 | 要分配的键和值 |
-| **并行** | 并行运行多个步骤。 | 要同时执行的步骤列表 |
-| **遍历** | 遍历集合并为每个项目执行步骤。 | 要遍历的集合或列表 |
-| **映射归约** | 对集合进行映射并基于表达式归约结果。 | 要映射和归约的集合和表达式 |
-| **如果-否则** | 基于条件执行步骤。 | 要评估的条件 |
-| **开关** | 基于多个条件执行步骤，类似于 switch-case 语句。 | 多个条件和相应的步骤 |
-| **生成** | 运行子工作流并等待其完成。 | 子工作流标识符和输入数据 |
-| **错误** | 通过指定错误消息来处理错误。 | 错误消息或处理指令 |
-| **睡眠** | 暂停工作流指定的持续时间。 | 持续时间（秒、分钟等） |
-| **返回** | 从工作流返回值。 | 要返回的值 |
-
-有关每种步骤类型的详细信息和高级用法，请参阅我们的[任务文档](https://docs.julep.ai/tasks)。
-
-## 高级功能
-
-Julep 提供了一系列高级功能来增强您的 AI 工作流：
-
-### 为代理添加工具
-
-通过集成外部工具和 API 来扩展代理的能力：
-
-```python
-client.agents.tools.create(
+    classDef core fill:#f9f,stroke:#333,stroke-width:2px;
+    class Agent,Tasks,Session core;
+**Agents**: AI-powered entities backed by large language models (LLMs) that execute tasks and interact with users.**Users**: Entities that interact with agents through sessions.**Sessions**: Stateful interactions between agents and users, maintaining context across multiple exchanges.**Tasks**: Multi-step, programmatic workflows that agents can execute, including various types of steps like prompts, tool calls, and conditional logic.**Tools**: Integrations that extend an agent's capabilities, including user-defined functions, system tools, or third-party API integrations.**Documents**: Text or data objects associated with agents or users, vectorized and stored for semantic search and retrieval.**Executions**: Instances of tasks that have been initiated with specific inputs, with their own lifecycle and state machine.For a more detailed explanation of these concepts and their interactions, please refer to our [Concepts Documentation](https://github.com/julep-ai/julep/blob/dev/docs/julep-concepts.md).理解任务任务是 Julep 工作流系统的核心。它们允许您定义代理可以执行的复杂、多步骤 AI 工作流。以下是任务组件的简要概述：**Name and Description**: Each task has a unique name and description for easy identification.**Main Steps**: The core of a task, defining the sequence of actions to be performed.**Tools**: Optional integrations that extend the capabilities of your agent during task execution.工作流步骤的类型Julep 中的任务可以包含各种类型的步骤，让您可以创建复杂而强大的工作流程。以下是按类别组织的可用步骤类型的概述：常见步骤**Prompt**: Send向 AI 模型发送消息并接收响应。- prompt: "Analyze the following data: {{data}}"
+**Tool Call**: Execute an integrated tool or API.- tool: web_search
+  arguments:
+    query: "Latest AI developments"
+**Evaluate**: Perform calculations or manipulate data.- evaluate:
+    average_score: "sum(scores) / len(scores)"
+**Wait for Input**: Pause workflow until input is received.- wait_for_input:
+    info:
+      message: "Please provide additional information."
+**Log**: Log a specified value or message.- log: "Processing completed for item {{item_id}}"
+关键值步骤**Get**: Retrieve a value from a key-value store.- get: "user_preference"
+**Set**: Assign a value to a key in a key-value store.- set:
+    user_preference: "dark_mode"
+迭代步骤**Foreach**: Iterate over a collection and perform steps for each item.- foreach:
+    in: "data_list"
+    do:
+      - log: "Processing item {{_}}"
+**Map-Reduce**: Map over a collection and reduce the results.- map_reduce:
+    over: "numbers"
+    map:
+      - evaluate:
+          squared: "_ ** 2"
+    reduce: "sum(results)"
+**Parallel**: Run multiple steps in parallel.- parallel:
+    - tool: web_search
+      arguments:
+        query: "AI news"
+    - tool: weather_check
+      arguments:
+        location: "New York"
+条件步骤**If-Else**: Conditional execution of steps.- if: "score > 0.8"
+  then:
+    - log: "High score achieved"
+  else:
+    - log: "Score needs improvement"
+**Switch**: Execute steps based on multiple conditions.- switch:
+    - case: "category == 'A'"
+      then:
+        - log: "Category A processing"
+    - case: "category == 'B'"
+      then:
+        - log: "Category B processing"
+    - case: "_"  # Default case
+      then:
+        - log: "Unknown category"
+其他控制流**Sleep**: Pause the workflow for a specified duration.- sleep:
+    seconds: 30
+**Return**: Return a value from the workflow.- return:
+    result: "Task completed successfully"
+**Yield**: Run a subworkflow and await its completion.- yield:
+    workflow: "data_processing_subflow"
+    arguments:
+      input_data: "{{raw_data}}"
+**Error**: Handle errors by specifying an error message.- error: "Invalid input provided"
+每种步骤类型在构建复杂的 AI 工作流中都有特定的用途。此分类有助于理解 Julep 任务中可用的各种控制流程和操作。高级功能Julep 提供一系列高级功能来增强您的 AI 工作流程：为代理添加工具通过集成外部工具和 API 来扩展代理的功能：client.agents.tools.create(
     agent_id=agent.id,
     name="web_search",
-    description="搜索网络以获取信息。",
+    description="Search the web for information.",
     integration={
         "provider": "brave",
         "method": "search",
         "setup": {"api_key": "your_brave_api_key"},
     },
 )
-```
-
-### 管理会话和用户
-
-Julep 为持久交互提供了强大的会话管理：
-
-```python
-session = client.sessions.create(
+管理会话和用户Julep 为持久交互提供了强大的会话管理：session = client.sessions.create(
     agent_id=agent.id,
-    user_id="user123",
+    user_id=user.id,
     context_overflow="adaptive"
 )
 
-# 在同一会话中继续对话
+# Continue conversation in the same session
 response = client.sessions.chat(
     session_id=session.id,
     messages=[
-        {
-            "role": "user",
-            "content": "继续我们之前的对话。"
-        }
+      {
+        "role": "user",
+        "content": "Follow up on the previous conversation."
+      }
     ]
 )
-```
-
-### 文档集成和搜索
-
-轻松管理和搜索代理的文档：
-
-```python
-# 上传文档
+文档集成与搜索轻松管理和搜索代理的文档：# Upload a document
 document = client.agents.docs.create(
     title="AI advancements",
     content="AI is changing the world...",
     metadata={"category": "research_paper"}
 )
 
-# 搜索文档
+# Search documents
 results = client.agents.docs.search(
     text="AI advancements",
     metadata_filter={"category": "research_paper"}
 )
-```
+For more advanced features and detailed usage, please refer to our [Advanced Features Documentation](https://docs.julep.ai/advanced-features).集成Julep 支持各种集成，可以扩展您的 AI 代理的功能。以下是可用集成及其支持的参数的列表：勇敢搜索setup:
+  api_key: string  # The API key for Brave Search
 
-有关更多高级功能和详细用法，请参阅我们的[高级功能文档](https://docs.julep.ai/advanced-features)。
+arguments:
+  query: string  # The search query for searching with Brave
 
-## SDK 参考
+output:
+  result: string  # The result of the Brave Search
+浏览器基础setup:
+  api_key: string       # The API key for BrowserBase
+  project_id: string    # The project ID for BrowserBase
+  session_id: string    # (Optional) The session ID for BrowserBasearguments:
+  urls: list[string]    # The URLs for loading with BrowserBaseoutput:
+  documents: list       # The documents loaded from the URLs
+### Email
 
-- [Node.js SDK](https://github.com/julep-ai/node-sdk/blob/main/api.md)
-- [Python SDK](https://github.com/julep-ai/python-sdk/blob/main/api.md)
+```yaml
+setup:
+  host: string      # The host of the email server
+  port: integer     # The port of the email server
+  user: string      # The username of the email server
+  password: string  # The password of the email server
 
-## API 参考
+arguments:
+  to: string        # The email address to send the email to
+  from: string      # The email address to send the email from
+  subject: string   # The subject of the email
+  body: string      # The body of the email
 
-探索我们全面的 API 文档，了解更多关于代理、任务和执行的信息：
+output:
+  success: boolean  # Whether the email was sent successfully
+蜘蛛setup:
+  spider_api_key: string  # The API key for Spider
 
-- [代理 API](https://api.julep.ai/api/docs#tag/agents)
-- [任务 API](https://api.julep.ai/api/docs#tag/tasks)
-- [执行 API](https://api.julep.ai/api/docs#tag/executions)
+arguments:
+  url: string             # The URL for which to fetch data
+  mode: string            # The type of crawlers (default: "scrape")
+  params: dict            # (Optional) The parameters for the Spider API
 
-## 示例和教程
+output:
+  documents: list         # The documents returned from the spider
+天气setup:
+  openweathermap_api_key: string  # The API key for OpenWeatherMap
 
-发现示例项目和教程，帮助您入门并基于提供的示例进行构建：
+arguments:
+  location: string                # The location for which to fetch weather data
 
-- [示例项目](https://github.com/julep-ai/julep/tree/main/examples)
-- [教程](https://docs.julep.ai/tutorials)
+output:
+  result: string                  # The weather data for the specified location
+维基百科arguments:
+  query: string           # The search query string
+  load_max_docs: integer  # Maximum number of documents to load (default: 2)
 
-## 贡献
-
-我们欢迎对项目的贡献！了解如何贡献以及我们的行为准则：
-
-- [贡献指南](https://github.com/julep-ai/julep/blob/main/CONTRIBUTING.md)
-- [行为准则](https://github.com/julep-ai/julep/blob/main/CODE_OF_CONDUCT.md)
-
-## 支持和社区
-
-加入我们的社区，获取帮助、提问和分享您的想法：
-
-- [Discord](https://discord.com/invite/JTSBGRZrzj)
-- [GitHub 讨论](https://github.com/julep-ai/julep/discussions)
-- [Twitter](https://twitter.com/julep_ai)
-
-## 许可证
-
-本项目采用 [Apache License 2.0](https://github.com/julep-ai/julep/blob/main/LICENSE) 许可。
-
-## 致谢
-
-我们要感谢所有贡献者和开源社区为他们宝贵的资源和贡献。
+output:
+  documents: list         # The documents returned from the Wikipedia search
+These integrations can be used within your tasks to extend the capabilities of your AI agents. For more detailed information on how to use these integrations in your workflows, please refer to our [Integrations Documentation](https://docs.julep.ai/integrations).SDK 参考[Node.js SDK](https://github.com/julep-ai/node-sdk/blob/main/api.md)[Python SDK](https://github.com/julep-ai/python-sdk/blob/main/api.md)API 参考浏览我们全面的 API 文档，以了解有关代理、任务和执行的更多信息：[Agents API](https://api.julep.ai/api/docs#tag/agents)[Tasks API](https://api.julep.ai/api/docs#tag/tasks)[Executions API](https://api.julep.ai/api/docs#tag/executions)->> Test <<-
+A simple update to text the translation github action

--- a/README-FR.md
+++ b/README-FR.md
@@ -23,17 +23,17 @@
 [!NOTE]
 👨‍💻 Here for the devfest.ai event? Join our [Discord](https://discord.com/invite/JTSBGRZrzj) and check out the details below.<details>
 <summary><b>🌟 Contributors and DevFest.AI Participants</b> (Click to expand)</summary>
-🌟 寄稿者を募集します!Julep プロジェクトに新しい貢献者を迎えられることを嬉しく思います。プロジェクトを始めるのに役立つ「最初の良い問題」をいくつか作成しました。貢献する方法は次のとおりです。Check out our [CONTRIBUTING.md](CONTRIBUTING.md) file for guidelines on how to contribute.Browse our [good first issues](https://github.com/julep-ai/julep/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) to find a task that interests you.If you have any questions or need help, don't hesitate to reach out on our [Discord](https://discord.com/invite/JTSBGRZrzj) channel.あなたの貢献は、大小を問わず私たちにとって貴重です。一緒に素晴らしいものを作りましょう！🚀🎉 DevFest.AI 2024年10月嬉しいニュースです！2024 年 10 月を通して DevFest.AI に参加します！🗓️このイベント中に Julep に貢献すると、素晴らしい Julep のグッズや景品を獲得するチャンスが得られます! 🎁世界中の開発者とともに AI リポジトリに貢献し、素晴らしいイベントに参加しましょう。この素晴らしい取り組みを企画してくださった DevFest.AI に心から感謝します。[!TIP]
+🌟 Appel aux contributeurs !Nous sommes ravis d'accueillir de nouveaux contributeurs au projet Julep ! Nous avons créé plusieurs « bons premiers numéros » pour vous aider à démarrer. Voici comment vous pouvez contribuer :Check out our [CONTRIBUTING.md](CONTRIBUTING.md) file for guidelines on how to contribute.Browse our [good first issues](https://github.com/julep-ai/julep/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) to find a task that interests you.If you have any questions or need help, don't hesitate to reach out on our [Discord](https://discord.com/invite/JTSBGRZrzj) channel.Vos contributions, grandes ou petites, nous sont précieuses. Construisons ensemble quelque chose d'extraordinaire ! 🚀🎉 DevFest.AI Octobre 2024Des nouvelles passionnantes ! Nous participons au DevFest.AI tout au long du mois d'octobre 2024 ! 🗓️Contribuez à Julep pendant cet événement et obtenez une chance de gagner de superbes produits et cadeaux Julep ! 🎁Rejoignez les développeurs du monde entier en contribuant aux référentiels d'IA et en participant à des événements incroyables.Un grand merci à DevFest.AI pour l'organisation de cette fantastique initiative ![!TIP]
 Ready to join the fun? **[Tweet that you are participating](https://twitter.com/intent/tweet?text=Pumped%20to%20be%20participating%20in%20%40devfestai%20with%20%40julep_ai%20building%20%23ai%20%23agents%20%23workflows%20Let's%20gooo!%20https%3A%2F%2Fgit.new%2Fjulep)** and let's get coding! 🖥️[!NOTE]
 Get your API key [here](https://dashboard-dev.julep.ai).While we are in beta, you can also reach out on [Discord](https://discord.com/invite/JTSBGRZrzj) to get rate limits lifted on your API key.![Julep DevFest.AI](https://media.giphy.com/media/YjyUeyotft6epaMHtU/giphy.gif)</details>
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 <details>
 <summary><h3>📖 Table of Contents</h3></summary>
-[Introduction](#introduction)[Quick Example](#quick-example)[Key Features](#key-features)[Why Julep vs. LangChain?](#why-julep-vs-langchain)[Different Use Cases](#different-use-cases)[Different Form Factor](#different-form-factor)[In Summary](#in-summary)[Installation](#installation)[Python Quick Start 🐍](#python-quick-start-)[Step 1: Create an Agent](#step-1-create-an-agent)[Step 2: Create a Task that generates a story and comic strip](#step-2-create-a-task-that-generates-a-story-and-comic-strip)[Step 3: Execute the Task](#step-3-execute-the-task)[Step 4: Chat with the Agent](#step-4-chat-with-the-agent)[Node.js Quick Start 🟩](#nodejs-quick-start-)[Step 1: Create an Agent](#step-1-create-an-agent-1)[Step 2: Create a Task that generates a story and comic strip](#step-2-create-a-task-that-generates-a-story-and-comic-strip-1)[Step 3: Execute the Task](#step-3-execute-the-task-1)[Step 4: Chat with the Agent](#step-4-chat-with-the-agent-1)[コンポーネント](#components)[Mental Model](#mental-model)[Concepts](#concepts)[Understanding Tasks](#understanding-tasks)[Types of Workflow Steps](#types-of-workflow-steps)[Advanced Features](#advanced-features)[Adding Tools to Agents](#adding-tools-to-agents)[Managing Sessions and Users](#managing-sessions-and-users)[Document Integration and Search](#document-integration-and-search)[Integrations](#integrations)[Brave Search](#brave-search)[BrowserBase](#browserbase)[Email](#email)[Spider](#spider)[Weather](#weather)[Wikipedia](#wikipedia)[SDK Reference](#sdk-reference)[API Reference](#api-reference)</details>
+[Introduction](#introduction)[Quick Example](#quick-example)[Key Features](#key-features)[Why Julep vs. LangChain?](#why-julep-vs-langchain)[Different Use Cases](#different-use-cases)[Different Form Factor](#different-form-factor)[In Summary](#in-summary)[Installation](#installation)[Python Quick Start 🐍](#python-quick-start-)[Step 1: Create an Agent](#step-1-create-an-agent)[Step 2: Create a Task that generates a story and comic strip](#step-2-create-a-task-that-generates-a-story-and-comic-strip)[Step 3: Execute the Task](#step-3-execute-the-task)[Step 4: Chat with the Agent](#step-4-chat-with-the-agent)[Node.js Quick Start 🟩](#nodejs-quick-start-)[Step 1: Create an Agent](#step-1-create-an-agent-1)[Step 2: Create a Task that generates a story and comic strip](#step-2-create-a-task-that-generates-a-story-and-comic-strip-1)[Step 3: Execute the Task](#step-3-execute-the-task-1)[Step 4: Chat with the Agent](#step-4-chat-with-the-agent-1)[Composants](#composant(nts)[Mental Model](#mental-model)[Concepts](#concepts)[Understanding Tasks](#understanding-tasks)[Types of Workflow Steps](#types-of-workflow-steps)[Advanced Features](#advanced-features)[Adding Tools to Agents](#adding-tools-to-agents)[Managing Sessions and Users](#managing-sessions-and-users)[Document Integration and Search](#document-integration-and-search)[Integrations](#integrations)[Brave Search](#brave-search)[BrowserBase](#browserbase)[Email](#email)[Spider](#spider)[Weather](#weather)[Wikipedia](#wikipedia)[SDK Reference](#sdk-reference)[API Reference](#api-reference)</details>
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-導入Julep は、過去のやり取りを記憶し、複雑なタスクを実行できる AI エージェントを作成するためのプラットフォームです。長期記憶を提供し、複数ステップのプロセスを管理します。Julep を使用すると、意思決定、ループ、並列処理、多数の外部ツールや API との統合を組み込んだ複数ステップのタスクを作成できます。多くの AI アプリケーションは、分岐が最小限の、プロンプトと API 呼び出しの単純な線形チェーンに制限されていますが、Julep はより複雑なシナリオを処理できるように構築されています。サポート対象:複雑で多段階のプロセス動的な意思決定並列実行[!TIP]
-Imagine you want to build an AI agent that can do more than just answer simple questions—it needs to handle complex tasks, remember past interactions, and maybe even use other tools or APIs. That's where Julep comes in.簡単な例次のことができる研究 AI エージェントを想像してください。トピックを取り上げ、そのトピックについて100個の検索クエリを考えてみましょう。これらのウェブ検索を並行して実行すると、結果をまとめると、要約をDiscordに送信するIn Julep, this would be a single task under <b>80 lines of code</b> and run <b>fully managed</b> all on its own. All of the steps are executed on Julep's own servers and you don't need to lift a finger. Here's a working example:name: Research Agent
+IntroductionJulep est une plateforme permettant de créer des agents IA qui se souviennent des interactions passées et peuvent effectuer des tâches complexes. Elle offre une mémoire à long terme et gère des processus en plusieurs étapes.Julep permet la création de tâches en plusieurs étapes intégrant la prise de décision, les boucles, le traitement parallèle et l'intégration avec de nombreux outils et API externes.Alors que de nombreuses applications d’IA se limitent à des chaînes simples et linéaires d’invites et d’appels d’API avec une ramification minimale, Julep est conçu pour gérer des scénarios plus complexes.Il prend en charge :Des processus complexes en plusieurs étapesPrise de décision dynamiqueExécution parallèle[!TIP]
+Imagine you want to build an AI agent that can do more than just answer simple questions—it needs to handle complex tasks, remember past interactions, and maybe even use other tools or APIs. That's where Julep comes in.Exemple rapideImaginez un agent d’IA de recherche capable d’effectuer les opérations suivantes :Prenez un sujet,Proposez 100 requêtes de recherche pour ce sujet,Effectuez ces recherches sur le Web en parallèle,Résumer les résultats,Envoyez le résumé sur DiscordIn Julep, this would be a single task under <b>80 lines of code</b> and run <b>fully managed</b> all on its own. All of the steps are executed on Julep's own servers and you don't need to lift a finger. Here's a working example:name: Research Agent
 
 # Optional: Define the input schema for the task
 input_schema:
@@ -110,11 +110,11 @@ main:
 
       {{_}}
 [!TIP]
-Julep is really useful when you want to build AI agents that can maintain context and state over long-term interactions. It's great for designing complex, multi-step workflows and integrating various tools and APIs directly into your agent's processes.この例では、Julep は並列実行を自動的に管理し、失敗したステップを再試行し、API リクエストを再送信し、タスクが完了するまで確実に実行し続けます。主な特徴🧠 **Persistent AI Agents**: Remember context and information over long-term interactions.💾 **Stateful Sessions**: Keep track of past interactions for personalized responses.🔄 **Multi-Step Tasks**: Build complex, multi-step processes with loops and decision-making.⏳ **Task Management**: Handle long-running tasks that can run indefinitely.🛠️ **Built-in Tools**: Use built-in tools and external APIs in your tasks.🔧 **Self-Healing**: Julep will automatically retry failed steps, resend messages, and generally keep your tasks running smoothly.📚 **RAG**: Use Julep's document store to build a system for retrieving と独自のデータを使用します。Julep は、単純なプロンプト応答モデルを超えた AI ユースケースを必要とするアプリケーションに最適です。Julep と LangChain を比較する理由さまざまなユースケースLangChain と Julep は、AI 開発スタック内で異なる重点を置いたツールと考えてください。LangChain は、プロンプトのシーケンスを作成し、AI モデルとのやり取りを管理するのに最適です。多数の事前構築された統合を備えた大規模なエコシステムを備えているため、何かをすぐに立ち上げて実行したい場合に便利です。LangChain は、プロンプトと API 呼び出しの線形チェーンを含む単純なユースケースに適しています。一方、Julep は、長期的なインタラクションを通じて物事を記憶できる永続的な AI エージェントの構築に重点を置いています。エージェントのプロセス内で複数のステップ、意思決定、さまざまなツールや API との直接統合を伴う複雑なタスクが必要な場合に効果を発揮します。永続的なセッションと複雑なタスクを管理するために、ゼロから設計されています。以下のことを必要とする複雑な AI アシスタントの構築を考えている場合には、Julep を使用してください。数日または数週間にわたってユーザーのインタラクションを追跡します。毎日のサマリーの送信やデータ ソースの監視などのスケジュールされたタスクを実行します。以前のやり取りや保存されたデータに基づいて決定を下します。タスクの一部として複数の外部サービスと対話します。そして、Julep は、ゼロから構築する必要なく、これらすべてをサポートするインフラストラクチャを提供します。異なるフォームファクタJulep is a **platform** that includes a language for describing tasks, a server for running those tasks, and an SDK for interacting with the platform. To build something with Julep, you write a description of the task in `YAML`, and then run the task in the cloud.Julep は、負荷の高い、複数のステップから成る、長時間実行されるタスク向けに構築されており、タスクの複雑さに制限はありません。LangChain is a **library** that includes a few tools and a framework for building linear chains of prompts and tools. To build something with LangChain, you typically write Python code that configures and runs the model chains you want to use.LangChain は、プロンプトと API 呼び出しの線形チェーンを含む単純なユースケースでは十分であり、実装も迅速です。要約すればステートレスまたは短期的なコンテキストで AI モデルのインタラクションとプロンプト シーケンスを管理する必要がある場合は、LangChain を使用します。高度なタスク機能、永続的なセッション、複雑なタスク管理を備えたステートフル エージェント用の堅牢なフレームワークが必要な場合は、Julep を選択してください。インストールTo get started with Julep, install it using [npm](https://www.npmjs.com/package/@julep/sdk) or [pip](https://pypi.org/project/julep/):npm install @julep/sdk
-またはpip install julep
+Julep is really useful when you want to build AI agents that can maintain context and state over long-term interactions. It's great for designing complex, multi-step workflows and integrating various tools and APIs directly into your agent's processes.Dans cet exemple, Julep gérera automatiquement les exécutions parallèles, réessayera les étapes ayant échoué, renverra les requêtes API et maintiendra les tâches en cours d'exécution de manière fiable jusqu'à leur achèvement.Caractéristiques principales🧠 **Persistent AI Agents**: Remember context and information over long-term interactions.💾 **Stateful Sessions**: Keep track of past interactions for personalized responses.🔄 **Multi-Step Tasks**: Build complex, multi-step processes with loops and decision-making.⏳ **Task Management**: Handle long-running tasks that can run indefinitely.🛠️ **Built-in Tools**: Use built-in tools and external APIs in your tasks.🔧 **Self-Healing**: Julep will automatically retry failed steps, resend messages, and generally keep your tasks running smoothly.📚 **RAG**: Use Julep's document store to build a system for retrieving et en utilisant vos propres données.Julep est idéal pour les applications qui nécessitent des cas d’utilisation de l’IA au-delà des simples modèles de réponse rapide.Pourquoi Julep vs. LangChain ?Différents cas d'utilisationConsidérez LangChain et Julep comme des outils avec des objectifs différents au sein de la pile de développement de l’IA.LangChain est idéal pour créer des séquences d'invites et gérer les interactions avec les modèles d'IA. Il dispose d'un vaste écosystème avec de nombreuses intégrations prédéfinies, ce qui le rend pratique si vous souhaitez mettre en place quelque chose rapidement. LangChain s'adapte bien aux cas d'utilisation simples qui impliquent une chaîne linéaire d'invites et d'appels d'API.Julep, en revanche, s'intéresse davantage à la création d'agents d'IA persistants capables de mémoriser des éléments au cours d'interactions à long terme. Il est particulièrement efficace lorsque vous avez besoin de tâches complexes impliquant plusieurs étapes, une prise de décision et une intégration avec divers outils ou API directement dans le processus de l'agent. Il est conçu dès le départ pour gérer les sessions persistantes et les tâches complexes.Utilisez Julep si vous imaginez créer un assistant IA complexe qui doit :Suivez les interactions des utilisateurs sur plusieurs jours ou semaines.Exécutez des tâches planifiées, comme l’envoi de résumés quotidiens ou la surveillance de sources de données.Prendre des décisions basées sur des interactions antérieures ou des données stockées.Interagir avec plusieurs services externes dans le cadre de sa tâche.Ensuite, Julep fournit l’infrastructure pour prendre en charge tout cela sans que vous ayez à le construire à partir de zéro.Différents facteurs de formeJulep is a **platform** that includes a language for describing tasks, a server for running those tasks, and an SDK for interacting with the platform. To build something with Julep, you write a description of the task in `YAML`, and then run the task in the cloud.Julep est conçu pour les tâches lourdes, en plusieurs étapes et de longue durée, et il n'y a aucune limite à la complexité de la tâche.LangChain is a **library** that includes a few tools and a framework for building linear chains of prompts and tools. To build something with LangChain, you typically write Python code that configures and runs the model chains you want to use.LangChain pourrait être suffisant et plus rapide à mettre en œuvre pour les cas d'utilisation simples impliquant une chaîne linéaire d'invites et d'appels d'API.En résuméUtilisez LangChain lorsque vous devez gérer les interactions des modèles d’IA et les séquences d’invite dans un contexte sans état ou à court terme.Choisissez Julep lorsque vous avez besoin d'un framework robuste pour les agents avec état avec des capacités de tâches avancées, des sessions persistantes et une gestion de tâches complexes.InstallationTo get started with Julep, install it using [npm](https://www.npmjs.com/package/@julep/sdk) or [pip](https://pypi.org/project/julep/):npm install @julep/sdk
+oupip install julep
 [!NOTE]
 Get your API key [here](https://dashboard-dev.julep.ai).While we are in beta, you can also reach out on [Discord](https://discord.com/invite/JTSBGRZrzj) to get rate limits lifted on your API key.[!TIP]
-💻 Are you a _show me the code!™_ kind of person? We have created a ton of cookbooks for you to get started with. **Check out the [cookbooks](https://github.com/julep-ai/julep/tree/dev/cookbooks)** to browse through examples.💡 There's also lots of ideas that you can build on top of Julep. **Check out the [list of ideas](https://github.com/julep-ai/julep/tree/dev/cookbooks/IDEAS.md)** to get some inspiration.Python クイックスタート 🐍ステップ1: エージェントを作成するimport yaml
+💻 Are you a _show me the code!™_ kind of person? We have created a ton of cookbooks for you to get started with. **Check out the [cookbooks](https://github.com/julep-ai/julep/tree/dev/cookbooks)** to browse through examples.💡 There's also lots of ideas that you can build on top of Julep. **Check out the [list of ideas](https://github.com/julep-ai/julep/tree/dev/cookbooks/IDEAS.md)** to get some inspiration.Démarrage rapide de Python 🐍Étape 1 : Créer un agentimport yaml
 from julep import Julep # or AsyncJulep
 
 client = Julep(api_key="your_julep_api_key")
@@ -138,7 +138,7 @@ client.agents.tools.create(
         },
     },
 )
-ステップ2: ストーリーと漫画を生成するタスクを作成する入力されたアイデアに基づいてストーリーを作成し、パネル化された漫画を生成するためのマルチステップタスクを定義しましょう。# 📋 Task
+Étape 2 : Créer une tâche qui génère une histoire et une bande dessinéeDéfinissons une tâche en plusieurs étapes pour créer une histoire et générer une bande dessinée à panneaux basée sur une idée d'entrée :# 📋 Task
 # Create a task that takes an idea and creates a story and a 4-panel comic strip
 task_yaml = """
 name: Story and Comic Creator
@@ -155,18 +155,18 @@ main:
           Provide the story and a numbered list of 4 brief descriptions for each panel illustrating key moments in the story.
     unwrap: true
 
-  # Step 2: Extract theパネルの説明とストーリーevaluate:
+  # Step 2: Extract thedescriptions des panneaux et histoireevaluate:
   story: _.split('1. ')[0].strip()
-  panels: re.findall(r'\\d+\\.\\s*(.*?)(?=\\d+\\.\\s*|$)', _)ステップ3: 画像生成ツールを使用して各パネルの画像を生成するforeach:
+  panels: re.findall(r'\\d+\\.\\s*(.*?)(?=\\d+\\.\\s*|$)', _)Étape 3 : Générer des images pour chaque panneau à l'aide de l'outil de génération d'imagesforeach:
   in: _.panels
   do:
     tool: image_generator
     arguments:
-      description: _ステップ4: ストーリーのキャッチーなタイトルを作成するプロンプト：role: system
+      description: _Étape 4 : Générez un titre accrocheur pour l'histoirerapide:role: system
 content: You are {{agent.name}}. {{agent.about}}role: user
 content: >
   Based on the story below, generate a catchy title.Story: {{outputs[1].story}}
-unwrap: trueステップ5: ストーリー、生成された画像、タイトルを返すreturn:
+unwrap: trueÉtape 5 : Renvoyer l'histoire, les images générées et le titrereturn:
   title: outputs[3]
   story: outputs[1].story
   comic_panels: "[output.image.url for output in outputs[2]]"
@@ -189,7 +189,7 @@ for transition in client.executions.transitions.stream(execution_id=execution.id
 
 # 📦 Once the execution is finished, retrieve the results
 result = client.executions.get(execution_id=execution.id)
-ステップ4: エージェントとチャットするエージェントとの対話型チャット セッションを開始します。session = client.sessions.create(agent_id=agent.id)
+Étape 4 : Discutez avec l'agentDémarrez une session de chat interactive avec l'agent :session = client.sessions.create(agent_id=agent.id)
 
 # 💬 Send messages to the agent
 while (message := input("Enter a message: ")) != "quit":
@@ -200,7 +200,7 @@ while (message := input("Enter a message: ")) != "quit":
 
     print(response)
 [!TIP]
-You can find the full python example [here](example.py).Node.js クイックスタート 🟩ステップ1: エージェントを作成するimport { Julep } from '@julep/sdk';
+You can find the full python example [here](example.py).Démarrage rapide de Node.js 🟩Étape 1 : Créer un agentimport { Julep } from '@julep/sdk';
 import yaml from 'js-yaml';
 
 const client = new Julep({ apiKey: 'your_julep_api_key' });
@@ -227,7 +227,7 @@ async function createAgent() {
 
   return agent;
 }
-ステップ2: ストーリーと漫画を生成するタスクを作成するconst taskYaml = `
+Étape 2 : Créer une tâche qui génère une histoire et une bande dessinéeconst taskYaml = `
 name: Story and Comic Creator
 description: Create a story based on an idea and generate a 4-panel comic strip illustrating the story.
 
@@ -277,7 +277,7 @@ async function createTask(agent) {
   const task = await client.tasks.create(agent.id, yaml.load(taskYaml));
   return task;
 }
-ステップ3: タスクを実行するasync function executeTask(task) {
+Étape 3 : Exécuter la tâcheasync function executeTask(task) {
   const execution = await client.executions.create(task.id, {
     input: { idea: "A cat who learns to fly" }
   });
@@ -291,7 +291,7 @@ async function createTask(agent) {
   const result = await client.executions.get(execution.id);
   return result;
 }
-ステップ4: エージェントとチャットするasync function chatWithAgent(agent) {
+Étape 4 : Discutez avec l'agentasync function chatWithAgent(agent) {
   const session = await client.sessions.create({ agent_id: agent.id });
 
   // 💬Send messages to the agent
@@ -315,7 +315,7 @@ async function runExample() {
   const result = await executeTask(task);
   console.log("Task Result:", result);
   await chatWithAgent(agent);
-}実行例()。コンソールのエラーをキャッチします。
+}runExample().catch(console.error);
 > [!TIP]
 > You can find the full Node.js example [here](example.js).
 
@@ -372,7 +372,7 @@ graph TD
 
     classDef core fill:#f9f,stroke:#333,stroke-width:2px;
     class Agent,Tasks,Session core;
-**Agents**: AI-powered entities backed by large language models (LLMs) that execute tasks and interact with users.**Users**: Entities that interact with agents through sessions.**Sessions**: Stateful interactions between agents and users, maintaining context across multiple exchanges.**Tasks**: Multi-step, programmatic workflows that agents can execute, including various types of steps like prompts, tool calls, and conditional logic.**Tools**: Integrations that extend an agent's capabilities, including user-defined functions, system tools, or third-party API integrations.**Documents**: Text or data objects associated with agents or users, vectorized and stored for semantic search and retrieval.**Executions**: Instances of tasks that have been initiated with specific inputs, with their own lifecycle and state machine.For a more detailed explanation of these concepts and their interactions, please refer to our [Concepts Documentation](https://github.com/julep-ai/julep/blob/dev/docs/julep-concepts.md).タスクを理解するタスクは Julep のワークフロー システムの中核です。タスクを使用すると、エージェントが実行できる複雑な複数ステップの AI ワークフローを定義できます。タスク コンポーネントの概要は次のとおりです。**Name and Description**: Each task has a unique name and description for easy identification.**Main Steps**: The core of a task, defining the sequence of actions to be performed.**Tools**: Optional integrations that extend the capabilities of your agent during task execution.ワークフローステップの種類Julep のタスクにはさまざまな種類のステップを含めることができるため、複雑で強力なワークフローを作成できます。利用可能なステップの種類の概要をカテゴリ別にまとめると次のようになります。一般的な手順**Prompt**: SendAI モデルにメッセージを送信し、応答を受け取ります。- prompt: "Analyze the following data: {{data}}"
+**Agents**: AI-powered entities backed by large language models (LLMs) that execute tasks and interact with users.**Users**: Entities that interact with agents through sessions.**Sessions**: Stateful interactions between agents and users, maintaining context across multiple exchanges.**Tasks**: Multi-step, programmatic workflows that agents can execute, including various types of steps like prompts, tool calls, and conditional logic.**Tools**: Integrations that extend an agent's capabilities, including user-defined functions, system tools, or third-party API integrations.**Documents**: Text or data objects associated with agents or users, vectorized and stored for semantic search and retrieval.**Executions**: Instances of tasks that have been initiated with specific inputs, with their own lifecycle and state machine.For a more detailed explanation of these concepts and their interactions, please refer to our [Concepts Documentation](https://github.com/julep-ai/julep/blob/dev/docs/julep-concepts.md).Comprendre les tâchesLes tâches sont au cœur du système de workflow de Julep. Elles vous permettent de définir des workflows IA complexes en plusieurs étapes que vos agents peuvent exécuter. Voici un bref aperçu des composants des tâches :**Name and Description**: Each task has a unique name and description for easy identification.**Main Steps**: The core of a task, defining the sequence of actions to be performed.**Tools**: Optional integrations that extend the capabilities of your agent during task execution.Types d'étapes du flux de travailLes tâches dans Julep peuvent inclure différents types d'étapes, ce qui vous permet de créer des flux de travail complexes et puissants. Voici un aperçu des types d'étapes disponibles, organisés par catégorie :Étapes courantes**Prompt**: Sendun message au modèle d'IA et recevoir une réponse.- prompt: "Analyze the following data: {{data}}"
 **Tool Call**: Execute an integrated tool or API.- tool: web_search
   arguments:
     query: "Latest AI developments"
@@ -382,10 +382,10 @@ graph TD
     info:
       message: "Please provide additional information."
 **Log**: Log a specified value or message.- log: "Processing completed for item {{item_id}}"
-キーバリューステップ**Get**: Retrieve a value from a key-value store.- get: "user_preference"
+Étapes clés-valeurs**Get**: Retrieve a value from a key-value store.- get: "user_preference"
 **Set**: Assign a value to a key in a key-value store.- set:
     user_preference: "dark_mode"
-反復ステップ**Foreach**: Iterate over a collection and perform steps for each item.- foreach:
+Étapes d'itération**Foreach**: Iterate over a collection and perform steps for each item.- foreach:
     in: "data_list"
     do:
       - log: "Processing item {{_}}"
@@ -402,7 +402,7 @@ graph TD
     - tool: weather_check
       arguments:
         location: "New York"
-条件付きステップ**If-Else**: Conditional execution of steps.- if: "score > 0.8"
+Étapes conditionnelles**If-Else**: Conditional execution of steps.- if: "score > 0.8"
   then:
     - log: "High score achieved"
   else:
@@ -417,7 +417,7 @@ graph TD
     - case: "_"  # Default case
       then:
         - log: "Unknown category"
-その他の制御フロー**Sleep**: Pause the workflow for a specified duration.- sleep:
+Autre flux de contrôle**Sleep**: Pause the workflow for a specified duration.- sleep:
     seconds: 30
 **Return**: Return a value from the workflow.- return:
     result: "Task completed successfully"
@@ -426,7 +426,7 @@ graph TD
     arguments:
       input_data: "{{raw_data}}"
 **Error**: Handle errors by specifying an error message.- error: "Invalid input provided"
-各ステップ タイプは、高度な AI ワークフローを構築する上で特定の目的を果たします。この分類は、Julep タスクで使用できるさまざまな制御フローと操作を理解するのに役立ちます。高度な機能Julep は、AI ワークフローを強化するためのさまざまな高度な機能を提供します。エージェントへのツールの追加外部ツールと API を統合してエージェントの機能を拡張します。client.agents.tools.create(
+Chaque type d'étape remplit un objectif spécifique dans la création de workflows d'IA sophistiqués. Cette catégorisation permet de comprendre les différents flux de contrôle et opérations disponibles dans les tâches Julep.Fonctionnalités avancéesJulep propose une gamme de fonctionnalités avancées pour améliorer vos flux de travail d'IA :Ajout d'outils aux agentsÉtendez les capacités de votre agent en intégrant des outils et des API externes :client.agents.tools.create(
     agent_id=agent.id,
     name="web_search",
     description="Search the web for information.",
@@ -436,7 +436,7 @@ graph TD
         "setup": {"api_key": "your_brave_api_key"},
     },
 )
-セッションとユーザーの管理Julep は、永続的なインタラクションのための堅牢なセッション管理を提供します。session = client.sessions.create(
+Gestion des sessions et des utilisateursJulep fournit une gestion de session robuste pour les interactions persistantes :session = client.sessions.create(
     agent_id=agent.id,
     user_id=user.id,
     context_overflow="adaptive"
@@ -452,7 +452,7 @@ response = client.sessions.chat(
       }
     ]
 )
-ドキュメントの統合と検索エージェントのドキュメントを簡単に管理および検索できます。# Upload a document
+Intégration et recherche de documentsGérez et recherchez facilement des documents pour vos agents :# Upload a document
 document = client.agents.docs.create(
     title="AI advancements",
     content="AI is changing the world...",
@@ -464,7 +464,7 @@ results = client.agents.docs.search(
     text="AI advancements",
     metadata_filter={"category": "research_paper"}
 )
-For more advanced features and detailed usage, please refer to our [Advanced Features Documentation](https://docs.julep.ai/advanced-features).統合Julep は、AI エージェントの機能を拡張するさまざまな統合をサポートしています。利用可能な統合とサポートされている引数のリストは次のとおりです。勇敢な検索setup:
+For more advanced features and detailed usage, please refer to our [Advanced Features Documentation](https://docs.julep.ai/advanced-features).IntégrationsJulep prend en charge diverses intégrations qui étendent les capacités de vos agents IA. Voici une liste des intégrations disponibles et de leurs arguments pris en charge :Recherche courageusesetup:
   api_key: string  # The API key for Brave Search
 
 arguments:
@@ -472,7 +472,7 @@ arguments:
 
 output:
   result: string  # The result of the Brave Search
-ブラウザベースsetup:
+Base de navigateursetup:
   api_key: string       # The API key for BrowserBase
   project_id: string    # The project ID for BrowserBase
   session_id: string    # (Optional) The session ID for BrowserBasearguments:
@@ -495,7 +495,7 @@ arguments:
 
 output:
   success: boolean  # Whether the email was sent successfully
-スパイダーsetup:
+Araignéesetup:
   spider_api_key: string  # The API key for Spider
 
 arguments:
@@ -505,7 +505,7 @@ arguments:
 
 output:
   documents: list         # The documents returned from the spider
-天気setup:
+Météosetup:
   openweathermap_api_key: string  # The API key for OpenWeatherMap
 
 arguments:
@@ -513,11 +513,11 @@ arguments:
 
 output:
   result: string                  # The weather data for the specified location
-ウィキペディアarguments:
+Wikipédiaarguments:
   query: string           # The search query string
   load_max_docs: integer  # Maximum number of documents to load (default: 2)
 
 output:
   documents: list         # The documents returned from the Wikipedia search
-These integrations can be used within your tasks to extend the capabilities of your AI agents. For more detailed information on how to use these integrations in your workflows, please refer to our [Integrations Documentation](https://docs.julep.ai/integrations).SDKリファレンス[Node.js SDK](https://github.com/julep-ai/node-sdk/blob/main/api.md)[Python SDK](https://github.com/julep-ai/python-sdk/blob/main/api.md)APIリファレンスエージェント、タスク、実行の詳細については、包括的な API ドキュメントをご覧ください。[Agents API](https://api.julep.ai/api/docs#tag/agents)[Tasks API](https://api.julep.ai/api/docs#tag/tasks)[Executions API](https://api.julep.ai/api/docs#tag/executions)->> Test <<-
+These integrations can be used within your tasks to extend the capabilities of your AI agents. For more detailed information on how to use these integrations in your workflows, please refer to our [Integrations Documentation](https://docs.julep.ai/integrations).Référence SDK[Node.js SDK](https://github.com/julep-ai/node-sdk/blob/main/api.md)[Python SDK](https://github.com/julep-ai/python-sdk/blob/main/api.md)Référence APIExplorez notre documentation API complète pour en savoir plus sur les agents, les tâches et les exécutions :[Agents API](https://api.julep.ai/api/docs#tag/agents)[Tasks API](https://api.julep.ai/api/docs#tag/tasks)[Executions API](https://api.julep.ai/api/docs#tag/executions)->> Test <<-
 A simple update to text the translation github action

--- a/README-FR.md
+++ b/README-FR.md
@@ -30,7 +30,26 @@ Get your API key [here](https://dashboard-dev.julep.ai).While we are in beta, yo
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 <details>
 <summary><h3>📖 Table of Contents</h3></summary>
-[Introduction](#introduction)[Quick Example](#quick-example)[Key Features](#key-features)[Why Julep vs. LangChain?](#why-julep-vs-langchain)[Different Use Cases](#different-use-cases)[Different Form Factor](#different-form-factor)[In Summary](#in-summary)[Installation](#installation)[Python Quick Start 🐍](#python-quick-start-)[Step 1: Create an Agent](#step-1-create-an-agent)[Step 2: Create a Task that generates a story and comic strip](#step-2-create-a-task-that-generates-a-story-and-comic-strip)[Step 3: Execute the Task](#step-3-execute-the-task)[Step 4: Chat with the Agent](#step-4-chat-with-the-agent)[Node.js Quick Start 🟩](#nodejs-quick-start-)[Step 1: Create an Agent](#step-1-create-an-agent-1)[Step 2: Create a Task that generates a story and comic strip](#step-2-create-a-task-that-generates-a-story-and-comic-strip-1)[Step 3: Execute the Task](#step-3-execute-the-task-1)[Step 4: Chat with the Agent](#step-4-chat-with-the-agent-1)[Composants](#composant(nts)[Mental Model](#mental-model)[Concepts](#concepts)[Understanding Tasks](#understanding-tasks)[Types of Workflow Steps](#types-of-workflow-steps)[Advanced Features](#advanced-features)[Adding Tools to Agents](#adding-tools-to-agents)[Managing Sessions and Users](#managing-sessions-and-users)[Document Integration and Search](#document-integration-and-search)[Integrations](#integrations)[Brave Search](#brave-search)[BrowserBase](#browserbase)[Email](#email)[Spider](#spider)[Weather](#weather)[Wikipedia](#wikipedia)[SDK Reference](#sdk-reference)[API Reference](#api-reference)</details>
+
+- [Optional: Define the input schema for the task](#optional-define-the-input-schema-for-the-task)
+- [Define the tools that the agent can use](#define-the-tools-that-the-agent-can-use)
+- [Special variables:](#special-variables)
+- [- inputs: for accessing the input to the task](#--inputs-for-accessing-the-input-to-the-task)
+- [- outputs: for accessing the output of previous steps](#--outputs-for-accessing-the-output-of-previous-steps)
+- [- _: for accessing the output of the previous step](#--_-for-accessing-the-output-of-the-previous-step)
+- [Define the main workflow](#define-the-main-workflow)
+- [Evaluate the search queries using a simple python expression](#evaluate-the-search-queries-using-a-simple-python-expression)
+- [Run the web search in parallel for each query](#run-the-web-search-in-parallel-for-each-query)
+- [Collect the results from the web search](#collect-the-results-from-the-web-search)
+- [Summarize the results](#summarize-the-results)
+- [Send the summary to Discord](#send-the-summary-to-discord)
+- [🛠️ Add an image generation tool (DALL·E) to the agent](#-add-an-image-generation-tool-dall%C2%B7e-to-the-agent)
+- [Create a task that takes an idea and creates a story and a 4-panel comic strip](#create-a-task-that-takes-an-idea-and-creates-a-story-and-a-4-panel-comic-strip)
+- [Step 1: Generate a story and outline into 4 panels](#step-1-generate-a-story-and-outline-into-4-panels)
+- [Step 2: Extract thedescriptions des panneaux et histoireevaluate:](#step-2-extract-thedescriptions-des-panneaux-et-histoireevaluate)
+    - [Step 3: Execute the Task](#step-3-execute-the-task)
+
+</details>
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 IntroductionJulep est une plateforme permettant de créer des agents IA qui se souviennent des interactions passées et peuvent effectuer des tâches complexes. Elle offre une mémoire à long terme et gère des processus en plusieurs étapes.Julep permet la création de tâches en plusieurs étapes intégrant la prise de décision, les boucles, le traitement parallèle et l'intégration avec de nombreux outils et API externes.Alors que de nombreuses applications d’IA se limitent à des chaînes simples et linéaires d’invites et d’appels d’API avec une ramification minimale, Julep est conçu pour gérer des scénarios plus complexes.Il prend en charge :Des processus complexes en plusieurs étapesPrise de décision dynamiqueExécution parallèle[!TIP]
 Imagine you want to build an AI agent that can do more than just answer simple questions—it needs to handle complex tasks, remember past interactions, and maybe even use other tools or APIs. That's where Julep comes in.Exemple rapideImaginez un agent d’IA de recherche capable d’effectuer les opérations suivantes :Prenez un sujet,Proposez 100 requêtes de recherche pour ce sujet,Effectuez ces recherches sur le Web en parallèle,Résumer les résultats,Envoyez le résumé sur DiscordIn Julep, this would be a single task under <b>80 lines of code</b> and run <b>fully managed</b> all on its own. All of the steps are executed on Julep's own servers and you don't need to lift a finger. Here's a working example:name: Research Agent

--- a/README-JP.md
+++ b/README-JP.md
@@ -30,7 +30,26 @@ Get your API key [here](https://dashboard-dev.julep.ai).While we are in beta, yo
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 <details>
 <summary><h3>📖 Table of Contents</h3></summary>
-[Introduction](#introduction)[Quick Example](#quick-example)[Key Features](#key-features)[Why Julep vs. LangChain?](#why-julep-vs-langchain)[Different Use Cases](#different-use-cases)[Different Form Factor](#different-form-factor)[In Summary](#in-summary)[Installation](#installation)[Python Quick Start 🐍](#python-quick-start-)[Step 1: Create an Agent](#step-1-create-an-agent)[Step 2: Create a Task that generates a story and comic strip](#step-2-create-a-task-that-generates-a-story-and-comic-strip)[Step 3: Execute the Task](#step-3-execute-the-task)[Step 4: Chat with the Agent](#step-4-chat-with-the-agent)[Node.js Quick Start 🟩](#nodejs-quick-start-)[Step 1: Create an Agent](#step-1-create-an-agent-1)[Step 2: Create a Task that generates a story and comic strip](#step-2-create-a-task-that-generates-a-story-and-comic-strip-1)[Step 3: Execute the Task](#step-3-execute-the-task-1)[Step 4: Chat with the Agent](#step-4-chat-with-the-agent-1)[コンポーネント](#components)[Mental Model](#mental-model)[Concepts](#concepts)[Understanding Tasks](#understanding-tasks)[Types of Workflow Steps](#types-of-workflow-steps)[Advanced Features](#advanced-features)[Adding Tools to Agents](#adding-tools-to-agents)[Managing Sessions and Users](#managing-sessions-and-users)[Document Integration and Search](#document-integration-and-search)[Integrations](#integrations)[Brave Search](#brave-search)[BrowserBase](#browserbase)[Email](#email)[Spider](#spider)[Weather](#weather)[Wikipedia](#wikipedia)[SDK Reference](#sdk-reference)[API Reference](#api-reference)</details>
+
+- [Optional: Define the input schema for the task](#optional-define-the-input-schema-for-the-task)
+- [Define the tools that the agent can use](#define-the-tools-that-the-agent-can-use)
+- [Special variables:](#special-variables)
+- [- inputs: for accessing the input to the task](#--inputs-for-accessing-the-input-to-the-task)
+- [- outputs: for accessing the output of previous steps](#--outputs-for-accessing-the-output-of-previous-steps)
+- [- _: for accessing the output of the previous step](#--_-for-accessing-the-output-of-the-previous-step)
+- [Define the main workflow](#define-the-main-workflow)
+- [Evaluate the search queries using a simple python expression](#evaluate-the-search-queries-using-a-simple-python-expression)
+- [Run the web search in parallel for each query](#run-the-web-search-in-parallel-for-each-query)
+- [Collect the results from the web search](#collect-the-results-from-the-web-search)
+- [Summarize the results](#summarize-the-results)
+- [Send the summary to Discord](#send-the-summary-to-discord)
+- [🛠️ Add an image generation tool (DALL·E) to the agent](#-add-an-image-generation-tool-dall%C2%B7e-to-the-agent)
+- [Create a task that takes an idea and creates a story and a 4-panel comic strip](#create-a-task-that-takes-an-idea-and-creates-a-story-and-a-4-panel-comic-strip)
+- [Step 1: Generate a story and outline into 4 panels](#step-1-generate-a-story-and-outline-into-4-panels)
+- [Step 2: Extract theパネルの説明とストーリーevaluate:](#step-2-extract-the%E3%83%91%E3%83%8D%E3%83%AB%E3%81%AE%E8%AA%AC%E6%98%8E%E3%81%A8%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AA%E3%83%BCevaluate)
+    - [Step 3: Execute the Task](#step-3-execute-the-task)
+
+</details>
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 導入Julep は、過去のやり取りを記憶し、複雑なタスクを実行できる AI エージェントを作成するためのプラットフォームです。長期記憶を提供し、複数ステップのプロセスを管理します。Julep を使用すると、意思決定、ループ、並列処理、多数の外部ツールや API との統合を組み込んだ複数ステップのタスクを作成できます。多くの AI アプリケーションは、分岐が最小限の、プロンプトと API 呼び出しの単純な線形チェーンに制限されていますが、Julep はより複雑なシナリオを処理できるように構築されています。サポート対象:複雑で多段階のプロセス動的な意思決定並列実行[!TIP]
 Imagine you want to build an AI agent that can do more than just answer simple questions—it needs to handle complex tasks, remember past interactions, and maybe even use other tools or APIs. That's where Julep comes in.簡単な例次のことができる研究 AI エージェントを想像してください。トピックを取り上げ、そのトピックについて100個の検索クエリを考えてみましょう。これらのウェブ検索を並行して実行すると、結果をまとめると、要約をDiscordに送信するIn Julep, this would be a single task under <b>80 lines of code</b> and run <b>fully managed</b> all on its own. All of the steps are executed on Julep's own servers and you don't need to lift a finger. Here's a working example:name: Research Agent

--- a/README.md
+++ b/README.md
@@ -948,4 +948,4 @@ Explore our comprehensive API documentation to learn more about agents, tasks, a
 - [Executions API](https://api.julep.ai/api/docs#tag/executions)
 
 ->> Test <<-
-A simple update to Readme file again
+A simple update to Readme file

--- a/README.md
+++ b/README.md
@@ -948,4 +948,4 @@ Explore our comprehensive API documentation to learn more about agents, tasks, a
 - [Executions API](https://api.julep.ai/api/docs#tag/executions)
 
 ->> Test <<-
-A simple update to Readme file
+A simple update to Readme file again

--- a/README.md
+++ b/README.md
@@ -946,3 +946,6 @@ Explore our comprehensive API documentation to learn more about agents, tasks, a
 - [Agents API](https://api.julep.ai/api/docs#tag/agents)
 - [Tasks API](https://api.julep.ai/api/docs#tag/tasks)
 - [Executions API](https://api.julep.ai/api/docs#tag/executions)
+
+->> Test <<-
+A simple update to Readme file

--- a/README.md
+++ b/README.md
@@ -948,4 +948,4 @@ Explore our comprehensive API documentation to learn more about agents, tasks, a
 - [Executions API](https://api.julep.ai/api/docs#tag/executions)
 
 ->> Test <<-
-A simple update to Readme file
+A simple update to text the translation github action

--- a/scripts/translate_readme.py
+++ b/scripts/translate_readme.py
@@ -1,0 +1,29 @@
+from googletrans import Translator
+import os
+
+# Initialize the translator
+translator = Translator()
+
+# Load the original README content
+with open('README.md', 'r', encoding='utf-8') as readme_file:
+    original_content = readme_file.read()
+
+# Define the target languages
+languages = {
+    'CN': 'zh-cn',  # Chinese
+    'JP': 'ja',     # Japanese
+    'FR': 'fr',     # French
+}
+
+# Translate the content and write to new files
+for code, lang in languages.items():
+    translated_content = translator.translate(original_content, dest=lang).text
+
+    # Write the translated content to a new file
+    with open(f'README-{code}.md', 'w', encoding='utf-8') as translated_file:
+        translated_file.write(f'# Translated README in {lang.upper()}\n\n')
+        translated_file.write(translated_content)
+    
+    print(f'Translated README.md to README-{code}.md')
+
+print("Translation complete!")

--- a/scripts/translate_readme.py
+++ b/scripts/translate_readme.py
@@ -1,29 +1,46 @@
-from googletrans import Translator
 import os
+from deep_translator import GoogleTranslator
 
-# Initialize the translator
-translator = Translator()
+# Define file paths relative to the script's location (outside scripts folder)
+# Assuming the script is in a 'scripts' folder and README.md is one level up
+base_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-# Load the original README content
-with open('README.md', 'r', encoding='utf-8') as readme_file:
-    original_content = readme_file.read()
+readme_path = os.path.join(base_path, 'README.md')
+readme_cn_path = os.path.join(base_path, 'README-CN.md')
+readme_jp_path = os.path.join(base_path, 'README-JP.md')
+readme_fr_path = os.path.join(base_path, 'README-FR.md')
 
-# Define the target languages
+# Language codes for GoogleTranslator
 languages = {
-    'CN': 'zh-cn',  # Chinese
-    'JP': 'ja',     # Japanese
-    'FR': 'fr',     # French
+    "chinese": "zh-CN",
+    "japanese": "ja",
+    "french": "fr"
 }
 
-# Translate the content and write to new files
-for code, lang in languages.items():
-    translated_content = translator.translate(original_content, dest=lang).text
+# Function to translate content
+def translate_content(content, target_lang):
+    translator = GoogleTranslator(source='en', target=target_lang)
+    return translator.translate(content)
 
-    # Write the translated content to a new file
-    with open(f'README-{code}.md', 'w', encoding='utf-8') as translated_file:
-        translated_file.write(f'# Translated README in {lang.upper()}\n\n')
-        translated_file.write(translated_content)
-    
-    print(f'Translated README.md to README-{code}.md')
+# Read the original README.md content
+with open(readme_path, 'r', encoding='utf-8') as f:
+    original_content = f.read()
 
-print("Translation complete!")
+# Translate and save each translation
+translations = {
+    "chinese": translate_content(original_content, languages["chinese"]),
+    "japanese": translate_content(original_content, languages["japanese"]),
+    "french": translate_content(original_content, languages["french"]),
+}
+
+# Write translated contents to respective files in the same location as README.md
+with open(readme_cn_path, 'w', encoding='utf-8') as f:
+    f.write(translations["chinese"])
+
+with open(readme_jp_path, 'w', encoding='utf-8') as f:
+    f.write(translations["japanese"])
+
+with open(readme_fr_path, 'w', encoding='utf-8') as f:
+    f.write(translations["french"])
+
+print("README.md translated to Chinese, Japanese, and French successfully!")


### PR DESCRIPTION
Draft PR for #600 

**The Automation currently works as described in the issue**

- This workflow takes approximately 5 minutes to complete.
- Links and code blocks are not translated.
- This approach uses the deep_translator library. A free web-scraping technique to access the Google Translate service. For better results, the official Google Translate tool may be better, but it is not free.

I am open to discussions on this.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Automates translation of `README.md` into Chinese, Japanese, and French using a GitHub action and Python script.
> 
>   - **GitHub Action**:
>     - New workflow `translate-readme.yml` triggers on `README.md` changes to automate translation.
>     - Uses `deep_translator` and `markdown-it-py` for translation and markdown parsing.
>   - **Translation Script**:
>     - `scripts/translate_readme.py` translates `README.md` into `README-CN.md`, `README-JP.md`, and `README-FR.md`.
>     - Handles text in markdown, preserving non-translatable elements like code blocks.
>     - Splits text into chunks to manage API limits.
>   - **Misc**:
>     - Adds translated `README` files: `README-CN.md`, `README-JP.md`, `README-FR.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for b363bea32d936c7f78972d6f3b098cf3321ea027. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->