### PR TITLE
feat(agents-api): Improve error reporting for ValidationError on union types

### DIFF
--- a/agents-api/agents_api/web.py
+++ b/agents-api/agents_api/web.py
@@ -16,6 +16,7 @@ from fastapi.responses import JSONResponse
 from litellm.exceptions import APIError
 from prometheus_fastapi_instrumentator import Instrumentator
 from pycozo.client import QueryException
+from pydantic import ValidationError
 from scalar_fastapi import get_scalar_api_reference
 from temporalio.service import RPCError
 
@@ -45,22 +46,67 @@ else:
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-def make_exception_handler(status: int) -> Callable[[Any, Any], Any]:
+def make_exception_handler(status_code: int) -> Callable[[Any, Any], Any]:
     """
     Creates a custom exception handler for the application.
 
     Parameters:
-    - status (int): The HTTP status code to return for this exception.
+    - status_code (int): The HTTP status code to return for this exception.
 
     Returns:
     A callable exception handler that logs the exception and returns a JSON response with the specified status code.
     """
 
-    async def _handler(request: Request, exc):
-        exc_str = f"{exc}".replace("\n", " ").replace("   ", " ")
-        logger.exception(exc)
-        content = {"status_code": status, "message": exc_str, "data": None}
-        return JSONResponse(content=content, status_code=status)
+    async def _handler(request: Request, exc: Exception):
+        errors = exc.errors() if hasattr(exc, "errors") else [exc]
+        location = None
+        offending_input = None
+
+        # Return the deepest matching possibility
+        if isinstance(exc, (ValidationError, RequestValidationError)):
+            # Get the deepest matching errors
+            max_depth = max(len(error["loc"]) for error in errors)
+            errors = [
+                error for error in errors if len(error["loc"]) == max_depth
+            ]
+
+            # Get the common location
+            location = errors[0]["loc"]
+            for error in errors[1:]:
+                for a, b in zip(location, error["loc"]):
+                    if a == b:
+                        continue
+                    location = location[:-1]
+                    break
+
+            location = location[1:]  # Skip the first element ("body")
+
+            # Get the part of the input that caused the error
+            offending_input = exc.body
+            for loc in location:
+                match offending_input:
+                    case dict():
+                        if loc not in offending_input:
+                            break
+                    case list():
+                        if not (isinstance(loc, int) and 0 <= loc < len(offending_input)):
+                            break
+                    case _:
+                        break
+
+                offending_input = offending_input[loc]
+
+            # Keep only the message from the error
+            errors = [error["msg"] for error in errors]
+
+        return JSONResponse(
+            content={
+                "errors": errors,
+                "offending_input": offending_input,
+                "location": location,
+            },
+            status_code=status_code,
+        )
 
     return _handler
 

--- a/agents-api/agents_api/web.py
+++ b/agents-api/agents_api/web.py
@@ -66,9 +66,7 @@ def make_exception_handler(status_code: int) -> Callable[[Any, Any], Any]:
         if isinstance(exc, (ValidationError, RequestValidationError)):
             # Get the deepest matching errors
             max_depth = max(len(error["loc"]) for error in errors)
-            errors = [
-                error for error in errors if len(error["loc"]) == max_depth
-            ]
+            errors = [error for error in errors if len(error["loc"]) == max_depth]
 
             # Get the common location
             location = errors[0]["loc"]
@@ -89,7 +87,9 @@ def make_exception_handler(status_code: int) -> Callable[[Any, Any], Any]:
                         if loc not in offending_input:
                             break
                     case list():
-                        if not (isinstance(loc, int) and 0 <= loc < len(offending_input)):
+                        if not (
+                            isinstance(loc, int) and 0 <= loc < len(offending_input)
+                        ):
                             break
                     case _:
                         break

