### PR TITLE
fix(agents-api): Fix retrying the `resource busy` errors

### DIFF
--- a/agents-api/agents_api/common/exceptions/tasks.py
+++ b/agents-api/agents_api/common/exceptions/tasks.py
@@ -24,6 +24,7 @@ import litellm
 import pydantic
 import requests
 import temporalio.exceptions
+from tenacity import RetryError
 
 # 🚫 The "No Second Chances" Club - errors that we won't retry
 # Because sometimes, no means no!
@@ -130,6 +131,9 @@ RETRYABLE_ERROR_TYPES = (
     #
     # Database/storage related (when the database needs a nap)
     asyncio.TimeoutError,
+    #
+    # Tenacity exceptions (retry when retrying goes wrong lol)
+    RetryError,
 )
 
 # HTTP status codes that say "maybe try again later?"

--- a/agents-api/agents_api/common/exceptions/tasks.py
+++ b/agents-api/agents_api/common/exceptions/tasks.py
@@ -180,15 +180,3 @@ def is_retryable_error(error: BaseException) -> bool:
     # If we don't know this error, we play it safe and don't retry
     # (stranger danger!)
     return False
-
-    # Check for specific HTTP errors that should be retried
-    if isinstance(error, fastapi.exceptions.HTTPException):
-        if error.status_code in RETRYABLE_HTTP_STATUS_CODES:
-            return True
-
-    if isinstance(error, httpx.HTTPStatusError):
-        if error.response.status_code in RETRYABLE_HTTP_STATUS_CODES:
-            return True
-
-    # If we don't know about the error, we should not retry
-    return False


### PR DESCRIPTION
When a `retry`-decorated function finishes the maximum amount of retries and still throws an error, `tenacity` throws an error with type `RetryError`, so I added that to the list of retryable errors
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Added `RetryError` to `RETRYABLE_ERROR_TYPES` in `tasks.py` to handle exhausted retry cases.
> 
>   - **Error Handling**:
>     - Added `RetryError` to `RETRYABLE_ERROR_TYPES` in `tasks.py` to handle cases where a `retry`-decorated function exhausts retries and throws this error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for d20007767bd9cce0f0bcaa8c7c6312bf33efcfda. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->