### PR TITLE
feat: Add metadata filter argument to doc search

### DIFF
--- a/agents-api/agents_api/autogen/Docs.py
+++ b/agents-api/agents_api/autogen/Docs.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from typing import Annotated, Any, Literal
 from uuid import UUID
 
-from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, StrictBool
 
 
 class BaseDocSearchRequest(BaseModel):
@@ -18,6 +18,7 @@ class BaseDocSearchRequest(BaseModel):
     """
     The language to be used for text-only search. Support for other languages coming soon.
     """
+    metadata_filter: dict[str, float | str | StrictBool | None]
 
 
 class CreateDocRequest(BaseModel):

--- a/agents-api/agents_api/models/docs/search_docs_by_text.py
+++ b/agents-api/agents_api/models/docs/search_docs_by_text.py
@@ -1,5 +1,6 @@
 """This module contains functions for searching documents in the CozoDB based on embedding queries."""
 
+import json
 import re
 from typing import Any, Literal, TypeVar
 from uuid import UUID
@@ -49,6 +50,7 @@ def search_docs_by_text(
     owners: list[tuple[Literal["user", "agent"], UUID]],
     query: str,
     k: int = 3,
+    metadata_filter: dict[str, Any] = {},
 ) -> tuple[list[str], dict]:
     """
     Searches for document snippets in CozoDB by embedding query.
@@ -57,7 +59,14 @@ def search_docs_by_text(
         owners (list[tuple[Literal["user", "agent"], UUID]]): The type of the owner of the documents.
         query (str): The query string.
         k (int, optional): The number of nearest neighbors to retrieve. Defaults to 3.
+        metadata_filter (dict[str, Any]): Dictionary to filter agents based on metadata.
     """
+    metadata_filter_str = ", ".join(
+        [
+            f"metadata->{json.dumps(k)} == {json.dumps(v)}"
+            for k, v in metadata_filter.items()
+        ]
+    )
 
     owners: list[list[str]] = [
         [owner_type, str(owner_id)] for owner_type, owner_id in owners
@@ -84,7 +93,8 @@ def search_docs_by_text(
                 owner_type,
                 owner_id,
                 doc_id
-            }}
+            }},
+            {metadata_filter_str}
 
         search_result[
             doc_id,

--- a/agents-api/agents_api/routers/docs/search_docs.py
+++ b/agents-api/agents_api/routers/docs/search_docs.py
@@ -25,21 +25,28 @@ def get_search_fn_and_params(
     search_fn, params = None, None
 
     match search_params:
-        case TextOnlyDocSearchRequest(text=query, limit=k):
+        case TextOnlyDocSearchRequest(
+            text=query, limit=k, metadata_filter=metadata_filter
+        ):
             search_fn = search_docs_by_text
             params = dict(
                 query=query,
                 k=k,
+                metadata_filter=metadata_filter,
             )
 
         case VectorDocSearchRequest(
-            vector=query_embedding, limit=k, confidence=confidence
+            vector=query_embedding,
+            limit=k,
+            confidence=confidence,
+            metadata_filter=metadata_filter,
         ):
             search_fn = search_docs_by_embedding
             params = dict(
                 query_embedding=query_embedding,
                 k=k,
                 confidence=confidence,
+                metadata_filter=metadata_filter,
             )
 
         case HybridDocSearchRequest(
@@ -48,6 +55,7 @@ def get_search_fn_and_params(
             limit=k,
             confidence=confidence,
             alpha=alpha,
+            metadata_filter=metadata_filter,
         ):
             search_fn = search_docs_hybrid
             params = dict(
@@ -56,6 +64,7 @@ def get_search_fn_and_params(
                 k=k,
                 embed_search_options=dict(confidence=confidence),
                 alpha=alpha,
+                metadata_filter=metadata_filter,
             )
 
     return search_fn, params

--- a/typespec/docs/models.tsp
+++ b/typespec/docs/models.tsp
@@ -82,6 +82,7 @@ model BaseDocSearchRequest {
 
     /** The language to be used for text-only search. Support for other languages coming soon. */
     lang: "en-US" = "en-US";
+    metadata_filter: MetadataFilter,
 }
 
 model VectorDocSearchRequest extends BaseDocSearchRequest {

--- a/typespec/tsp-output/@typespec/openapi3/openapi-0.4.0.yaml
+++ b/typespec/tsp-output/@typespec/openapi3/openapi-0.4.0.yaml
@@ -2425,6 +2425,7 @@ components:
       required:
         - limit
         - lang
+        - metadata_filter
       properties:
         limit:
           type: integer
@@ -2438,6 +2439,14 @@ components:
             - en-US
           description: The language to be used for text-only search. Support for other languages coming soon.
           default: en-US
+        metadata_filter:
+          type: object
+          additionalProperties:
+            anyOf:
+              - type: number
+              - type: string
+              - type: boolean
+            nullable: true
     Docs.CreateDocRequest:
       type: object
       required:

--- a/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
+++ b/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
@@ -2425,6 +2425,7 @@ components:
       required:
         - limit
         - lang
+        - metadata_filter
       properties:
         limit:
           type: integer
@@ -2438,6 +2439,14 @@ components:
             - en-US
           description: The language to be used for text-only search. Support for other languages coming soon.
           default: en-US
+        metadata_filter:
+          type: object
+          additionalProperties:
+            anyOf:
+              - type: number
+              - type: string
+              - type: boolean
+            nullable: true
     Docs.CreateDocRequest:
       type: object
       required:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `metadata_filter` to document search requests and functions for filtering by metadata.
> 
>   - **Behavior**:
>     - Add `metadata_filter` argument to `BaseDocSearchRequest` in `Docs.py` for filtering document searches by metadata.
>     - Update `search_docs_by_embedding()` and `search_docs_by_text()` in `search_docs_by_embedding.py` and `search_docs_by_text.py` to handle `metadata_filter`.
>     - Modify `get_search_fn_and_params()` in `search_docs.py` to pass `metadata_filter` to search functions.
>   - **Models**:
>     - Update `BaseDocSearchRequest` in `models.tsp` to include `metadata_filter`.
>   - **API Documentation**:
>     - Add `metadata_filter` to OpenAPI specifications in `openapi-0.4.0.yaml` and `openapi-1.0.0.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 385ddbfa06f1b3f92225cf56c1ca060ec6e013a1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->