--- a/agents-api/agents_api/web.py
+++ b/agents-api/agents_api/web.py
@@ -58,14 +58,13 @@ def make_exception_handler(status_code: int) -> Callable[[Any, Any], Any]:
     """
 
     async def _handler(request: Request, exc: Exception):
-
         location = None
         offending_input = None
 
         # Return the deepest matching possibility
         if isinstance(exc, (ValidationError, RequestValidationError)):
             errors = exc.errors()
-            
+
             # Get the deepest matching errors
             max_depth = max(len(error["loc"]) for error in errors)
             errors = [error for error in errors if len(error["loc"]) == max_depth]
@@ -97,7 +96,7 @@ def make_exception_handler(status_code: int) -> Callable[[Any, Any], Any]:
                         break
 
                 offending_input = offending_input[loc]
-                
+
                 # Keep only the message from the error
                 errors = [error.get("msg", error) for error in errors]
 


### PR DESCRIPTION
Previously, the error messages on validation errors were horrendous. The following input would have yielded a huge, unreadable mess as an error message. This happened because we make heavy use of union types and pydantic tries to unify each type and collects the error for each one of them. Fixed by returning only the deepest matching exceptions.

### Input

```yaml
name: Browserbase Task

tools:
- name: computer
  type: computer_20241022
  computer_20241022:
    display_height_px: 768
    display_width_px: 1024
    display_number: 1

- name: spider_crawler
  type: integration
  integration:
    provider: spider
    setup:
      spider_api_key: "sk-8d6285a0-7b9f-493d-bcf4-3e15e68b1304"

main:

- tool: spider_crawler
  arguments:
    url: "'https://julep.ai'"
- prompt:
    - role: useaar                    # <---- the problem
      content: hi
```

### New error format

```python
{'errors': ["Input should be 'user', 'assistant', 'system', 'function', 'function_response', 'function_call' or 'auto'"], 'offending_input': {'prompt': [{'role': 'useaar', 'content': 'hi'}]}, 'location': ['main', 1, 'PromptStep', 'prompt', 'list[PromptItem]', 0, 'role']}
```

```json
{
    "errors": [
        "Input should be 'user', 'assistant', 'system', 'function', 'function_response', 'function_call' or 'auto'"
    ],
    "offending_input": {
        "prompt": [
            {
                "role": "useaar",
                "content": "hi"
            }
        ]
    },
    "location": [
        "main",
        1,
        "PromptStep",
        "prompt",
        "list[PromptItem]",
        0,
        "role"
    ]
}
```

### Previous error format

```python
[{'type': 'missing', 'loc': ('body', 'main', 1, 'EvaluateStep', 'evaluate'), 'msg': 'Field required', 'input': {'prompt': [{'role': 'useaar', 'content': 'hi'}]}}, {'type': 'missing', 'loc': ('body', 'main', 1, 'ToolCallStep', 'tool'), 'msg': 'Field required', 'input': {'prompt': [{'role': 'useaar', 'content': 'hi'}]}}, {'type': 'literal_error', 'loc': ('body', 'main', 1, 'PromptStep', 'prompt', 'list[PromptItem]', 0, 'role'), 'msg': "Input should be 'user', 'assistant', 'system', 'function', 'function_response', 'function_call' or 'auto'", 'input': 'useaar', 'ctx': {'expected': "'user', 'assistant', 'system', 'function', 'function_response', 'function_call' or 'auto'"}}, {'type': 'string_type', 'loc': ('body', 'main', 1, 'PromptStep', 'prompt', 'str'), 'msg': 'Input should be a valid string', 'input': [{'role': 'useaar', 'content': 'hi'}]}, {'type': 'missing', 'loc': ('body', 'main', 1, 'GetStep', 'get'), 'msg': 'Field required', 'input': {'prompt': [{'role': 'useaar', 'content': 'hi'}]}}, {'type': 'missing', 'loc': ('body', 'main', 1, 'SetStep', 'set'), 'msg': 'Field required', 'input': {'prompt': [{'role': 'useaar', 'content': 'hi'}]}}, {'type': 'missing', 'loc': ('body', 'main', 1, 'LogStep', 'log'), 'msg': 'Field required', 'input': {'prompt': [{'role': 'useaar', 'content': 'hi'}]}}, {'type': 'missing', 'loc': ('body', 'main', 1, 'YieldStep', 'workflow'), 'msg': 'Field required', 'input': {'prompt': [{'role': 'useaar', 'content': 'hi'}]}}, {'type': 'missing', 'loc': ('body', 'main', 1, 'ReturnStep', 'return'), 'msg': 'Field required', 'input': {'prompt': [{'role': 'useaar', 'content': 'hi'}]}}, {'type': 'missing', 'loc': ('body', 'main', 1, 'SleepStep', 'sleep'), 'msg': 'Field required', 'input': {'prompt': [{'role': 'useaar', 'content': 'hi'}]}}, {'type': 'missing', 'loc': ('body', 'main', 1, 'ErrorWorkflowStep', 'error'), 'msg': 'Field required', 'input': {'prompt': [{'role': 'useaar', 'content': 'hi'}]}}, {'type': 'missing', 'loc': ('body', 'main', 1, 'WaitForInputStep', 'wait_for_input'), 'msg': 'Field required', 'input': {'prompt': [{'role': 'useaar', 'content': 'hi'}]}}, {'type': 'missing', 'loc': ('body', 'main', 1, 'IfElseWorkflowStep', 'if'), 'msg': 'Field required', 'input': {'prompt': [{'role': 'useaar', 'content': 'hi'}]}}, {'type': 'missing', 'loc': ('body', 'main', 1, 'IfElseWorkflowStep', 'then'), 'msg': 'Field required', 'input': {'prompt': [{'role': 'useaar', 'content': 'hi'}]}}, {'type': 'missing', 'loc': ('body', 'main', 1, 'SwitchStep', 'switch'), 'msg': 'Field required', 'input': {'prompt': [{'role': 'useaar', 'content': 'hi'}]}}, {'type': 'missing', 'loc': ('body', 'main', 1, 'ForeachStep', 'foreach'), 'msg': 'Field required', 'input': {'prompt': [{'role': 'useaar', 'content': 'hi'}]}}, {'type': 'missing', 'loc': ('body', 'main', 1, 'ParallelStep', 'parallel'), 'msg': 'Field required', 'input': {'prompt': [{'role': 'useaar', 'content': 'hi'}]}}, {'type': 'missing', 'loc': ('body', 'main', 1, 'Main', 'over'), 'msg': 'Field required', 'input': {'prompt': [{'role': 'useaar', 'content': 'hi'}]}}, {'type': 'missing', 'loc': ('body', 'main', 1, 'Main', 'map'), 'msg': 'Field required', 'input': {'prompt': [{'role': 'useaar', 'content': 'hi'}]}}]
```

```json
[
    {
        "type": "missing",
        "loc": [
            "body",
            "main",
            1,
            "EvaluateStep",
            "evaluate"
        ],
        "msg": "Field required",
        "input": {
            "prompt": [
                {
                    "role": "useaar",
                    "content": "hi"
                }
            ]
        }
    },
    {
        "type": "missing",
        "loc": [
            "body",
            "main",
            1,
            "ToolCallStep",
            "tool"
        ],
        "msg": "Field required",
        "input": {
            "prompt": [
                {
                    "role": "useaar",
                    "content": "hi"
                }
            ]
        }
    },
    {
        "type": "literal_error",
        "loc": [
            "body",
            "main",
            1,
            "PromptStep",
            "prompt",
            "list[PromptItem]",
            0,
            "role"
        ],
        "msg": "Input should be 'user', 'assistant', 'system', 'function', 'function_response', 'function_call' or 'auto'",
        "input": "useaar",
        "ctx": {
            "expected": "'user', 'assistant', 'system', 'function', 'function_response', 'function_call' or 'auto'"
        }
    },
    {
        "type": "string_type",
        "loc": [
            "body",
            "main",
            1,
            "PromptStep",
            "prompt",
            "str"
        ],
        "msg": "Input should be a valid string",
        "input": [
            {
                "role": "useaar",
                "content": "hi"
            }
        ]
    },
    {
        "type": "missing",
        "loc": [
            "body",
            "main",
            1,
            "GetStep",
            "get"
        ],
        "msg": "Field required",
        "input": {
            "prompt": [
                {
                    "role": "useaar",
                    "content": "hi"
                }
            ]
        }
    },
    {
        "type": "missing",
        "loc": [
            "body",
            "main",
            1,
            "SetStep",
            "set"
        ],
        "msg": "Field required",
        "input": {
            "prompt": [
                {
                    "role": "useaar",
                    "content": "hi"
                }
            ]
        }
    },
    {
        "type": "missing",
        "loc": [
            "body",
            "main",
            1,
            "LogStep",
            "log"
        ],
        "msg": "Field required",
        "input": {
            "prompt": [
                {
                    "role": "useaar",
                    "content": "hi"
                }
            ]
        }
    },
    {
        "type": "missing",
        "loc": [
            "body",
            "main",
            1,
            "YieldStep",
            "workflow"
        ],
        "msg": "Field required",
        "input": {
            "prompt": [
                {
                    "role": "useaar",
                    "content": "hi"
                }
            ]
        }
    },
    {
        "type": "missing",
        "loc": [
            "body",
            "main",
            1,
            "ReturnStep",
            "return"
        ],
        "msg": "Field required",
        "input": {
            "prompt": [
                {
                    "role": "useaar",
                    "content": "hi"
                }
            ]
        }
    },
    {
        "type": "missing",
        "loc": [
            "body",
            "main",
            1,
            "SleepStep",
            "sleep"
        ],
        "msg": "Field required",
        "input": {
            "prompt": [
                {
                    "role": "useaar",
                    "content": "hi"
                }
            ]
        }
    },
    {
        "type": "missing",
        "loc": [
            "body",
            "main",
            1,
            "ErrorWorkflowStep",
            "error"
        ],
        "msg": "Field required",
        "input": {
            "prompt": [
                {
                    "role": "useaar",
                    "content": "hi"
                }
            ]
        }
    },
    {
        "type": "missing",
        "loc": [
            "body",
            "main",
            1,
            "WaitForInputStep",
            "wait_for_input"
        ],
        "msg": "Field required",
        "input": {
            "prompt": [
                {
                    "role": "useaar",
                    "content": "hi"
                }
            ]
        }
    },
    {
        "type": "missing",
        "loc": [
            "body",
            "main",
            1,
            "IfElseWorkflowStep",
            "if"
        ],
        "msg": "Field required",
        "input": {
            "prompt": [
                {
                    "role": "useaar",
                    "content": "hi"
                }
            ]
        }
    },
    {
        "type": "missing",
        "loc": [
            "body",
            "main",
            1,
            "IfElseWorkflowStep",
            "then"
        ],
        "msg": "Field required",
        "input": {
            "prompt": [
                {
                    "role": "useaar",
                    "content": "hi"
                }
            ]
        }
    },
    {
        "type": "missing",
        "loc": [
            "body",
            "main",
            1,
            "SwitchStep",
            "switch"
        ],
        "msg": "Field required",
        "input": {
            "prompt": [
                {
                    "role": "useaar",
                    "content": "hi"
                }
            ]
        }
    },
    {
        "type": "missing",
        "loc": [
            "body",
            "main",
            1,
            "ForeachStep",
            "foreach"
        ],
        "msg": "Field required",
        "input": {
            "prompt": [
                {
                    "role": "useaar",
                    "content": "hi"
                }
            ]
        }
    },
    {
        "type": "missing",
        "loc": [
            "body",
            "main",
            1,
            "ParallelStep",
            "parallel"
        ],
        "msg": "Field required",
        "input": {
            "prompt": [
                {
                    "role": "useaar",
                    "content": "hi"
                }
            ]
        }
    },
    {
        "type": "missing",
        "loc": [
            "body",
            "main",
            1,
            "Main",
            "over"
        ],
        "msg": "Field required",
        "input": {
            "prompt": [
                {
                    "role": "useaar",
                    "content": "hi"
                }
            ]
        }
    },
    {
        "type": "missing",
        "loc": [
            "body",
            "main",
            1,
            "Main",
            "map"
        ],
        "msg": "Field required",
        "input": {
            "prompt": [
                {
                    "role": "useaar",
                    "content": "hi"
                }
            ]
        }
    }
]
```

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance error reporting for `ValidationError` and `RequestValidationError` in `make_exception_handler` by providing detailed error information.
> 
>   - **Error Handling**:
>     - Enhance `make_exception_handler` in `web.py` to improve error reporting for `ValidationError` and `RequestValidationError`.
>     - Extracts deepest matching errors, common location, and offending input for better clarity.
>     - Returns only the error messages in the response.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 5292f57215413df342c92218a4a5c3f1d08d8a6e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->