### PR TITLE
chore(agents-api): Bump cozo version

### DIFF
--- a/memory-store/Dockerfile
+++ b/memory-store/Dockerfile
@@ -12,7 +12,7 @@ FROM rust:1.80.1-bookworm AS builder
 RUN apt-get update && apt-get install -y liburing-dev
 
 # Clone the CozoDB repository with submodules (checkout the specified commit)
-ARG COZO_COMMIT=57b7b440fd93440d985f2259eeaaf2ba5cc7569e
+ARG COZO_COMMIT=695d0282fa9836bd93b4ff4313ec1cfb514c4f3b
 RUN \
     git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/cozodb/cozo.git /usr/src/cozo && \
     cd /usr/src/cozo && \


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update CozoDB commit hash in `memory-store/Dockerfile` to a newer version.
> 
>   - **Dockerfile Update**:
>     - Update `COZO_COMMIT` in `memory-store/Dockerfile` from `57b7b440fd93440d985f2259eeaaf2ba5cc7569e` to `695d0282fa9836bd93b4ff4313ec1cfb514c4f3b`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 7a68397a4be4664251a53a9e32dd0f372eecb2da. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->