### PR TITLE
feat(agents-api): prompt step claude hotfix for tools

### DIFF
--- a/agents-api/agents_api/activities/task_steps/prompt_step.py
+++ b/agents-api/agents_api/activities/task_steps/prompt_step.py
@@ -164,8 +164,10 @@ async def prompt_step(context: StepContext) -> StepOutcome:
 
         # Filter tools for specific types
         filtered_tools = [
-            tool for tool in formatted_tools
-            if tool["type"] in ["computer_20241022", "bash_20241022", "text_editor_20241022"]
+            tool
+            for tool in formatted_tools
+            if tool["type"]
+            in ["computer_20241022", "bash_20241022", "text_editor_20241022"]
         ]
 
         # Claude Response

--- a/agents-api/agents_api/activities/task_steps/prompt_step.py
+++ b/agents-api/agents_api/activities/task_steps/prompt_step.py
@@ -162,11 +162,17 @@ async def prompt_step(context: StepContext) -> StepOutcome:
         # Anthropic expects a list of messages with role and content (and no name etc)
         prompt = [{"role": "user", "content": message["content"]} for message in prompt]
 
+        # Filter tools for specific types
+        filtered_tools = [
+            tool for tool in formatted_tools
+            if tool["type"] in ["computer_20241022", "bash_20241022", "text_editor_20241022"]
+        ]
+
         # Claude Response
         claude_response: BetaMessage = await client.beta.messages.create(
             model="claude-3-5-sonnet-20241022",
             messages=prompt,
-            tools=formatted_tools,
+            tools=filtered_tools,
             max_tokens=1024,
             betas=betas,
         )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Filters tools in `prompt_step()` to specific types before passing to Claude API in `prompt_step.py`.
> 
>   - **Behavior**:
>     - In `prompt_step()` in `prompt_step.py`, filters `formatted_tools` to include only `computer_20241022`, `bash_20241022`, and `text_editor_20241022` types before passing to Claude API.
>     - Ensures only these tool types are used in Claude API calls, potentially affecting tool usage in responses.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 355c9709f89ff95e74f4e9864c9f487ad48de3ab. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->