### PR TITLE
feat(agents-api): Add ``metadata`` field to ``DocReference`` and retrieve it in the query

### DIFF
--- a/agents-api/agents_api/autogen/Docs.py
+++ b/agents-api/agents_api/autogen/Docs.py
@@ -87,6 +87,7 @@ class DocReference(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
     )
+    metadata: dict[str, Any] | None = None
     owner: DocOwner
     """
     The owner of this document.

--- a/agents-api/agents_api/autogen/Tools.py
+++ b/agents-api/agents_api/autogen/Tools.py
@@ -12,6 +12,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    RootModel,
     StrictBool,
 )
 

--- a/agents-api/agents_api/models/docs/search_docs_by_embedding.py
+++ b/agents-api/agents_api/models/docs/search_docs_by_embedding.py
@@ -136,6 +136,7 @@ def search_docs_by_embedding(
                 content,
                 distance,
                 embedding,
+                metadata,
             ] :=
                 # Get input values
                 input[owner_type, owner_id, query],
@@ -146,6 +147,7 @@ def search_docs_by_embedding(
                     owner_id,
                     doc_id,
                     title,
+                    metadata,
                 }},
 
                 # Search for snippets in the embedding space
@@ -169,6 +171,7 @@ def search_docs_by_embedding(
                 content,
                 distance,
                 embedding,
+                metadata,
             }}
         }}
 
@@ -191,6 +194,7 @@ def search_docs_by_embedding(
                 content,
                 distance,
                 embedding,
+                metadata,
             ] :=
                 # Get input values
                 input[owner_type, owner_id, query],
@@ -201,6 +205,7 @@ def search_docs_by_embedding(
                     owner_id,
                     doc_id,
                     title,
+                    metadata,
                 }},
 
                 # Search for snippets in the embedding space
@@ -223,6 +228,7 @@ def search_docs_by_embedding(
                 content,
                 distance,
                 embedding,
+                metadata,
             }}
         }}
         %end
@@ -239,10 +245,11 @@ def search_docs_by_embedding(
             distance,
             title,
             embedding,
+            metadata,
         ] := 
             owners[owner_type, owner_id_str],
             owner_id = to_uuid(owner_id_str),
-            *_search_result{{ doc_id, index, title, content, distance, embedding, }},
+            *_search_result{{ doc_id, index, title, content, distance, embedding, metadata }},
             snippet_data = [index, content]
 
         :limit {k}   # Get more candidates for diversity
@@ -255,6 +262,7 @@ def search_docs_by_embedding(
             distance,
             title,
             embedding,
+            metadata,
         }}
     """
 
