### PR TITLE
fix(agents-api): Add metadata_filter to openapi spec

### DIFF
--- a/agents-api/agents_api/autogen/Docs.py
+++ b/agents-api/agents_api/autogen/Docs.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from typing import Annotated, Any, Literal
 from uuid import UUID
 
-from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, StrictBool
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
 
 
 class BaseDocSearchRequest(BaseModel):
@@ -18,7 +18,7 @@ class BaseDocSearchRequest(BaseModel):
     """
     The language to be used for text-only search. Support for other languages coming soon.
     """
-    metadata_filter: dict[str, float | str | StrictBool | None] = {}
+    metadata_filter: dict[str, Any] = {}
     mmr_strength: Annotated[float, Field(ge=0.0, lt=1.0)] = 0
     """
     MMR Strength (mmr_strength = 1 - mmr_lambda)

--- a/agents-api/agents_api/autogen/Tools.py
+++ b/agents-api/agents_api/autogen/Tools.py
@@ -12,6 +12,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    RootModel,
     StrictBool,
 )
 

--- a/agents-api/agents_api/dependencies/query_filter.py
+++ b/agents-api/agents_api/dependencies/query_filter.py
@@ -1,6 +1,7 @@
-from typing import Any, Callable
+from typing import Annotated, Any, Callable
 
-from fastapi import Request
+from fastapi import Query, Request
+from pydantic import BaseModel, ConfigDict
 
 
 def convert_value(value: str) -> Any:
@@ -15,9 +16,13 @@ def convert_value(value: str) -> Any:
     return value
 
 
+class MetadataFilter(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
 def create_filter_extractor(
-    prefix: str = "filter",
-) -> Callable[[Request], dict[str, Any]]:
+    prefix: str = "metadata_filter",
+) -> Callable[[Request], MetadataFilter]:
     """
     Creates a dependency function to extract filter parameters with a given prefix.
 
