### PR TITLE
feat(agents-api): Increase timeout to 60s for executing integration activity

### DIFF
--- a/agents-api/agents_api/clients/integrations.py
+++ b/agents-api/agents_api/clients/integrations.py
@@ -21,7 +21,7 @@ async def run_integration_service(
 
     setup = setup or None
 
-    async with AsyncClient() as client:
+    async with AsyncClient(timeout=60) as client:
         response = await client.post(
             url,
             json={"arguments": arguments, "setup": setup},


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase timeout to 60 seconds for `AsyncClient` in `run_integration_service` to allow longer execution times.
> 
>   - **Behavior**:
>     - Increase timeout to 60 seconds for `AsyncClient` in `run_integration_service` function in `integrations.py` to allow longer execution times for integration activities.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for f62a392322a6821a6c30ecd5e8ebf5cda107e9a6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->