### PR TITLE
fix(monitoring): Update volume paths in monitoring docker-compose.yml

### DIFF
--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - multi-tenant
 
     volumes:
-      - ./config/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./prometheus/config/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus_data:/prometheus
     
     depends_on:
@@ -28,7 +28,7 @@ services:
       - 3000:3000
     volumes:
       - grafana_data:/var/lib/grafana
-      - ./provisioning:/etc/grafana/provisioning
+      - ./grafana/provisioning:/etc/grafana/provisioning
     profiles:
       - multi-tenant
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update volume paths for Prometheus and Grafana in `monitoring/docker-compose.yml`.
> 
>   - **Volume Path Updates**:
>     - Update Prometheus volume path from `./config/prometheus.yml` to `./prometheus/config/prometheus.yml` in `monitoring/docker-compose.yml`.
>     - Update Grafana volume path from `./provisioning` to `./grafana/provisioning` in `monitoring/docker-compose.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for d7886dd3c80513054842e02bd0065647e1933cd9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->