### PR TITLE
fix(agents-api): Enable retrying assertion errors for prepare execution input

### DIFF
--- a/agents-api/agents_api/models/execution/prepare_execution_input.py
+++ b/agents-api/agents_api/models/execution/prepare_execution_input.py
@@ -31,6 +31,7 @@ T = TypeVar("T")
         QueryException: partialclass(HTTPException, status_code=400),
         ValidationError: partialclass(HTTPException, status_code=400),
         TypeError: partialclass(HTTPException, status_code=400),
+        AssertionError: lambda e: HTTPException(status_code=422, detail=str(e)),
     }
 )
 @wrap_in_class(

--- a/agents-api/agents_api/models/execution/prepare_execution_input.py
+++ b/agents-api/agents_api/models/execution/prepare_execution_input.py
@@ -31,7 +31,11 @@ T = TypeVar("T")
         QueryException: partialclass(HTTPException, status_code=400),
         ValidationError: partialclass(HTTPException, status_code=400),
         TypeError: partialclass(HTTPException, status_code=400),
-        AssertionError: lambda e: HTTPException(status_code=400, detail=str(e)),
+        AssertionError: lambda e: HTTPException(
+            status_code=429,
+            detail=str(e),
+            headers={"x-should-retry": "true"},
+        ),
     }
 )
 @wrap_in_class(

--- a/agents-api/agents_api/models/execution/prepare_execution_input.py
+++ b/agents-api/agents_api/models/execution/prepare_execution_input.py
@@ -31,7 +31,7 @@ T = TypeVar("T")
         QueryException: partialclass(HTTPException, status_code=400),
         ValidationError: partialclass(HTTPException, status_code=400),
         TypeError: partialclass(HTTPException, status_code=400),
-        AssertionError: lambda e: HTTPException(status_code=422, detail=str(e)),
+        AssertionError: lambda e: HTTPException(status_code=429, detail=str(e)),
     }
 )
 @wrap_in_class(

--- a/agents-api/agents_api/models/execution/prepare_execution_input.py
+++ b/agents-api/agents_api/models/execution/prepare_execution_input.py
@@ -31,7 +31,7 @@ T = TypeVar("T")
         QueryException: partialclass(HTTPException, status_code=400),
         ValidationError: partialclass(HTTPException, status_code=400),
         TypeError: partialclass(HTTPException, status_code=400),
-        AssertionError: lambda e: HTTPException(status_code=429, detail=str(e)),
+        AssertionError: lambda e: HTTPException(status_code=400, detail=str(e)),
     }
 )
 @wrap_in_class(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `AssertionError` handling in `prepare_execution_input.py` to return status code 429 with a retry header.
> 
>   - **Behavior**:
>     - Change `AssertionError` handling in `prepare_execution_input.py` to return status code 429 instead of 422.
>     - Add `x-should-retry: true` header to `AssertionError` responses, indicating retry capability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 9719afe22909c14cf102992eef5c7f689c6f6086. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->