### PR TITLE
fix(agents-api): Convert assertion errors to 422 http errors

### DIFF
--- a/agents-api/agents_api/models/execution/prepare_execution_input.py
+++ b/agents-api/agents_api/models/execution/prepare_execution_input.py
@@ -31,6 +31,7 @@ T = TypeVar("T")
         QueryException: partialclass(HTTPException, status_code=400),
         ValidationError: partialclass(HTTPException, status_code=400),
         TypeError: partialclass(HTTPException, status_code=400),
+        AssertionError: lambda e: HTTPException(status_code=422, detail=str(e)),
     }
 )
 @wrap_in_class(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Convert `AssertionError` to HTTP 422 error in `prepare_execution_input.py`.
> 
>   - **Error Handling**:
>     - Convert `AssertionError` to HTTP 422 error in `prepare_execution_input.py` using `rewrap_exceptions` decorator.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for b07f915f6df289abdbdaed200a3a2c128c288204. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->