### PR TITLE
feat(agents-api): Add python expression support to prompt step

### DIFF
--- a/agents-api/agents_api/activities/execute_system.py
+++ b/agents-api/agents_api/activities/execute_system.py
@@ -15,7 +15,6 @@ from ..autogen.Docs import (
     VectorDocSearchRequest,
 )
 from ..autogen.Tools import SystemDef
-from ..common.protocol.developers import Developer
 from ..common.protocol.tasks import StepContext
 from ..common.storage_handler import auto_blob_store
 from ..env import testing

--- a/agents-api/agents_api/activities/task_steps/prompt_step.py
+++ b/agents-api/agents_api/activities/task_steps/prompt_step.py
@@ -19,6 +19,7 @@ from ...common.storage_handler import auto_blob_store
 from ...common.utils.template import render_template
 from ...env import anthropic_api_key, debug
 from ..utils import get_handler
+from .base_evaluate import base_evaluate
 
 COMPUTER_USE_BETA_FLAG = "computer-use-2024-10-22"
 
@@ -77,42 +78,66 @@ def format_tool(tool: Tool) -> dict:
     return formatted
 
 
+EVAL_PROMPT_PREFIX = "$_ "
+
+
 @activity.defn
 @auto_blob_store
 @beartype
 async def prompt_step(context: StepContext) -> StepOutcome:
     # Get context data
     prompt: str | list[dict] = context.current_step.model_dump()["prompt"]
-    context_data: dict = context.model_dump()
+    context_data: dict = context.model_dump(include_remote=True)
 
