### PR TITLE
feat(agents-api): Add support for claude computer-use

### DIFF
--- a/agents-api/agents_api/activities/execute_system.py
+++ b/agents-api/agents_api/activities/execute_system.py
@@ -225,8 +225,9 @@ async def execute_system(
                 return create_session_query(**arguments)
             elif system.operation == "update":
                 return update_session_query(**arguments)
-            elif system.operation == "delete":
-                return update_session_query(**arguments)
+            # FIXME: @hamada needs to be fixed
+            # elif system.operation == "delete":
+            #     return update_session_query(**arguments)
             elif system.operation == "delete":
                 return delete_session_query(**arguments)
         # TASKS

--- a/agents-api/agents_api/activities/task_steps/prompt_step.py
+++ b/agents-api/agents_api/activities/task_steps/prompt_step.py
@@ -1,6 +1,6 @@
 import os
 
-from anthropic import Anthropic  # Import Anthropic client
+from anthropic import AsyncAnthropic, Anthropic  # Import AsyncAnthropic client
 from beartype import beartype
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
@@ -9,6 +9,7 @@ from ...autogen.Tools import Tool
 from ...clients import (
     litellm,  # We dont directly import `acompletion` so we can mock it
 )
+from litellm.utils import CustomStreamWrapper, ModelResponse
 from ...common.protocol.tasks import StepContext, StepOutcome
 from ...common.storage_handler import auto_blob_store
 from ...common.utils.template import render_template
@@ -20,7 +21,7 @@ COMPUTER_USE_BETA_FLAG = "computer-use-2024-10-22"
 
 # FIXME: This shouldn't be here.
 def format_agent_tool(tool: Tool) -> dict:
-    if tool.function:
+    if tool.type == "function":
         return {
             "type": "function",
             "function": {
@@ -29,20 +30,20 @@ def format_agent_tool(tool: Tool) -> dict:
                 "parameters": tool.function.parameters,
             },
         }
-    elif tool.computer_20241022:
+    elif tool.type == "computer_20241022":
         return {
             "type": tool.type,
             "name": tool.name,
-            "display_width_px": tool.display_width_px,
-            "display_height_px": tool.display_height_px,
-            "display_number": tool.display_number,
+            "display_width_px": tool.spec['display_width_px'],
+            "display_height_px": tool.spec['display_height_px'],
+            "display_number": tool.spec['display_number'],
         }
-    elif tool.bash_20241022:
+    elif tool.type == "bash_20241022":
         return {
             "type": tool.type,
             "name": tool.name,
         }
-    elif tool.text_editor_20241022:
+    elif tool.type == "text_editor_20241022":
         return {
             "type": tool.type,
             "name": tool.name,
@@ -50,7 +51,6 @@ def format_agent_tool(tool: Tool) -> dict:
     # TODO: Add integration | system | api_call tool types
     else:
         return {}
-
 
 @activity.defn
 @auto_blob_store
@@ -86,7 +86,7 @@ async def prompt_step(context: StepContext) -> StepOutcome:
         sort_by="created_at",
         direction="desc",
     )
-
+    # grab the tools from context.current_step.tools and then append it to the agent_tools
     if context.current_step.settings:
         passed_settings: dict = context.current_step.settings.model_dump(
             exclude_unset=True
@@ -99,25 +99,38 @@ async def prompt_step(context: StepContext) -> StepOutcome:
         prompt = [{"role": "user", "content": prompt}]
 
     # Format agent_tools for litellm
+    # Initialize the formatted_agent_tools with context tools
+    task_tools = context.tools
     formatted_agent_tools = [
-        format_agent_tool(tool) for tool in agent_tools if format_agent_tool(tool)
+        format_agent_tool(tool) for tool in task_tools
     ]
+    # Add agent_tools if they are not already in formatted_agent_tools
+    for agent_tool in agent_tools:
+        if format_agent_tool(agent_tool) and format_agent_tool(agent_tool) not in formatted_agent_tools:
+            formatted_agent_tools.append(format_agent_tool(agent_tool))
 
     # Check if the model is Anthropic
-    if "claude-3.5-sonnet-20241022" == agent_model.lower():
+    if (agent_model.lower().startswith("claude-3.5")
+        and any(
+            tool["type"] in ["computer_20241022", "bash_20241022", "text_editor_20241022"]
+            for tool in formatted_agent_tools)
+        ):
         # Retrieve the API key from the environment variable
         betas = [COMPUTER_USE_BETA_FLAG]
         # Use Anthropic API directly
-        client = Anthropic(api_key=anthropic_api_key)
-
+        client = AsyncAnthropic(api_key=anthropic_api_key)
+        new_prompt = [{"role": "user", "content": prompt[0]["content"]}]
         # Claude Response
         response = await client.beta.messages.create(
-            model=agent_model,
-            messages=prompt,
+            model="claude-3-5-sonnet-20241022",
+            messages=new_prompt,
             tools=formatted_agent_tools,
             max_tokens=1024,
             betas=betas,
         )
+        print("-" * 100)
+        # print("Model Response: ", model_response)
+        print("Response: ", response)
 
         return StepOutcome(
             output=response.model_dump()

--- a/agents-api/agents_api/autogen/Tools.py
+++ b/agents-api/agents_api/autogen/Tools.py
@@ -687,6 +687,18 @@ class CreateToolRequest(BaseModel):
     """
     Name of the tool (must be unique for this agent and a valid python identifier string )
     """
+    type: Literal[
+        "function",
+        "integration",
+        "system",
+        "api_call",
+        "computer_20241022",
+        "text_editor_20241022",
+        "bash_20241022",
+    ]
+    """
+    Type of the tool
+    """
     description: str | None = None
     """
     Description of the tool
@@ -952,6 +964,21 @@ class PatchToolRequest(BaseModel):
     name: Annotated[str | None, Field(max_length=40, pattern="^[^\\W0-9]\\w*$")] = None
     """
     Name of the tool (must be unique for this agent and a valid python identifier string )
+    """
+    type: (
+        Literal[
+            "function",
+            "integration",
+            "system",
+            "api_call",
+            "computer_20241022",
+            "text_editor_20241022",
+            "bash_20241022",
+        ]
+        | None
+    ) = None
+    """
+    Type of the tool
     """
     description: str | None = None
     """
@@ -1380,6 +1407,18 @@ class Tool(BaseModel):
     """
     Name of the tool (must be unique for this agent and a valid python identifier string )
     """
+    type: Literal[
+        "function",
+        "integration",
+        "system",
+        "api_call",
+        "computer_20241022",
+        "text_editor_20241022",
+        "bash_20241022",
+    ]
+    """
+    Type of the tool
+    """
     description: str | None = None
     """
     Description of the tool
@@ -1456,6 +1495,18 @@ class UpdateToolRequest(BaseModel):
     name: Annotated[str, Field(max_length=40, pattern="^[^\\W0-9]\\w*$")]
     """
     Name of the tool (must be unique for this agent and a valid python identifier string )
+    """
+    type: Literal[
+        "function",
+        "integration",
+        "system",
+        "api_call",
+        "computer_20241022",
+        "text_editor_20241022",
+        "bash_20241022",
+    ]
+    """
+    Type of the tool
     """
     description: str | None = None
     """

--- a/agents-api/agents_api/common/protocol/tasks.py
+++ b/agents-api/agents_api/common/protocol/tasks.py
@@ -235,13 +235,12 @@ def task_to_spec(
     for tool in task.tools:
         tool_spec = getattr(tool, tool.type)
 
-        tools.append(
-            TaskToolDef(
-                type=tool.type,
-                spec=tool_spec.model_dump(),
-                **tool.model_dump(exclude={"type"}),
-            )
+        tool_obj = dict(
+            type=tool.type,
+            spec=tool_spec.model_dump(),
+            **tool.model_dump(exclude={"type"}),
         )
+        tools.append(TaskToolDef(**tool_obj))
 
     workflows = [Workflow(name="main", steps=task_data.pop("main"))]
 

--- a/integrations-service/integrations/autogen/Tools.py
+++ b/integrations-service/integrations/autogen/Tools.py
@@ -687,6 +687,18 @@ class CreateToolRequest(BaseModel):
     """
     Name of the tool (must be unique for this agent and a valid python identifier string )
     """
+    type: Literal[
+        "function",
+        "integration",
+        "system",
+        "api_call",
+        "computer_20241022",
+        "text_editor_20241022",
+        "bash_20241022",
+    ]
+    """
+    Type of the tool
+    """
     description: str | None = None
     """
     Description of the tool
@@ -952,6 +964,21 @@ class PatchToolRequest(BaseModel):
     name: Annotated[str | None, Field(max_length=40, pattern="^[^\\W0-9]\\w*$")] = None
     """
     Name of the tool (must be unique for this agent and a valid python identifier string )
+    """
+    type: (
+        Literal[
+            "function",
+            "integration",
+            "system",
+            "api_call",
+            "computer_20241022",
+            "text_editor_20241022",
+            "bash_20241022",
+        ]
+        | None
+    ) = None
+    """
+    Type of the tool
     """
     description: str | None = None
     """
@@ -1380,6 +1407,18 @@ class Tool(BaseModel):
     """
     Name of the tool (must be unique for this agent and a valid python identifier string )
     """
+    type: Literal[
+        "function",
+        "integration",
+        "system",
+        "api_call",
+        "computer_20241022",
+        "text_editor_20241022",
+        "bash_20241022",
+    ]
+    """
+    Type of the tool
+    """
     description: str | None = None
     """
     Description of the tool
@@ -1456,6 +1495,18 @@ class UpdateToolRequest(BaseModel):
     name: Annotated[str, Field(max_length=40, pattern="^[^\\W0-9]\\w*$")]
     """
     Name of the tool (must be unique for this agent and a valid python identifier string )
+    """
+    type: Literal[
+        "function",
+        "integration",
+        "system",
+        "api_call",
+        "computer_20241022",
+        "text_editor_20241022",
+        "bash_20241022",
+    ]
+    """
+    Type of the tool
     """
     description: str | None = None
     """

--- a/typespec/tools/models.tsp
+++ b/typespec/tools/models.tsp
@@ -210,6 +210,9 @@ model Tool {
     /** Name of the tool (must be unique for this agent and a valid python identifier string )*/
     name: validPythonIdentifier;
 
+    /** Type of the tool */
+    type: ToolType;
+
     /** Description of the tool */
     description?: string;
 

--- a/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
+++ b/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
@@ -6656,11 +6656,16 @@ components:
       type: object
       required:
         - name
+        - type
       properties:
         name:
           allOf:
             - $ref: '#/components/schemas/Common.validPythonIdentifier'
           description: Name of the tool (must be unique for this agent and a valid python identifier string )
+        type:
+          allOf:
+            - $ref: '#/components/schemas/Tools.ToolType'
+          description: Type of the tool
         description:
           type: string
           description: Description of the tool
@@ -6885,6 +6890,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/Common.validPythonIdentifier'
           description: Name of the tool (must be unique for this agent and a valid python identifier string )
+        type:
+          allOf:
+            - $ref: '#/components/schemas/Tools.ToolType'
+          description: Type of the tool
         description:
           type: string
           description: Description of the tool
@@ -7291,6 +7300,7 @@ components:
       type: object
       required:
         - name
+        - type
         - created_at
         - updated_at
         - id
@@ -7299,6 +7309,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/Common.validPythonIdentifier'
           description: Name of the tool (must be unique for this agent and a valid python identifier string )
+        type:
+          allOf:
+            - $ref: '#/components/schemas/Tools.ToolType'
+          description: Type of the tool
         description:
           type: string
           description: Description of the tool
@@ -7380,11 +7394,16 @@ components:
       type: object
       required:
         - name
+        - type
       properties:
         name:
           allOf:
             - $ref: '#/components/schemas/Common.validPythonIdentifier'
           description: Name of the tool (must be unique for this agent and a valid python identifier string )
+        type:
+          allOf:
+            - $ref: '#/components/schemas/Tools.ToolType'
+          description: Type of the tool
         description:
           type: string
           description: Description of the tool


### PR DESCRIPTION
```python
from anthropic import Anthropic
from anthropic.types.beta.beta_message import BetaMessage

from litellm import ChatCompletionMessageToolCall, Function, Message
from litellm.types.utils import Choices, ModelResponse

# ...
# ...


    # Check if the model is Anthropic and bash/editor/computer use tool is included
    if "claude" in agent_model.lower() and any(
        tool.type in ["bash_20241022", "text_editor_20241022", "computer_20241022"]
        for tool in agent_tools
    ):
        # Retrieve the API key from the environment variable
        betas = [COMPUTER_USE_BETA_FLAG]
        # Use Anthropic API directly
        client = Anthropic(api_key=anthropic_api_key)

        # Claude Response
        claude_response: BetaMessage = await client.beta.messages.create(
            model=agent_model,
            messages=prompt,
            tools=formatted_agent_tools,
            max_tokens=1024,
            betas=betas,
        )

# Claude returns [ToolUse | TextBlock]
        # We need to convert tool_use to tool_calls
        # And set content = TextBlock.text
        # But we need to ensure no more than one text block is returned
        if (
            len([block for block in claude_response.content if block.type == "text"])
            > 1
        ):
            raise ApplicationError("Claude should only return one message")

        text_block = next(
            (block for block in claude_response.content if block.type == "text"),
            None,
        )

        stop_reason = claude_response.stop_reason

        if stop_reason == "tool_use":
            choice = Choices(
                message=Message(
                    role="assistant",
                    content=text_block.text if text_block else None,
                    tool_calls=[
                        ChatCompletionMessageToolCall(
                            type="function",
                            function=Function(
                                name=block.name,
                                arguments=block.input,
                            ),
                        )
                        for block in claude_response.content
                        if block.type == "tool_use"
                    ],
                ),
                finish_reason="tool_calls",
            )
        else:
            assert text_block, "Claude should always return a text block for stop_reason=stop"

            choice = Choices(
                message=Message(
                    role="assistant",
                    content=text_block.text,
                ),
                finish_reason="stop",
            )
```

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds support for Anthropic Claude model with new tool types, updates models, and fixes a bug in `execute_system.py`.
> 
>   - **Behavior**:
>     - Adds support for Anthropic Claude model with `computer_20241022`, `text_editor_20241022`, and `bash_20241022` tools in `prompt_step.py`.
>     - Handles tool use in Claude responses, raising an error if multiple messages are returned.
>   - **Models**:
>     - Adds `type` field to `Tool`, `CreateToolRequest`, `PatchToolRequest`, and `UpdateToolRequest` models.
>     - Updates `ToolType` enum to include new tool types.
>   - **Misc**:
>     - Fixes a bug in `execute_system.py` related to `delete` operation handling.
>     - Imports `AsyncAnthropic` in `prompt_step.py` for asynchronous API calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 5867ecb6f0760f7ced71b94d9d21b00ea0cb7115. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->