### PR TITLE
fix(integrations-docker): fixed port issue in docker build step

### DIFF
--- a/integrations-service/docker-compose.yml
+++ b/integrations-service/docker-compose.yml
@@ -8,12 +8,13 @@ x--shared-environment: &shared-environment
 services:
   integrations:
     image: julepai/integrations:${TAG:-dev}
+    build: .
+    
     environment:
       <<: *shared-environment
-
-    build: .
+    
     ports:
-      - "${INTEGRATIONS_SERVICE_PORT}:${INTEGRATIONS_SERVICE_PORT}"
+      - "${INTEGRATIONS_SERVICE_PORT:-8000}:${INTEGRATIONS_SERVICE_PORT:-8000}" # map host to container port
 
     develop:
       watch:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes port mapping issue in `docker-compose.yml` by setting default port to 8000 if not specified.
> 
>   - **Docker Configuration**:
>     - In `docker-compose.yml`, fixed port mapping issue by setting default port to 8000 if `INTEGRATIONS_SERVICE_PORT` is not specified.
>     - Moved `build` directive above `environment` for better organization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 8638efc6338222c9fb93c37238401da53faf20c2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->