@@ -267,6 +275,7 @@ def search_docs_by_embedding(
             distance,
             title,
             embedding,
+            metadata,
         ] := 
             *_interim {
                 owner_type,
@@ -276,6 +285,7 @@ def search_docs_by_embedding(
                 distance,
                 title,
                 embedding,
+                metadata,
             }
 
         m[
@@ -285,6 +295,7 @@ def search_docs_by_embedding(
             snippet,
             distance,
             title,
+            metadata,
         ] := 
             n[
                 doc_id,
@@ -294,6 +305,7 @@ def search_docs_by_embedding(
                 distance,
                 title,
                 embedding,
+                metadata,
             ],
             snippet = {
                 "index": snippet_datum->0,
@@ -309,6 +321,7 @@ def search_docs_by_embedding(
             snippet,
             distance,
             title,
+            metadata,
         ] := m[
             id,
             owner_type,
@@ -316,6 +329,7 @@ def search_docs_by_embedding(
             snippet,
             distance,
             title,
+            metadata,
         ]
     """
 

--- a/agents-api/agents_api/models/docs/search_docs_by_embedding.py
+++ b/agents-api/agents_api/models/docs/search_docs_by_embedding.py
@@ -37,6 +37,7 @@ T = TypeVar("T")
             "id": d["owner_id"],
             "role": d["owner_type"],
         },
+        "metadata": d.get("metadata", {}),
         **d,
     },
 )

--- a/agents-api/agents_api/models/docs/search_docs_by_text.py
+++ b/agents-api/agents_api/models/docs/search_docs_by_text.py
@@ -142,6 +142,7 @@ def search_docs_by_text(
             title,
             owner_type,
             owner_id,
+            metadata,
         ] :=
             candidate[doc_id],
             *docs {{
@@ -149,6 +150,7 @@ def search_docs_by_text(
                 owner_id,
                 doc_id,
                 title,
+                metadata,
             }},
             search_result [
                 doc_id,
@@ -168,6 +170,7 @@ def search_docs_by_text(
             snippet,
             distance,
             title,
+            metadata,
         ] := 
             candidate[id],
             input[owner_type, owner_id],
@@ -178,6 +181,7 @@ def search_docs_by_text(
                 title,
                 owner_type,
                 owner_id,
+                metadata,
             ]
 
         # Sort the results by distance to find the closest matches

--- a/agents-api/agents_api/models/docs/search_docs_by_text.py
+++ b/agents-api/agents_api/models/docs/search_docs_by_text.py
@@ -39,6 +39,7 @@ T = TypeVar("T")
             "id": d["owner_id"],
             "role": d["owner_type"],
         },
+        "metadata": d.get("metadata", {}),
         **d,
     },
 )

--- a/agents-api/tests/test_docs_queries.py
+++ b/agents-api/tests/test_docs_queries.py
@@ -1,5 +1,6 @@
 # Tests for entry queries
 
+import asyncio
 from ward import test
 
 from agents_api.autogen.openapi_model import CreateDocRequest
@@ -85,7 +86,7 @@ def _(
 
 
 @test("model: search docs by text")
-def _(client=cozo_client, agent=test_agent, developer_id=test_developer_id):
+async def _(client=cozo_client, agent=test_agent, developer_id=test_developer_id):
     create_doc(
         developer_id=developer_id,
         owner_type="agent",
@@ -96,6 +97,8 @@ def _(client=cozo_client, agent=test_agent, developer_id=test_developer_id):
         client=client,
     )
 
+    await asyncio.sleep(1)
+
     result = search_docs_by_text(
         developer_id=developer_id,
         owners=[("agent", agent.id)],
@@ -104,10 +107,11 @@ def _(client=cozo_client, agent=test_agent, developer_id=test_developer_id):
     )
 
     assert len(result) >= 1
+    assert result[0].metadata is not None
 
 
 @test("model: search docs by embedding")
-def _(client=cozo_client, agent=test_agent, developer_id=test_developer_id):
+async def _(client=cozo_client, agent=test_agent, developer_id=test_developer_id):
     doc = create_doc(
         developer_id=developer_id,
         owner_type="agent",
@@ -125,6 +129,8 @@ def _(client=cozo_client, agent=test_agent, developer_id=test_developer_id):
         client=client,
     )
 
+    await asyncio.sleep(1)
+
     ### Search
     query_embedding = [0.99] * EMBEDDING_SIZE
 
@@ -136,6 +142,7 @@ def _(client=cozo_client, agent=test_agent, developer_id=test_developer_id):
     )
 
     assert len(result) >= 1
+    assert result[0].metadata is not None
 
 
 @test("model: embed snippets")

--- a/agents-api/tests/test_docs_queries.py
+++ b/agents-api/tests/test_docs_queries.py
@@ -1,6 +1,7 @@
 # Tests for entry queries
 
 import asyncio
+
 from ward import test
 
 from agents_api.autogen.openapi_model import CreateDocRequest

--- a/integrations-service/integrations/autogen/Docs.py
+++ b/integrations-service/integrations/autogen/Docs.py
@@ -87,6 +87,7 @@ class DocReference(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
     )
+    metadata: dict[str, Any] | None = None
     owner: DocOwner
     """
     The owner of this document.

--- a/integrations-service/integrations/autogen/Tools.py
+++ b/integrations-service/integrations/autogen/Tools.py
@@ -12,6 +12,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    RootModel,
     StrictBool,
 )
 

--- a/typespec/docs/models.tsp
+++ b/typespec/docs/models.tsp
@@ -50,6 +50,8 @@ model Snippet {
 }
 
 model DocReference {
+    ...HasMetadata;
+
     /** The owner of this document. */
     owner: DocOwner;
 

--- a/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
+++ b/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
@@ -2564,6 +2564,9 @@ components:
         - snippet
         - distance
       properties:
+        metadata:
+          type: object
+          additionalProperties: {}
         owner:
           allOf:
             - $ref: '#/components/schemas/Docs.DocOwner'


### PR DESCRIPTION
Added ``metadata`` to ``DocReference`` in typespec, and fetched the ``metadata`` in ``search_docs_by_text`` and ``search_docs_by_embedding``

Closes #814 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `metadata` field to `DocReference` and update search functions and OpenAPI schema to handle it.
> 
>   - **Behavior**:
>     - Add `metadata` field to `DocReference` in `Docs.py` and `models.tsp`.
>     - Update `search_docs_by_text.py` and `search_docs_by_embedding.py` to retrieve `metadata` from documents.
>   - **OpenAPI**:
>     - Update `openapi-1.0.0.yaml` to include `metadata` in `DocReference` schema.
>   - **Tests**:
>     - Modify tests in `test_docs_queries.py` to check for `metadata` in search results.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 2ced7db1c3ecdce406228c4d975d6b3c622326a0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->