-    # Render template messages
-    prompt = await render_template(
-        prompt,
-        context_data,
-        skip_vars=["developer_id"],
+    # If the prompt is a string and starts with $_ then we need to evaluate it
+    should_evaluate_prompt = isinstance(prompt, str) and prompt.startswith(
+        EVAL_PROMPT_PREFIX
     )
+
+    if should_evaluate_prompt:
+        prompt = await base_evaluate(
+            prompt[len(EVAL_PROMPT_PREFIX) :].strip(), context_data
+        )
+
+        if not isinstance(prompt, (str, list)):
+            raise ApplicationError(
+                "Invalid prompt expression, expected a string or list"
+            )
+
+    # Wrap the prompt in a list if it is not already
+    prompt = (
+        prompt if isinstance(prompt, list) else [{"role": "user", "content": prompt}]
+    )
+
+    # Render template messages if we didn't evaluate the prompt
+    if not should_evaluate_prompt:
+        # Render template messages
+        prompt = await render_template(
+            prompt,
+            context_data,
+            skip_vars=["developer_id"],
+        )
+
     # Get settings and run llm
     agent_default_settings: dict = (
         context.execution_input.agent.default_settings.model_dump()
         if context.execution_input.agent.default_settings
         else {}
     )
+
     agent_model: str = (
         context.execution_input.agent.model
         if context.execution_input.agent.model
         else "gpt-4o"
     )
 
+    # Get passed settings
     if context.current_step.settings:
         passed_settings: dict = context.current_step.settings.model_dump(
             exclude_unset=True
         )
     else:
         passed_settings: dict = {}
-
-    # Wrap the prompt in a list if it is not already
-    if isinstance(prompt, str):
-        prompt = [{"role": "user", "content": prompt}]
 
     # Format tools for litellm
     formatted_tools = [format_tool(tool) for tool in context.tools]

--- a/agents-api/agents_api/autogen/Sessions.py
+++ b/agents-api/agents_api/autogen/Sessions.py
@@ -43,12 +43,10 @@ class CreateSessionRequest(BaseModel):
     """
     Action to start on context window overflow
     """
-    forward_tool_results: StrictBool | None = None
+    auto_run_tools: StrictBool = False
     """
-    Whether to forward the tool results to the model when available.
-    "true" => always forward
-    "false" => never forward
-    null => forward if applicable (default)
+    Whether to auto-run the tool and send the tool results to the model when available.
+    (default: false for sessions, true for tasks)
 
     If a tool call is made, the tool's output will be sent back to the model as the model's input.
     If a tool call is not made, the model's output will be returned as is.
@@ -80,12 +78,10 @@ class PatchSessionRequest(BaseModel):
     """
     Action to start on context window overflow
     """
-    forward_tool_results: StrictBool | None = None
+    auto_run_tools: StrictBool = False
     """
-    Whether to forward the tool results to the model when available.
-    "true" => always forward
-    "false" => never forward
-    null => forward if applicable (default)
+    Whether to auto-run the tool and send the tool results to the model when available.
+    (default: false for sessions, true for tasks)
 
     If a tool call is made, the tool's output will be sent back to the model as the model's input.
     If a tool call is not made, the model's output will be returned as is.
@@ -117,12 +113,10 @@ class Session(BaseModel):
     """
     Action to start on context window overflow
     """
-    forward_tool_results: StrictBool | None = None
+    auto_run_tools: StrictBool = False
     """
-    Whether to forward the tool results to the model when available.
-    "true" => always forward
-    "false" => never forward
-    null => forward if applicable (default)
+    Whether to auto-run the tool and send the tool results to the model when available.
+    (default: false for sessions, true for tasks)
 
     If a tool call is made, the tool's output will be sent back to the model as the model's input.
     If a tool call is not made, the model's output will be returned as is.
@@ -190,12 +184,10 @@ class UpdateSessionRequest(BaseModel):
     """
     Action to start on context window overflow
     """
-    forward_tool_results: StrictBool | None = None
+    auto_run_tools: StrictBool = False
     """
-    Whether to forward the tool results to the model when available.
-    "true" => always forward
-    "false" => never forward
-    null => forward if applicable (default)
+    Whether to auto-run the tool and send the tool results to the model when available.
+    (default: false for sessions, true for tasks)
 
     If a tool call is made, the tool's output will be sent back to the model as the model's input.
     If a tool call is not made, the model's output will be returned as is.
@@ -234,12 +226,10 @@ class CreateOrUpdateSessionRequest(CreateSessionRequest):
     """
     Action to start on context window overflow
     """
-    forward_tool_results: StrictBool | None = None
+    auto_run_tools: StrictBool = False
     """
-    Whether to forward the tool results to the model when available.
-    "true" => always forward
-    "false" => never forward
-    null => forward if applicable (default)
+    Whether to auto-run the tool and send the tool results to the model when available.
+    (default: false for sessions, true for tasks)
 
     If a tool call is made, the tool's output will be sent back to the model as the model's input.
     If a tool call is not made, the model's output will be returned as is.

--- a/agents-api/agents_api/autogen/Tasks.py
+++ b/agents-api/agents_api/autogen/Tasks.py
@@ -710,6 +710,10 @@ class PromptStep(BaseModel):
     If a tool call is made, the tool's output will be used as the model's input.
     If a tool call is not made, the model's output will be used as the next step's input.
     """
+    disable_cache: StrictBool = False
+    """
+    Whether to disable caching for the prompt step
+    """
 
 
 class PromptStepUpdateItem(BaseModel):
@@ -751,6 +755,10 @@ class PromptStepUpdateItem(BaseModel):
 
     If a tool call is made, the tool's output will be used as the model's input.
     If a tool call is not made, the model's output will be used as the next step's input.
+    """
+    disable_cache: StrictBool = False
+    """
+    Whether to disable caching for the prompt step
     """
 
 

--- a/agents-api/agents_api/autogen/Tasks.py
+++ b/agents-api/agents_api/autogen/Tasks.py
@@ -702,12 +702,10 @@ class PromptStep(BaseModel):
     """
     Whether to unwrap the output of the prompt step, equivalent to `response.choices[0].message.content`
     """
-    forward_tool_results: StrictBool | None = None
+    auto_run_tools: StrictBool = True
     """
-    Whether to forward the tool results to the model when available.
-    "true" => always forward
-    "false" => never forward
-    null => forward if applicable (default)
+    Whether to auto-run the tool and send the tool results to the model when available.
+    (default: true for prompt steps, false for sessions)
 
     If a tool call is made, the tool's output will be used as the model's input.
     If a tool call is not made, the model's output will be used as the next step's input.
@@ -746,12 +744,10 @@ class PromptStepUpdateItem(BaseModel):
     """
     Whether to unwrap the output of the prompt step, equivalent to `response.choices[0].message.content`
     """
-    forward_tool_results: StrictBool | None = None
+    auto_run_tools: StrictBool = True
     """
-    Whether to forward the tool results to the model when available.
-    "true" => always forward
-    "false" => never forward
-    null => forward if applicable (default)
+    Whether to auto-run the tool and send the tool results to the model when available.
+    (default: true for prompt steps, false for sessions)
 
     If a tool call is made, the tool's output will be used as the model's input.
     If a tool call is not made, the model's output will be used as the next step's input.

--- a/agents-api/agents_api/autogen/Tasks.py
+++ b/agents-api/agents_api/autogen/Tasks.py
@@ -686,7 +686,7 @@ class PromptStep(BaseModel):
     """
     The prompt to run
     """
-    tools: Literal["all"] | list[ToolRef | CreateToolRequest] = []
+    tools: Literal["all"] | list[ToolRef | CreateToolRequest] = "all"
     """
     The tools to use for the prompt
     """
@@ -728,7 +728,7 @@ class PromptStepUpdateItem(BaseModel):
     """
     The prompt to run
     """
-    tools: Literal["all"] | list[ToolRefUpdateItem | CreateToolRequest] = []
+    tools: Literal["all"] | list[ToolRefUpdateItem | CreateToolRequest] = "all"
     """
     The tools to use for the prompt
     """

--- a/agents-api/agents_api/autogen/Tools.py
+++ b/agents-api/agents_api/autogen/Tools.py
@@ -12,7 +12,6 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
-    RootModel,
     StrictBool,
 )
 

--- a/agents-api/agents_api/models/session/create_or_update_session.py
+++ b/agents-api/agents_api/models/session/create_or_update_session.py
@@ -53,7 +53,7 @@ def create_or_update_session(
     data: CreateOrUpdateSessionRequest,
 ) -> tuple[list[str], dict]:
     data.metadata = data.metadata or {}
-    session_data = data.model_dump()
+    session_data = data.model_dump(exclude={"auto_run_tools"})
 
     user = session_data.pop("user")
     agent = session_data.pop("agent")

--- a/agents-api/agents_api/models/session/create_or_update_session.py
+++ b/agents-api/agents_api/models/session/create_or_update_session.py
@@ -53,7 +53,7 @@ def create_or_update_session(
     data: CreateOrUpdateSessionRequest,
 ) -> tuple[list[str], dict]:
     data.metadata = data.metadata or {}
-    session_data = data.model_dump(exclude={"auto_run_tools"})
+    session_data = data.model_dump(exclude={"auto_run_tools", "disable_cache"})
 
     user = session_data.pop("user")
     agent = session_data.pop("agent")

--- a/agents-api/agents_api/models/session/create_session.py
+++ b/agents-api/agents_api/models/session/create_session.py
@@ -60,7 +60,7 @@ def create_session(
     session_id = session_id or uuid4()
 
     data.metadata = data.metadata or {}
-    session_data = data.model_dump()
+    session_data = data.model_dump(exclude={"auto_run_tools"})
 
     user = session_data.pop("user")
     agent = session_data.pop("agent")

--- a/agents-api/agents_api/models/session/create_session.py
+++ b/agents-api/agents_api/models/session/create_session.py
@@ -60,7 +60,7 @@ def create_session(
     session_id = session_id or uuid4()
 
     data.metadata = data.metadata or {}
-    session_data = data.model_dump(exclude={"auto_run_tools"})
+    session_data = data.model_dump(exclude={"auto_run_tools", "disable_cache"})
 
     user = session_data.pop("user")
     agent = session_data.pop("agent")

--- a/agents-api/agents_api/workflows/task_execution/__init__.py
+++ b/agents-api/agents_api/workflows/task_execution/__init__.py
@@ -404,7 +404,7 @@ class TaskExecutionWorkflow:
                 "finish_reason"
             ] == "tool_calls" and (tool_calls_input := choice["message"]["tool_calls"])[
                 0
-            ]["type"] == "function":
+            ]["type"] not in ["integration", "api_call", "system"]:
                 workflow.logger.debug("Prompt step: Received FUNCTION tool call")
 
                 # Enter a wait-for-input step to ask the developer to run the tool calls

--- a/agents-api/agents_api/workflows/task_execution/__init__.py
+++ b/agents-api/agents_api/workflows/task_execution/__init__.py
@@ -400,11 +400,11 @@ class TaskExecutionWorkflow:
 
             case PromptStep(auto_run_tools=True, unwrap=False), StepOutcome(
                 output=response
-            ) if (message := response["choices"][0]["message"])[
+            ) if (choice := response["choices"][0])[
                 "finish_reason"
-            ] == "tool_calls" and (tool_calls_input := message["tool_calls"])[0][
-                "type"
-            ] == "function":
+            ] == "tool_calls" and (tool_calls_input := choice["message"]["tool_calls"])[
+                0
+            ]["type"] == "function":
                 workflow.logger.debug("Prompt step: Received FUNCTION tool call")
 
                 # Enter a wait-for-input step to ask the developer to run the tool calls
@@ -430,11 +430,11 @@ class TaskExecutionWorkflow:
 
             case PromptStep(auto_run_tools=True, unwrap=False), StepOutcome(
                 output=response
-            ) if (message := response["choices"][0]["message"])[
+            ) if (choice := response["choices"][0])[
                 "finish_reason"
-            ] == "tool_calls" and (tool_calls_input := message["tool_calls"])[0][
-                "type"
-            ] == "integration":
+            ] == "tool_calls" and (tool_calls_input := choice["message"]["tool_calls"])[
+                0
+            ]["type"] == "integration":
                 workflow.logger.debug("Prompt step: Received INTEGRATION tool call")
 
                 # FIXME: Implement integration tool calls
@@ -445,11 +445,11 @@ class TaskExecutionWorkflow:
 
             case PromptStep(auto_run_tools=True, unwrap=False), StepOutcome(
                 output=response
-            ) if (message := response["choices"][0]["message"])[
+            ) if (choice := response["choices"][0])[
                 "finish_reason"
-            ] == "tool_calls" and (tool_calls_input := message["tool_calls"])[0][
-                "type"
-            ] == "api_call":
+            ] == "tool_calls" and (tool_calls_input := choice["message"]["tool_calls"])[
+                0
+            ]["type"] == "api_call":
                 workflow.logger.debug("Prompt step: Received API_CALL tool call")
 
                 # FIXME: Implement API_CALL tool calls
@@ -460,11 +460,11 @@ class TaskExecutionWorkflow:
 
             case PromptStep(auto_run_tools=True, unwrap=False), StepOutcome(
                 output=response
-            ) if (message := response["choices"][0]["message"])[
+            ) if (choice := response["choices"][0])[
                 "finish_reason"
-            ] == "tool_calls" and (tool_calls_input := message["tool_calls"])[0][
-                "type"
-            ] == "system":
+            ] == "tool_calls" and (tool_calls_input := choice["message"]["tool_calls"])[
+                0
+            ]["type"] == "system":
                 workflow.logger.debug("Prompt step: Received SYSTEM tool call")
 
                 # FIXME: Implement SYSTEM tool calls
@@ -474,9 +474,9 @@ class TaskExecutionWorkflow:
                 # TODO: Feed the tool call results back to the model (see above)
 
             case PromptStep(unwrap=False), StepOutcome(output=response) if (
-                message := response["choices"][0]["message"]
+                choice := response["choices"][0]
             )["finish_reason"] == "tool_calls" and (
-                tool_calls_input := message["tool_calls"]
+                tool_calls_input := choice["message"]["tool_calls"]
             )[0]["type"] not in ["function", "integration", "api_call", "system"]:
                 workflow.logger.debug(
                     f"Prompt step: Received unknown tool call: {tool_calls_input[0]['type']}"

--- a/agents-api/agents_api/workflows/task_execution/__init__.py
+++ b/agents-api/agents_api/workflows/task_execution/__init__.py
@@ -400,7 +400,7 @@ class TaskExecutionWorkflow:
 
             case PromptStep(auto_run_tools=True, unwrap=False), StepOutcome(
                 output=response
-            ) if (message := response["choices"][0])[
+            ) if (message := response["choices"][0]["message"])[
                 "finish_reason"
             ] == "tool_calls" and (tool_calls_input := message["tool_calls"])[0][
                 "type"
@@ -430,7 +430,7 @@ class TaskExecutionWorkflow:
 
             case PromptStep(auto_run_tools=True, unwrap=False), StepOutcome(
                 output=response
-            ) if (message := response["choices"][0])[
+            ) if (message := response["choices"][0]["message"])[
                 "finish_reason"
             ] == "tool_calls" and (tool_calls_input := message["tool_calls"])[0][
                 "type"
@@ -445,7 +445,7 @@ class TaskExecutionWorkflow:
 
             case PromptStep(auto_run_tools=True, unwrap=False), StepOutcome(
                 output=response
-            ) if (message := response["choices"][0])[
+            ) if (message := response["choices"][0]["message"])[
                 "finish_reason"
             ] == "tool_calls" and (tool_calls_input := message["tool_calls"])[0][
                 "type"
@@ -460,7 +460,7 @@ class TaskExecutionWorkflow:
 
             case PromptStep(auto_run_tools=True, unwrap=False), StepOutcome(
                 output=response
-            ) if (message := response["choices"][0])[
+            ) if (message := response["choices"][0]["message"])[
                 "finish_reason"
             ] == "tool_calls" and (tool_calls_input := message["tool_calls"])[0][
                 "type"
@@ -474,7 +474,7 @@ class TaskExecutionWorkflow:
                 # TODO: Feed the tool call results back to the model (see above)
 
             case PromptStep(unwrap=False), StepOutcome(output=response) if (
-                message := response["choices"][0]
+                message := response["choices"][0]["message"]
             )["finish_reason"] == "tool_calls" and (
                 tool_calls_input := message["tool_calls"]
             )[0]["type"] not in ["function", "integration", "api_call", "system"]:

--- a/agents-api/agents_api/workflows/task_execution/__init__.py
+++ b/agents-api/agents_api/workflows/task_execution/__init__.py
@@ -372,10 +372,23 @@ class TaskExecutionWorkflow:
                 state = PartialTransition(type="resume", output=result)
 
             case PromptStep(unwrap=True), StepOutcome(output=response):
+                finish_reason = response["choices"][0]["finish_reason"]
+                if finish_reason == "tool_calls":
+                    workflow.logger.error(
+                        "Prompt step: Tool calls not supported in unwrap mode"
+                    )
+
+                    state = PartialTransition(
+                        type="error", output="Tool calls not supported in unwrap mode"
+                    )
+                    await transition(context, state)
+
+                    raise ApplicationError("Tool calls not supported in unwrap mode")
+
                 workflow.logger.debug(f"Prompt step: Received response: {response}")
                 state = PartialTransition(output=response)
 
-            case PromptStep(forward_tool_results=False, unwrap=False), StepOutcome(
+            case PromptStep(auto_run_tools=False, unwrap=False), StepOutcome(
                 output=response
             ):
                 workflow.logger.debug(f"Prompt step: Received response: {response}")
@@ -387,12 +400,22 @@ class TaskExecutionWorkflow:
                 workflow.logger.debug(f"Prompt step: Received response: {response}")
                 state = PartialTransition(output=response)
 
-            case PromptStep(unwrap=False), StepOutcome(output=response) if response[
-                "choices"
-            ][0]["finish_reason"] == "tool_calls":
-                workflow.logger.debug("Prompt step: Received tool call")
-                message = response["choices"][0]["message"]
-                tool_calls_input = message["tool_calls"]
+            ## TODO: Handle multiple tool calls and multiple choices
+            # case PromptStep(unwrap=False), StepOutcome(output=response) if response[
+            #     "choices"
+            # ][0]["finish_reason"] == "tool_calls":
+            #     workflow.logger.debug("Prompt step: Received tool call")
+            #     message = response["choices"][0]["message"]
+            #     tool_calls_input = message["tool_calls"]
+
+            case PromptStep(auto_run_tools=True, unwrap=False), StepOutcome(
+                output=response
+            ) if (message := response["choices"][0])[
+                "finish_reason"
+            ] == "tool_calls" and (tool_calls_input := message["tool_calls"])[0][
+                "type"
+            ] == "function":
+                workflow.logger.debug("Prompt step: Received FUNCTION tool call")
 
                 # Enter a wait-for-input step to ask the developer to run the tool calls
                 tool_calls_results = await workflow.execute_activity(
@@ -414,6 +437,67 @@ class TaskExecutionWorkflow:
                     retry_policy=DEFAULT_RETRY_POLICY,
                 )
                 state = PartialTransition(output=new_response.output, type="resume")
+
+            case PromptStep(auto_run_tools=True, unwrap=False), StepOutcome(
+                output=response
+            ) if (message := response["choices"][0])[
+                "finish_reason"
+            ] == "tool_calls" and (tool_calls_input := message["tool_calls"])[0][
+                "type"
+            ] == "integration":
+                workflow.logger.debug("Prompt step: Received INTEGRATION tool call")
+
+                # FIXME: Implement integration tool calls
+                # See: MANUAL TOOL CALL INTEGRATION (below)
+                raise NotImplementedError("Integration tool calls not yet supported")
+
+                # TODO: Feed the tool call results back to the model (see above)
+
+            case PromptStep(auto_run_tools=True, unwrap=False), StepOutcome(
+                output=response
+            ) if (message := response["choices"][0])[
+                "finish_reason"
+            ] == "tool_calls" and (tool_calls_input := message["tool_calls"])[0][
+                "type"
+            ] == "api_call":
+                workflow.logger.debug("Prompt step: Received API_CALL tool call")
+
+                # FIXME: Implement API_CALL tool calls
+                # See: MANUAL TOOL CALL API_CALL (below)
+                raise NotImplementedError("API_CALL tool calls not yet supported")
+
+                # TODO: Feed the tool call results back to the model (see above)
+
+            case PromptStep(auto_run_tools=True, unwrap=False), StepOutcome(
+                output=response
+            ) if (message := response["choices"][0])[
+                "finish_reason"
+            ] == "tool_calls" and (tool_calls_input := message["tool_calls"])[0][
+                "type"
+            ] == "system":
+                workflow.logger.debug("Prompt step: Received SYSTEM tool call")
+
+                # FIXME: Implement SYSTEM tool calls
+                # See: MANUAL TOOL CALL SYSTEM (below)
+                raise NotImplementedError("SYSTEM tool calls not yet supported")
+
+                # TODO: Feed the tool call results back to the model (see above)
+
+            case PromptStep(unwrap=False), StepOutcome(output=response) if (
+                message := response["choices"][0]
+            )["finish_reason"] == "tool_calls" and (
+                tool_calls_input := message["tool_calls"]
+            )[0]["type"] not in ["function", "integration", "api_call", "system"]:
+                workflow.logger.debug(
+                    f"Prompt step: Received unknown tool call: {tool_calls_input[0]['type']}"
+                )
+                state = PartialTransition(output=response)
+
+            case SetStep(), StepOutcome(output=evaluated_output):
+                workflow.logger.info("Set step: Updating user state")
+
+            case SetStep(), StepOutcome(output=evaluated_output):
+                workflow.logger.info("Set step: Updating user state")
 
             case SetStep(), StepOutcome(output=evaluated_output):
                 workflow.logger.info("Set step: Updating user state")
@@ -452,6 +536,8 @@ class TaskExecutionWorkflow:
             case ToolCallStep(), StepOutcome(output=tool_call) if tool_call[
                 "type"
             ] == "integration":
+                # MANUAL TOOL CALL INTEGRATION
+                workflow.logger.debug("ToolCallStep: Received INTEGRATION tool call")
                 call = tool_call["integration"]
                 tool_name = call["name"]
                 arguments = call["arguments"]
@@ -490,6 +576,8 @@ class TaskExecutionWorkflow:
             case ToolCallStep(), StepOutcome(output=tool_call) if tool_call[
                 "type"
             ] == "api_call":
+                # MANUAL TOOL CALL API_CALL
+                workflow.logger.debug("ToolCallStep: Received API_CALL tool call")
                 call = tool_call["api_call"]
                 tool_name = call["name"]
                 arguments = call["arguments"]
@@ -528,6 +616,8 @@ class TaskExecutionWorkflow:
             case ToolCallStep(), StepOutcome(output=tool_call) if tool_call[
                 "type"
             ] == "system":
+                # MANUAL TOOL CALL SYSTEM
+                workflow.logger.debug("ToolCallStep: Received SYSTEM tool call")
                 call = tool_call.get("system")
 
                 system_call = SystemDef(**call)
@@ -545,12 +635,16 @@ class TaskExecutionWorkflow:
                 workflow.logger.error(
                     f"Unhandled step type: {type(context.current_step).__name__}"
                 )
+                state = PartialTransition(type="error", output="Not implemented")
+                await transition(context, state)
+
                 raise ApplicationError("Not implemented")
 
         # 4. Transition to the next step
         workflow.logger.info(f"Transitioning after step {context.cursor.step}")
 
         # The returned value is the transition finally created
+        state = state or PartialTransition(type="error", output="Not implemented")
         final_state = await transition(context, state)
 
         # ---

--- a/integrations-service/integrations/autogen/Sessions.py
+++ b/integrations-service/integrations/autogen/Sessions.py
@@ -43,12 +43,10 @@ class CreateSessionRequest(BaseModel):
     """
     Action to start on context window overflow
     """
-    forward_tool_results: StrictBool | None = None
+    auto_run_tools: StrictBool = False
     """
-    Whether to forward the tool results to the model when available.
-    "true" => always forward
-    "false" => never forward
-    null => forward if applicable (default)
+    Whether to auto-run the tool and send the tool results to the model when available.
+    (default: false for sessions, true for tasks)
 
     If a tool call is made, the tool's output will be sent back to the model as the model's input.
     If a tool call is not made, the model's output will be returned as is.
@@ -80,12 +78,10 @@ class PatchSessionRequest(BaseModel):
     """
     Action to start on context window overflow
     """
-    forward_tool_results: StrictBool | None = None
+    auto_run_tools: StrictBool = False
     """
-    Whether to forward the tool results to the model when available.
-    "true" => always forward
-    "false" => never forward
-    null => forward if applicable (default)
+    Whether to auto-run the tool and send the tool results to the model when available.
+    (default: false for sessions, true for tasks)
 
     If a tool call is made, the tool's output will be sent back to the model as the model's input.
     If a tool call is not made, the model's output will be returned as is.
@@ -117,12 +113,10 @@ class Session(BaseModel):
     """
     Action to start on context window overflow
     """
-    forward_tool_results: StrictBool | None = None
+    auto_run_tools: StrictBool = False
     """
-    Whether to forward the tool results to the model when available.
-    "true" => always forward
-    "false" => never forward
-    null => forward if applicable (default)
+    Whether to auto-run the tool and send the tool results to the model when available.
+    (default: false for sessions, true for tasks)
 
     If a tool call is made, the tool's output will be sent back to the model as the model's input.
     If a tool call is not made, the model's output will be returned as is.
@@ -190,12 +184,10 @@ class UpdateSessionRequest(BaseModel):
     """
     Action to start on context window overflow
     """
-    forward_tool_results: StrictBool | None = None
+    auto_run_tools: StrictBool = False
     """
-    Whether to forward the tool results to the model when available.
-    "true" => always forward
-    "false" => never forward
-    null => forward if applicable (default)
+    Whether to auto-run the tool and send the tool results to the model when available.
+    (default: false for sessions, true for tasks)
 
     If a tool call is made, the tool's output will be sent back to the model as the model's input.
     If a tool call is not made, the model's output will be returned as is.
@@ -234,12 +226,10 @@ class CreateOrUpdateSessionRequest(CreateSessionRequest):
     """
     Action to start on context window overflow
     """
-    forward_tool_results: StrictBool | None = None
+    auto_run_tools: StrictBool = False
     """
-    Whether to forward the tool results to the model when available.
-    "true" => always forward
-    "false" => never forward
-    null => forward if applicable (default)
+    Whether to auto-run the tool and send the tool results to the model when available.
+    (default: false for sessions, true for tasks)
 
     If a tool call is made, the tool's output will be sent back to the model as the model's input.
     If a tool call is not made, the model's output will be returned as is.

--- a/integrations-service/integrations/autogen/Tasks.py
+++ b/integrations-service/integrations/autogen/Tasks.py
@@ -710,6 +710,10 @@ class PromptStep(BaseModel):
     If a tool call is made, the tool's output will be used as the model's input.
     If a tool call is not made, the model's output will be used as the next step's input.
     """
+    disable_cache: StrictBool = False
+    """
+    Whether to disable caching for the prompt step
+    """
 
 
 class PromptStepUpdateItem(BaseModel):
@@ -751,6 +755,10 @@ class PromptStepUpdateItem(BaseModel):
 
     If a tool call is made, the tool's output will be used as the model's input.
     If a tool call is not made, the model's output will be used as the next step's input.
+    """
+    disable_cache: StrictBool = False
+    """
+    Whether to disable caching for the prompt step
     """
 
 

--- a/integrations-service/integrations/autogen/Tasks.py
+++ b/integrations-service/integrations/autogen/Tasks.py
@@ -702,12 +702,10 @@ class PromptStep(BaseModel):
     """
     Whether to unwrap the output of the prompt step, equivalent to `response.choices[0].message.content`
     """
-    forward_tool_results: StrictBool | None = None
+    auto_run_tools: StrictBool = True
     """
-    Whether to forward the tool results to the model when available.
-    "true" => always forward
-    "false" => never forward
-    null => forward if applicable (default)
+    Whether to auto-run the tool and send the tool results to the model when available.
+    (default: true for prompt steps, false for sessions)
 
     If a tool call is made, the tool's output will be used as the model's input.
     If a tool call is not made, the model's output will be used as the next step's input.
@@ -746,12 +744,10 @@ class PromptStepUpdateItem(BaseModel):
     """
     Whether to unwrap the output of the prompt step, equivalent to `response.choices[0].message.content`
     """
-    forward_tool_results: StrictBool | None = None
+    auto_run_tools: StrictBool = True
     """
-    Whether to forward the tool results to the model when available.
-    "true" => always forward
-    "false" => never forward
-    null => forward if applicable (default)
+    Whether to auto-run the tool and send the tool results to the model when available.
+    (default: true for prompt steps, false for sessions)
 
     If a tool call is made, the tool's output will be used as the model's input.
     If a tool call is not made, the model's output will be used as the next step's input.

--- a/integrations-service/integrations/autogen/Tasks.py
+++ b/integrations-service/integrations/autogen/Tasks.py
@@ -686,7 +686,7 @@ class PromptStep(BaseModel):
     """
     The prompt to run
     """
-    tools: Literal["all"] | list[ToolRef | CreateToolRequest] = []
+    tools: Literal["all"] | list[ToolRef | CreateToolRequest] = "all"
     """
     The tools to use for the prompt
     """
@@ -728,7 +728,7 @@ class PromptStepUpdateItem(BaseModel):
     """
     The prompt to run
     """
-    tools: Literal["all"] | list[ToolRefUpdateItem | CreateToolRequest] = []
+    tools: Literal["all"] | list[ToolRefUpdateItem | CreateToolRequest] = "all"
     """
     The tools to use for the prompt
     """

--- a/integrations-service/integrations/models/brave.py
+++ b/integrations-service/integrations/models/brave.py
@@ -1,5 +1,6 @@
 from typing import List
-from pydantic import Field, BaseModel
+
+from pydantic import BaseModel, Field
 
 from .base_models import BaseOutput
 

--- a/integrations-service/integrations/models/brave.py
+++ b/integrations-service/integrations/models/brave.py
@@ -9,5 +9,6 @@ class SearchResult(BaseModel):
     link: str
     snippet: str
 
+
 class BraveSearchOutput(BaseOutput):
     result: List[SearchResult] = Field(..., description="A list of search results")

--- a/integrations-service/integrations/utils/integrations/brave.py
+++ b/integrations-service/integrations/utils/integrations/brave.py
@@ -26,11 +26,10 @@ async def search(
     tool = BraveSearch.from_api_key(api_key=setup.api_key, search_kwargs={"count": 3})
 
     result = tool.run(arguments.query)
-    
+
     try:
         parsed_result = [SearchResult(**item) for item in json.loads(result)]
     except json.JSONDecodeError as e:
         raise ValueError("Malformed JSON response from Brave Search") from e
-    
 
     return BraveSearchOutput(result=parsed_result)

--- a/integrations-service/integrations/utils/integrations/brave.py
+++ b/integrations-service/integrations/utils/integrations/brave.py
@@ -1,7 +1,8 @@
+import json
+
 from beartype import beartype
 from langchain_community.tools import BraveSearch
 from tenacity import retry, stop_after_attempt, wait_exponential
-import json
 
 from ...autogen.Tools import BraveSearchArguments, BraveSearchSetup
 from ...models import BraveSearchOutput, SearchResult

--- a/typespec/sessions/models.tsp
+++ b/typespec/sessions/models.tsp
@@ -62,14 +62,12 @@ model Session {
     /** Action to start on context window overflow */
     context_overflow: ContextOverflowType | null = null;
 
-    /** Whether to forward the tool results to the model when available.
-     * "true" => always forward
-     * "false" => never forward
-     * null => forward if applicable (default)
+    /** Whether to auto-run the tool and send the tool results to the model when available.
+     * (default: false for sessions, true for tasks)
      * 
      * If a tool call is made, the tool's output will be sent back to the model as the model's input.
      * If a tool call is not made, the model's output will be returned as is. */
-    forward_tool_results: boolean | null = null;
+    auto_run_tools: boolean = false;
 
     ...HasId;
     ...HasMetadata;

--- a/typespec/tasks/steps.tsp
+++ b/typespec/tasks/steps.tsp
@@ -120,6 +120,9 @@ model PromptStepDef {
      * If a tool call is made, the tool's output will be used as the model's input.
      * If a tool call is not made, the model's output will be used as the next step's input. */
     auto_run_tools: boolean = true;
+
+    /** Whether to disable caching for the prompt step */
+    disable_cache: boolean = false;
 }
 
 model EvaluateStep extends BaseWorkflowStep<"evaluate"> {

--- a/typespec/tasks/steps.tsp
+++ b/typespec/tasks/steps.tsp
@@ -103,7 +103,7 @@ model PromptStepDef {
     prompt: JinjaTemplate | InputChatMLMessage<JinjaTemplate>[];
 
     /** The tools to use for the prompt */
-    tools: "all" | (ToolRef | CreateToolRequest)[] = #[];
+    tools: "all" | (ToolRef | CreateToolRequest)[] = "all";
 
     /** The tool choice for the prompt */
     tool_choice?: ToolChoiceOption;

--- a/typespec/tasks/steps.tsp
+++ b/typespec/tasks/steps.tsp
@@ -114,14 +114,12 @@ model PromptStepDef {
     /** Whether to unwrap the output of the prompt step, equivalent to `response.choices[0].message.content` */
     unwrap?: boolean = false;
 
-    /** Whether to forward the tool results to the model when available.
-     * "true" => always forward
-     * "false" => never forward
-     * null => forward if applicable (default)
-     * 
+    /** Whether to auto-run the tool and send the tool results to the model when available.
+     * (default: true for prompt steps, false for sessions)
+     *
      * If a tool call is made, the tool's output will be used as the model's input.
      * If a tool call is not made, the model's output will be used as the next step's input. */
-    forward_tool_results: boolean | null = null;
+    auto_run_tools: boolean = true;
 }
 
 model EvaluateStep extends BaseWorkflowStep<"evaluate"> {

--- a/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
+++ b/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
@@ -4845,7 +4845,7 @@ components:
                   - $ref: '#/components/schemas/Tasks.ToolRef'
                   - $ref: '#/components/schemas/Tools.CreateToolRequest'
           description: The tools to use for the prompt
-          default: []
+          default: all
         tool_choice:
           anyOf:
             - type: string
@@ -4976,7 +4976,7 @@ components:
                   - $ref: '#/components/schemas/Tasks.ToolRefUpdateItem'
                   - $ref: '#/components/schemas/Tools.CreateToolRequest'
           description: The tools to use for the prompt
-          default: []
+          default: all
         tool_choice:
           anyOf:
             - type: string

--- a/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
+++ b/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
@@ -3216,7 +3216,7 @@ components:
         - render_templates
         - token_budget
         - context_overflow
-        - forward_tool_results
+        - auto_run_tools
       properties:
         id:
           $ref: '#/components/schemas/Common.uuid'
@@ -3326,18 +3326,15 @@ components:
           nullable: true
           description: Action to start on context window overflow
           default: null
-        forward_tool_results:
+        auto_run_tools:
           type: boolean
-          nullable: true
           description: |-
-            Whether to forward the tool results to the model when available.
-            "true" => always forward
-            "false" => never forward
-            null => forward if applicable (default)
+            Whether to auto-run the tool and send the tool results to the model when available.
+            (default: false for sessions, true for tasks)
 
             If a tool call is made, the tool's output will be sent back to the model as the model's input.
             If a tool call is not made, the model's output will be returned as is.
-          default: null
+          default: false
         metadata:
           type: object
           additionalProperties: {}
@@ -3350,7 +3347,7 @@ components:
         - render_templates
         - token_budget
         - context_overflow
-        - forward_tool_results
+        - auto_run_tools
       properties:
         user:
           allOf:
@@ -3458,18 +3455,15 @@ components:
           nullable: true
           description: Action to start on context window overflow
           default: null
-        forward_tool_results:
+        auto_run_tools:
           type: boolean
-          nullable: true
           description: |-
-            Whether to forward the tool results to the model when available.
-            "true" => always forward
-            "false" => never forward
-            null => forward if applicable (default)
+            Whether to auto-run the tool and send the tool results to the model when available.
+            (default: false for sessions, true for tasks)
 
             If a tool call is made, the tool's output will be sent back to the model as the model's input.
             If a tool call is not made, the model's output will be returned as is.
-          default: null
+          default: false
         metadata:
           type: object
           additionalProperties: {}
@@ -3612,18 +3606,15 @@ components:
           nullable: true
           description: Action to start on context window overflow
           default: null
-        forward_tool_results:
+        auto_run_tools:
           type: boolean
-          nullable: true
           description: |-
-            Whether to forward the tool results to the model when available.
-            "true" => always forward
-            "false" => never forward
-            null => forward if applicable (default)
+            Whether to auto-run the tool and send the tool results to the model when available.
+            (default: false for sessions, true for tasks)
 
             If a tool call is made, the tool's output will be sent back to the model as the model's input.
             If a tool call is not made, the model's output will be returned as is.
-          default: null
+          default: false
         metadata:
           type: object
           additionalProperties: {}
@@ -3636,7 +3627,7 @@ components:
         - render_templates
         - token_budget
         - context_overflow
-        - forward_tool_results
+        - auto_run_tools
         - id
         - created_at
         - updated_at
@@ -3737,18 +3728,15 @@ components:
           nullable: true
           description: Action to start on context window overflow
           default: null
-        forward_tool_results:
+        auto_run_tools:
           type: boolean
-          nullable: true
           description: |-
-            Whether to forward the tool results to the model when available.
-            "true" => always forward
-            "false" => never forward
-            null => forward if applicable (default)
+            Whether to auto-run the tool and send the tool results to the model when available.
+            (default: false for sessions, true for tasks)
 
             If a tool call is made, the tool's output will be sent back to the model as the model's input.
             If a tool call is not made, the model's output will be returned as is.
-          default: null
+          default: false
         id:
           allOf:
             - $ref: '#/components/schemas/Common.uuid'
@@ -3821,7 +3809,7 @@ components:
         - render_templates
         - token_budget
         - context_overflow
-        - forward_tool_results
+        - auto_run_tools
       properties:
         situation:
           type: string
@@ -3913,18 +3901,15 @@ components:
           nullable: true
           description: Action to start on context window overflow
           default: null
-        forward_tool_results:
+        auto_run_tools:
           type: boolean
-          nullable: true
           description: |-
-            Whether to forward the tool results to the model when available.
-            "true" => always forward
-            "false" => never forward
-            null => forward if applicable (default)
+            Whether to auto-run the tool and send the tool results to the model when available.
+            (default: false for sessions, true for tasks)
 
             If a tool call is made, the tool's output will be sent back to the model as the model's input.
             If a tool call is not made, the model's output will be returned as is.
-          default: null
+          default: false
         metadata:
           type: object
           additionalProperties: {}
@@ -4771,7 +4756,7 @@ components:
         - kind_
         - prompt
         - tools
-        - forward_tool_results
+        - auto_run_tools
       properties:
         kind_:
           type: string
@@ -4877,18 +4862,15 @@ components:
           type: boolean
           description: Whether to unwrap the output of the prompt step, equivalent to `response.choices[0].message.content`
           default: false
-        forward_tool_results:
+        auto_run_tools:
           type: boolean
-          nullable: true
           description: |-
-            Whether to forward the tool results to the model when available.
-            "true" => always forward
-            "false" => never forward
-            null => forward if applicable (default)
+            Whether to auto-run the tool and send the tool results to the model when available.
+            (default: true for prompt steps, false for sessions)
 
             If a tool call is made, the tool's output will be used as the model's input.
             If a tool call is not made, the model's output will be used as the next step's input.
-          default: null
+          default: true
       allOf:
         - type: object
           required:
@@ -4911,7 +4893,7 @@ components:
       required:
         - prompt
         - tools
-        - forward_tool_results
+        - auto_run_tools
       properties:
         prompt:
           anyOf:
@@ -5011,18 +4993,15 @@ components:
           type: boolean
           description: Whether to unwrap the output of the prompt step, equivalent to `response.choices[0].message.content`
           default: false
-        forward_tool_results:
+        auto_run_tools:
           type: boolean
-          nullable: true
           description: |-
-            Whether to forward the tool results to the model when available.
-            "true" => always forward
-            "false" => never forward
-            null => forward if applicable (default)
+            Whether to auto-run the tool and send the tool results to the model when available.
+            (default: true for prompt steps, false for sessions)
 
             If a tool call is made, the tool's output will be used as the model's input.
             If a tool call is not made, the model's output will be used as the next step's input.
-          default: null
+          default: true
       allOf:
         - type: object
           properties:

--- a/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
+++ b/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
@@ -4757,6 +4757,7 @@ components:
         - prompt
         - tools
         - auto_run_tools
+        - disable_cache
       properties:
         kind_:
           type: string
@@ -4871,6 +4872,10 @@ components:
             If a tool call is made, the tool's output will be used as the model's input.
             If a tool call is not made, the model's output will be used as the next step's input.
           default: true
+        disable_cache:
+          type: boolean
+          description: Whether to disable caching for the prompt step
+          default: false
       allOf:
         - type: object
           required:
@@ -4894,6 +4899,7 @@ components:
         - prompt
         - tools
         - auto_run_tools
+        - disable_cache
       properties:
         prompt:
           anyOf:
@@ -5002,6 +5008,10 @@ components:
             If a tool call is made, the tool's output will be used as the model's input.
             If a tool call is not made, the model's output will be used as the next step's input.
           default: true
+        disable_cache:
+          type: boolean
+          description: Whether to disable caching for the prompt step
+          default: false
       allOf:
         - type: object
           properties:


### PR DESCRIPTION
- **wip(agents-api): Auto-run tools in prompt steps**
- **refactor: Lint integrations-service (CI)**
- **feat(agents-api): Add python expression support to prompt step**
- **feat(agents-api): Default prompt_step.tools = 'all'**

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add Python expression support to prompt steps in agents API, with default tool settings and refactoring.
> 
>   - **Behavior**:
>     - Add Python expression evaluation for prompts starting with `$_` in `prompt_step()` in `prompt_step.py`.
>     - Default `tools` in `PromptStep` to `'all'` in `Tasks.py`.
>     - Default `auto_run_tools` to `True` for `PromptStep` and `False` for sessions in `Sessions.py` and `Tasks.py`.
>   - **Refactoring**:
>     - Remove unused import `Developer` from `execute_system.py`.
>     - Remove unused import `RootModel` from `Tools.py`.
>     - Linting changes in `integrations-service`.
>   - **Testing**:
>     - Add test for prompt step with Python expression in `test_execution_workflow.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 42540832c612f541e595c3bc52ba53cf4c7bbe24. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->