### PR TITLE
fix(agents-api): prompt step tool calls

### DIFF
--- a/agents-api/agents_api/activities/task_steps/prompt_step.py
+++ b/agents-api/agents_api/activities/task_steps/prompt_step.py
@@ -248,6 +248,8 @@ async def prompt_step(context: StepContext) -> StepOutcome:
         )
 
     else:
+        # FIXME: hardcoded tool to a None value as the tool calls are not implemented yet
+        formatted_tools = None
         # Use litellm for other models
         completion_data: dict = {
             "model": agent_model,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `prompt_step`, set `formatted_tools` to `None` for non-Anthropic models as tool calls are not implemented.
> 
>   - **Behavior**:
>     - In `prompt_step`, set `formatted_tools` to `None` for non-Anthropic models as tool calls are not implemented.
>   - **Comments**:
>     - Added FIXME comment indicating the hardcoded `None` value for `formatted_tools` due to unimplemented tool calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 366b8455dbac0b56e32558b38c7e270bcf66e679. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->