### PR TITLE
feat(agents-api): Add `alpha` to hybrid search params in system tools execution

### DIFF
--- a/agents-api/agents_api/activities/execute_system.py
+++ b/agents-api/agents_api/activities/execute_system.py
@@ -109,7 +109,8 @@ async def execute_system(
                         search_params = HybridDocSearchRequest(
                             text=arguments.pop("text"),
                             vector=arguments.pop("vector"),
-                            confidence=arguments.pop("confidence", 0.7),
+                            alpha=arguments.pop("alpha", 0.75),
+                            confidence=arguments.pop("confidence", 0.5),
                             limit=arguments.get("limit", 10),
                         )
 

--- a/agents-api/agents_api/models/execution/create_execution.py
+++ b/agents-api/agents_api/models/execution/create_execution.py
@@ -60,7 +60,9 @@ def create_execution(
         data["metadata"] = data.get("metadata", {})
         execution_data = data
 
-    if execution_data["output"] is not None and not isinstance(execution_data["output"], dict):
+    if execution_data["output"] is not None and not isinstance(
+        execution_data["output"], dict
+    ):
         execution_data["output"] = {OUTPUT_UNNEST_KEY: execution_data["output"]}
 
     columns, values = cozo_process_mutate_data(

--- a/agents-api/agents_api/models/execution/get_execution.py
+++ b/agents-api/agents_api/models/execution/get_execution.py
@@ -32,7 +32,9 @@ T = TypeVar("T")
     one=True,
     transform=lambda d: {
         **d,
-        "output": d["output"][OUTPUT_UNNEST_KEY] if OUTPUT_UNNEST_KEY in d["output"] else d["output"],
+        "output": d["output"][OUTPUT_UNNEST_KEY]
+        if OUTPUT_UNNEST_KEY in d["output"]
+        else d["output"],
     },
 )
 @cozo_query


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `alpha` parameter to hybrid search in `execute_system()` with default value 0.75 and adjust `confidence` default to 0.5.
> 
>   - **Behavior**:
>     - Add `alpha` parameter to `HybridDocSearchRequest` in `execute_system()` for hybrid search when both `text` and `vector` are present.
>     - Default `alpha` value set to 0.75.
>     - Change default `confidence` value from 0.7 to 0.5 in hybrid search context.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for e67b64cf0b843c496f7f451f3c1b5e76a7f626c9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->