@@ -31,7 +36,12 @@ def create_filter_extractor(
     # Add a dot to the prefix to allow for nested filters
     prefix += "."
 
-    def extract_filters(request: Request) -> dict[str, Any]:
+    def extract_filters(
+        request: Request,
+        metadata_filter: Annotated[
+            MetadataFilter, Query(default_factory=MetadataFilter)
+        ],
+    ) -> MetadataFilter:
         """
         Extracts query parameters that start with the specified prefix and returns them as a dictionary.
 
@@ -49,6 +59,6 @@ def create_filter_extractor(
                 filter_key = key[len(prefix) :]
                 filters[filter_key] = convert_value(value)
 
-        return filters
+        return MetadataFilter(**filters)
 
     return extract_filters

--- a/agents-api/agents_api/dependencies/query_filter.py
+++ b/agents-api/agents_api/dependencies/query_filter.py
@@ -22,7 +22,7 @@ class MetadataFilter(BaseModel):
 
 def create_filter_extractor(
     prefix: str = "metadata_filter",
-) -> Callable[[Request], MetadataFilter]:
+) -> Callable[[Request, MetadataFilter], MetadataFilter]:
     """
     Creates a dependency function to extract filter parameters with a given prefix.
 

--- a/agents-api/agents_api/routers/agents/list_agents.py
+++ b/agents-api/agents_api/routers/agents/list_agents.py
@@ -5,7 +5,7 @@ from fastapi import Depends
 
 from ...autogen.openapi_model import Agent, ListResponse
 from ...dependencies.developer_id import get_developer_id
-from ...dependencies.query_filter import create_filter_extractor
+from ...dependencies.query_filter import MetadataFilter, create_filter_extractor
 from ...models.agent.list_agents import list_agents as list_agents_query
 from .router import router
 
@@ -17,7 +17,7 @@ async def list_agents(
     # Example:
     # > ?metadata_filter.name=John&metadata_filter.age=30
     metadata_filter: Annotated[
-        dict, Depends(create_filter_extractor("metadata_filter"))
+        MetadataFilter, Depends(create_filter_extractor("metadata_filter"))
     ],
     limit: int = 100,
     offset: int = 0,
@@ -30,7 +30,7 @@ async def list_agents(
         offset=offset,
         sort_by=sort_by,
         direction=direction,
-        metadata_filter=metadata_filter or {},
+        metadata_filter=metadata_filter.model_dump(mode="json") or {},
     )
 
     return ListResponse[Agent](items=agents)

--- a/agents-api/agents_api/routers/docs/list_docs.py
+++ b/agents-api/agents_api/routers/docs/list_docs.py
@@ -2,12 +2,12 @@ import json
 from typing import Annotated, Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, BeforeValidator, ConfigDict
 from fastapi import Depends, Query
+from pydantic import BaseModel, BeforeValidator, ConfigDict
 
 from ...autogen.openapi_model import Doc, ListResponse
 from ...dependencies.developer_id import get_developer_id
-from ...dependencies.query_filter import create_filter_extractor, MetadataFilter
+from ...dependencies.query_filter import MetadataFilter, create_filter_extractor
 from ...models.docs.list_docs import list_docs as list_docs_query
 from .router import router
 

--- a/agents-api/agents_api/routers/docs/list_docs.py
+++ b/agents-api/agents_api/routers/docs/list_docs.py
@@ -12,14 +12,6 @@ from ...models.docs.list_docs import list_docs as list_docs_query
 from .router import router
 
 
-class ListDocsQuery(BaseModel):
-    limit: int = 100
-    offset: int = 0
-    sort_by: Literal["created_at", "updated_at"] = "created_at"
-    direction: Literal["asc", "desc"] = "desc"
-    metadata_filter: MetadataFilter = None
-
-
 @router.get("/users/{user_id}/docs", tags=["docs"])
 async def list_user_docs(
     x_developer_id: Annotated[UUID, Depends(get_developer_id)],

--- a/agents-api/agents_api/routers/docs/list_docs.py
+++ b/agents-api/agents_api/routers/docs/list_docs.py
@@ -1,22 +1,33 @@
-from typing import Annotated, Literal
+import json
+from typing import Annotated, Literal, Optional
 from uuid import UUID
 
-from fastapi import Depends
+from pydantic import BaseModel, BeforeValidator, ConfigDict
+from fastapi import Depends, Query
 
 from ...autogen.openapi_model import Doc, ListResponse
 from ...dependencies.developer_id import get_developer_id
-from ...dependencies.query_filter import create_filter_extractor
+from ...dependencies.query_filter import create_filter_extractor, MetadataFilter
 from ...models.docs.list_docs import list_docs as list_docs_query
 from .router import router
+
+
+class ListDocsQuery(BaseModel):
+    limit: int = 100
+    offset: int = 0
+    sort_by: Literal["created_at", "updated_at"] = "created_at"
+    direction: Literal["asc", "desc"] = "desc"
+    metadata_filter: MetadataFilter = None
 
 
 @router.get("/users/{user_id}/docs", tags=["docs"])
 async def list_user_docs(
     x_developer_id: Annotated[UUID, Depends(get_developer_id)],
-    metadata_filter: Annotated[
-        dict, Depends(create_filter_extractor("metadata_filter"))
-    ],
     user_id: UUID,
+    metadata_filter: Annotated[
+        MetadataFilter,
+        Depends(create_filter_extractor("metadata_filter")),
+    ],
     limit: int = 100,
     offset: int = 0,
     sort_by: Literal["created_at", "updated_at"] = "created_at",
@@ -30,7 +41,7 @@ async def list_user_docs(
         offset=offset,
         sort_by=sort_by,
         direction=direction,
-        metadata_filter=metadata_filter or {},
+        metadata_filter=metadata_filter.model_dump(mode="json"),
     )
 
     return ListResponse[Doc](items=docs)
@@ -39,10 +50,10 @@ async def list_user_docs(
 @router.get("/agents/{agent_id}/docs", tags=["docs"])
 async def list_agent_docs(
     x_developer_id: Annotated[UUID, Depends(get_developer_id)],
-    metadata_filter: Annotated[
-        dict, Depends(create_filter_extractor("metadata_filter"))
-    ],
     agent_id: UUID,
+    metadata_filter: Annotated[
+        MetadataFilter, Depends(create_filter_extractor("metadata_filter"))
+    ],
     limit: int = 100,
     offset: int = 0,
     sort_by: Literal["created_at", "updated_at"] = "created_at",
@@ -56,7 +67,7 @@ async def list_agent_docs(
         offset=offset,
         sort_by=sort_by,
         direction=direction,
-        metadata_filter=metadata_filter or {},
+        metadata_filter=metadata_filter.model_dump(mode="json"),
     )
 
     return ListResponse[Doc](items=docs)

--- a/agents-api/agents_api/routers/sessions/list_sessions.py
+++ b/agents-api/agents_api/routers/sessions/list_sessions.py
@@ -5,7 +5,7 @@ from fastapi import Depends
 
 from ...autogen.openapi_model import ListResponse, Session
 from ...dependencies.developer_id import get_developer_id
-from ...dependencies.query_filter import create_filter_extractor
+from ...dependencies.query_filter import MetadataFilter, create_filter_extractor
 from ...models.session.list_sessions import list_sessions as list_sessions_query
 from .router import router
 
@@ -14,8 +14,8 @@ from .router import router
 async def list_sessions(
     x_developer_id: Annotated[UUID, Depends(get_developer_id)],
     metadata_filter: Annotated[
-        dict, Depends(create_filter_extractor("metadata_filter"))
-    ] = {},
+        MetadataFilter, Depends(create_filter_extractor("metadata_filter"))
+    ] = MetadataFilter(),
     limit: int = 100,
     offset: int = 0,
     sort_by: Literal["created_at", "updated_at"] = "created_at",
@@ -27,7 +27,7 @@ async def list_sessions(
         offset=offset,
         sort_by=sort_by,
         direction=direction,
-        metadata_filter=metadata_filter or {},
+        metadata_filter=metadata_filter.model_dump(mode="json") or {},
     )
 
     return ListResponse[Session](items=sessions)

--- a/agents-api/agents_api/routers/users/list_users.py
+++ b/agents-api/agents_api/routers/users/list_users.py
@@ -5,7 +5,7 @@ from fastapi import Depends
 
 from ...autogen.openapi_model import ListResponse, User
 from ...dependencies.developer_id import get_developer_id
-from ...dependencies.query_filter import create_filter_extractor
+from ...dependencies.query_filter import MetadataFilter, create_filter_extractor
 from ...models.user.list_users import list_users as list_users_query
 from .router import router
 
@@ -14,7 +14,7 @@ from .router import router
 async def list_users(
     x_developer_id: Annotated[UUID, Depends(get_developer_id)],
     metadata_filter: Annotated[
-        dict, Depends(create_filter_extractor("metadata_filter"))
+        MetadataFilter, Depends(create_filter_extractor("metadata_filter"))
     ],
     limit: int = 100,
     offset: int = 0,
@@ -27,7 +27,7 @@ async def list_users(
         offset=offset,
         sort_by=sort_by,
         direction=direction,
-        metadata_filter=metadata_filter or {},
+        metadata_filter=metadata_filter.model_dump(mode="json") or {},
     )
 
     return ListResponse[User](items=users)

--- a/agents-api/agents_api/web.py
+++ b/agents-api/agents_api/web.py
@@ -159,7 +159,7 @@ app: FastAPI = FastAPI(
 )
 
 # Enable metrics
-Instrumentator().instrument(app).expose(app)
+Instrumentator().instrument(app).expose(app, include_in_schema=False)
 
 # Create a new router for the docs
 scalar_router = APIRouter()

--- a/agents-api/tests/fixtures.py
+++ b/agents-api/tests/fixtures.py
@@ -149,8 +149,7 @@ def test_session(
     session = create_session(
         developer_id=developer_id,
         data=CreateSessionRequest(
-            agent=test_agent.id,
-            user=test_user.id,
+            agent=test_agent.id, user=test_user.id, metadata={"test": "test"}
         ),
         client=cozo_client,
     )

--- a/agents-api/tests/test_agent_routes.py
+++ b/agents-api/tests/test_agent_routes.py
@@ -210,3 +210,21 @@ def _(make_request=make_request):
 
     assert isinstance(agents, list)
     assert len(agents) > 0
+
+
+@test("route: list agents with metadata filter")
+def _(make_request=make_request):
+    response = make_request(
+        method="GET",
+        url="/agents",
+        params={
+            "metadata_filter": {"test": "test"},
+        },
+    )
+
+    assert response.status_code == 200
+    response = response.json()
+    agents = response["items"]
+
+    assert isinstance(agents, list)
+    assert len(agents) > 0

--- a/agents-api/tests/test_docs_routes.py
+++ b/agents-api/tests/test_docs_routes.py
@@ -134,6 +134,40 @@ def _(make_request=make_request, agent=test_agent):
     assert isinstance(docs, list)
 
 
+@test("route: list user docs with metadata filter")
+def _(make_request=make_request, user=test_user):
+    response = make_request(
+        method="GET",
+        url=f"/users/{user.id}/docs",
+        params={
+            "metadata_filter": {"test": "test"},
+        },
+    )
+
+    assert response.status_code == 200
+    response = response.json()
+    docs = response["items"]
+
+    assert isinstance(docs, list)
+
+
+@test("route: list agent docs with metadata filter")
+def _(make_request=make_request, agent=test_agent):
+    response = make_request(
+        method="GET",
+        url=f"/agents/{agent.id}/docs",
+        params={
+            "metadata_filter": {"test": "test"},
+        },
+    )
+
+    assert response.status_code == 200
+    response = response.json()
+    docs = response["items"]
+
+    assert isinstance(docs, list)
+
+
 # TODO: Fix this test. It fails sometimes and sometimes not.
 @test("route: search agent docs")
 async def _(make_request=make_request, agent=test_agent, doc=test_doc):

--- a/agents-api/tests/test_sessions.py
+++ b/agents-api/tests/test_sessions.py
@@ -1,0 +1,36 @@
+from ward import test
+
+from tests.fixtures import client, make_request, test_session
+
+
+@test("model: list sessions")
+def _(make_request=make_request):
+    response = make_request(
+        method="GET",
+        url="/sessions",
+    )
+
+    assert response.status_code == 200
+    response = response.json()
+    sessions = response["items"]
+
+    assert isinstance(sessions, list)
+    assert len(sessions) > 0
+
+
+@test("model: list sessions with metadata filter")
+def _(make_request=make_request):
+    response = make_request(
+        method="GET",
+        url="/sessions",
+        params={
+            "metadata_filter": {"test": "test"},
+        },
+    )
+
+    assert response.status_code == 200
+    response = response.json()
+    sessions = response["items"]
+
+    assert isinstance(sessions, list)
+    assert len(sessions) > 0

--- a/agents-api/tests/test_user_routes.py
+++ b/agents-api/tests/test_user_routes.py
@@ -165,3 +165,21 @@ def _(make_request=make_request):
 
     assert isinstance(users, list)
     assert len(users) > 0
+
+
+@test("model: list users with right metadata filter")
+def _(make_request=make_request, user=test_user):
+    response = make_request(
+        method="GET",
+        url="/users",
+        params={
+            "metadata_filter": {"test": "test"},
+        },
+    )
+
+    assert response.status_code == 200
+    response = response.json()
+    users = response["items"]
+
+    assert isinstance(users, list)
+    assert len(users) > 0

--- a/integrations-service/integrations/autogen/Docs.py
+++ b/integrations-service/integrations/autogen/Docs.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from typing import Annotated, Any, Literal
 from uuid import UUID
 
-from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, StrictBool
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
 
 
 class BaseDocSearchRequest(BaseModel):
@@ -18,7 +18,7 @@ class BaseDocSearchRequest(BaseModel):
     """
     The language to be used for text-only search. Support for other languages coming soon.
     """
-    metadata_filter: dict[str, float | str | StrictBool | None] = {}
+    metadata_filter: dict[str, Any] = {}
     mmr_strength: Annotated[float, Field(ge=0.0, lt=1.0)] = 0
     """
     MMR Strength (mmr_strength = 1 - mmr_lambda)

--- a/integrations-service/integrations/autogen/Tools.py
+++ b/integrations-service/integrations/autogen/Tools.py
@@ -12,6 +12,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    RootModel,
     StrictBool,
 )
 

--- a/typespec/common/types.tsp
+++ b/typespec/common/types.tsp
@@ -13,7 +13,7 @@ namespace Common;
 //
 
 alias Metadata = Record<unknown>;
-alias MetadataFilter = Record<concreteType>;
+alias MetadataFilter = Record<unknown>;
 
 model ResourceCreatedResponse {
     @doc("ID of created resource")
@@ -52,7 +52,7 @@ model PaginationOptions {
     @query direction: sortDirection = "asc",
 
     /** Object to filter results by metadata */
-    @query metadata_filter: MetadataFilter,
+    @query metadata_filter: Record<unknown> = #{},
 }
 
 @events

--- a/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
+++ b/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
@@ -1340,12 +1340,8 @@ components:
       description: Object to filter results by metadata
       schema:
         type: object
-        additionalProperties:
-          anyOf:
-            - type: number
-            - type: string
-            - type: boolean
-          nullable: true
+        additionalProperties: {}
+        default: {}
       explode: false
     Common.PaginationOptions.offset:
       name: offset
@@ -2451,12 +2447,7 @@ components:
           default: en-US
         metadata_filter:
           type: object
-          additionalProperties:
-            anyOf:
-              - type: number
-              - type: string
-              - type: boolean
-            nullable: true
+          additionalProperties: {}
           default: {}
         mmr_strength:
           type: number


### PR DESCRIPTION
Signed-off-by: Diwank Singh Tomer <diwank.singh@gmail.com>

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `metadata_filter` to OpenAPI spec and update related models, endpoints, and tests for flexible metadata filtering.
> 
>   - **Behavior**:
>     - Update `metadata_filter` type to `dict[str, Any]` in `BaseDocSearchRequest` in `Docs.py`.
>     - Modify `create_filter_extractor` in `query_filter.py` to use `MetadataFilter` model.
>     - Update API endpoints in `list_agents.py`, `list_docs.py`, `list_sessions.py`, and `list_users.py` to use `MetadataFilter`.
>   - **Models**:
>     - Add `MetadataFilter` model in `query_filter.py`.
>   - **OpenAPI**:
>     - Change `MetadataFilter` alias to `Record<unknown>` in `types.tsp`.
>     - Update OpenAPI spec in `openapi-1.0.0.yaml` to reflect `metadata_filter` changes.
>   - **Tests**:
>     - Add tests for `metadata_filter` in `test_agent_routes.py`, `test_docs_routes.py`, `test_sessions.py`, and `test_user_routes.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for e5a29f75da1ccc16410507c73021b2835df34546. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->