### PR TITLE
fix: Use search_params.limit value instead of constant

### DIFF
--- a/agents-api/agents_api/autogen/Docs.py
+++ b/agents-api/agents_api/autogen/Docs.py
@@ -96,7 +96,7 @@ class DocReference(BaseModel):
     ID of the document
     """
     title: str | None = None
-    snippets: Annotated[list[Snippet], Field(min_length=1)]
+    snippet: Snippet
     distance: float | None = None
 
 

--- a/agents-api/agents_api/autogen/Tools.py
+++ b/agents-api/agents_api/autogen/Tools.py
@@ -12,6 +12,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    RootModel,
     StrictBool,
 )
 

--- a/agents-api/agents_api/models/docs/search_docs_by_embedding.py
+++ b/agents-api/agents_api/models/docs/search_docs_by_embedding.py
@@ -281,7 +281,7 @@ def search_docs_by_embedding(
             doc_id,
             owner_type,
             owner_id,
-            collect(snippet),
+            snippet,
             distance,
             title,
         ] := 
@@ -305,14 +305,14 @@ def search_docs_by_embedding(
             id,
             owner_type,
             owner_id,
-            snippets,
+            snippet,
             distance,
             title,
         ] := m[
             id,
             owner_type,
             owner_id,
-            snippets,
+            snippet,
             distance,
             title,
         ]

--- a/agents-api/agents_api/models/docs/search_docs_by_text.py
+++ b/agents-api/agents_api/models/docs/search_docs_by_text.py
@@ -136,7 +136,7 @@ def search_docs_by_text(
 
         m[
             doc_id,
-            collect(snippet),
+            snippet,
             distance,
             title,
             owner_type,
@@ -164,7 +164,7 @@ def search_docs_by_text(
             id,
             owner_type,
             owner_id,
-            snippets,
+            snippet,
             distance,
             title,
         ] := 
@@ -172,7 +172,7 @@ def search_docs_by_text(
             input[owner_type, owner_id],
             m[
                 id,
-                snippets,
+                snippet,
                 distance,
                 title,
                 owner_type,

--- a/agents-api/agents_api/routers/docs/search_docs.py
+++ b/agents-api/agents_api/routers/docs/search_docs.py
@@ -89,15 +89,15 @@ async def search_user_docs(
         **params,
     )
 
-    k = 3
-
     if (
         not isinstance(search_params, TextOnlyDocSearchRequest)
         and search_params.mmr_strength > 0
-        and len(docs) > k
+        and len(docs) > search_params.limit
     ):
         indices = maximal_marginal_relevance(
-            params["query_embedding"], [doc.embedding for doc in docs], k=k
+            params["query_embedding"],
+            [doc.embedding for doc in docs],
+            k=search_params.limit,
         )
         docs = [doc for i, doc in enumerate(docs) if i in set(indices)]
 
@@ -128,15 +128,15 @@ async def search_agent_docs(
         **params,
     )
 
-    k = 3
-
     if (
         not isinstance(search_params, TextOnlyDocSearchRequest)
         and search_params.mmr_strength > 0
-        and len(docs) > k
+        and len(docs) > search_params.limit
     ):
         indices = maximal_marginal_relevance(
-            params["query_embedding"], [doc.embedding for doc in docs], k=k
+            params["query_embedding"],
+            [doc.embedding for doc in docs],
+            k=search_params.limit,
         )
         docs = [doc for i, doc in enumerate(docs) if i in set(indices)]
 

--- a/agents-api/agents_api/routers/sessions/chat.py
+++ b/agents-api/agents_api/routers/sessions/chat.py
@@ -62,7 +62,7 @@ async def chat(
     env["docs"] = [
         dict(
             title=ref.title,
-            content=[snippet.content for snippet in ref.snippets],
+            content=[ref.snippet.content],
         )
         for ref in doc_references
     ]

--- a/integrations-service/integrations/autogen/Docs.py
+++ b/integrations-service/integrations/autogen/Docs.py
@@ -96,7 +96,7 @@ class DocReference(BaseModel):
     ID of the document
     """
     title: str | None = None
-    snippets: Annotated[list[Snippet], Field(min_length=1)]
+    snippet: Snippet
     distance: float | None = None
 
 

--- a/typespec/docs/models.tsp
+++ b/typespec/docs/models.tsp
@@ -57,9 +57,8 @@ model DocReference {
     id: Doc.id;
 
     title?: string;
-    
-    @minItems(1)
-    snippets: Snippet[];
+
+    snippet: Snippet;
     distance: float | null = null;
 }
 

--- a/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
+++ b/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
@@ -2561,7 +2561,7 @@ components:
       required:
         - owner
         - id
-        - snippets
+        - snippet
         - distance
       properties:
         owner:
@@ -2575,11 +2575,8 @@ components:
           description: ID of the document
         title:
           type: string
-        snippets:
-          type: array
-          items:
-            $ref: '#/components/schemas/Docs.Snippet'
-          minItems: 1
+        snippet:
+          $ref: '#/components/schemas/Docs.Snippet'
         distance:
           type: number
           nullable: true


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Replaced constant `k` with `search_params.limit` for dynamic document processing in search functions and updated models.
> 
>   - **Behavior**:
>     - Replace constant `k` with `search_params.limit` in `search_user_docs()` and `search_agent_docs()` for `maximal_marginal_relevance()` call.
>     - Allows dynamic control over document processing based on `search_params.limit`.
>   - **Functions**:
>     - Affects `search_user_docs()` and `search_agent_docs()` in `search_docs.py`.
>   - **Models**:
>     - Change `snippets` to `snippet` in `DocReference` in `Docs.py` and `models.tsp`.
>   - **Misc**:
>     - Add `RootModel` import in `Tools.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 4c47490d2b380d6d5fa1e01fca65bb6f88f8ae76. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->