### PR TITLE
feat(litellm-proxy): Add support for `o1-mini` and `o1-preview` models

### DIFF
--- a/llm-proxy/litellm-config.yaml
+++ b/llm-proxy/litellm-config.yaml
@@ -31,6 +31,18 @@ model_list:
     tags: ["paid"]
     api_key: os.environ/OPENAI_API_KEY
 
+- model_name: o1-mini
+  litellm_params:
+    model: openai/o1-mini
+    api_key: os.environ/OPENAI_API_KEY
+    tags: ["paid"]
+
+- model_name: o1-preview
+  litellm_params:
+    model: openai/o1-preview
+    api_key: os.environ/OPENAI_API_KEY
+    tags: ["paid"]
+
 # Anthropic models
 - model_name: "claude-3.5-sonnet"
   litellm_params:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for `o1-mini` and `o1-preview` models in `litellm-config.yaml` with specific configurations.
> 
>   - **Models**:
>     - Add support for `o1-mini` and `o1-preview` models in `litellm-config.yaml`.
>     - Configure `o1-mini` and `o1-preview` with `model` names `openai/o1-mini` and `openai/o1-preview` respectively.
>     - Both models use `os.environ/OPENAI_API_KEY` for `api_key` and are tagged as `paid`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 12137df2a5b72cd495f61a00d7ee968580460d1e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->