### PR TITLE
fix(agents-api): Use larch.pickle to avoid DeadlockError

### DIFF
--- a/agents-api/Dockerfile
+++ b/agents-api/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     dpkg-dev \
     gcc \
     g++ \
+    libboost-all-dev \
     libbluetooth-dev \
     libbz2-dev \
     libc6-dev \

--- a/agents-api/Dockerfile.worker
+++ b/agents-api/Dockerfile.worker
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     dpkg-dev \
     gcc \
     g++ \
+    libboost-all-dev \
     libbluetooth-dev \
     libbz2-dev \
     libc6-dev \

--- a/agents-api/agents_api/worker/codec.py
+++ b/agents-api/agents_api/worker/codec.py
@@ -6,10 +6,11 @@
 
 import dataclasses
 import logging
-import pickle
 import sys
+import time
 from typing import Any, Optional, Type
 
+import larch.pickle as pickle
 import temporalio.converter
 
 # from beartype import BeartypeConf
@@ -24,15 +25,25 @@ from temporalio.converter import (
 
 
 def serialize(x: Any) -> bytes:
-    pickled = pickle.dumps(x, protocol=pickle.HIGHEST_PROTOCOL)
+    start_time = time.time()
+    pickled = pickle.dumps(x, protocol=-1)
     compressed = compress(pickled)
+
+    duration = time.time() - start_time
+    if duration > 1:
+        print(f"||| [SERIALIZE] Time taken: {duration}s // Object size: {sys.getsizeof(x) / 1000}kb")
 
     return compressed
 
 
 def deserialize(b: bytes) -> Any:
+    start_time = time.time()
     decompressed = decompress(b)
     object = pickle.loads(decompressed)
+
+    duration = time.time() - start_time
+    if duration > 1:
+        print(f"||| [DESERIALIZE] Time taken: {duration}s // Object size: {sys.getsizeof(b) / 1000}kb")
 
     return object
 

--- a/agents-api/gunicorn_conf.py
+++ b/agents-api/gunicorn_conf.py
@@ -5,7 +5,7 @@ TESTING = os.getenv("TESTING", "false").lower() == "true"
 DEBUG = os.getenv("DEBUG", "false").lower() == "true"
 
 # Gunicorn config variables
-workers = multiprocessing.cpu_count() - 1 if not (TESTING or DEBUG) else 1
+workers = multiprocessing.cpu_count() // 2 if not (TESTING or DEBUG) else 1
 worker_class = "uvicorn.workers.UvicornWorker"
 bind = "0.0.0.0:8080"
 keepalive = 120

--- a/agents-api/poetry.lock
+++ b/agents-api/poetry.lock
@@ -2247,6 +2247,22 @@ build = ["build", "twine"]
 test = ["pytest", "pytest-cov"]
 
 [[package]]
+name = "larch-pickle"
+version = "1.4.3"
+description = "A faster python pickle replacement"
+optional = false
+python-versions = "*"
+files = [
+    {file = "larch-pickle-1.4.3.tar.gz", hash = "sha256:560575f0061bf4e598adfc10f2b84b0ae3b61f8c27734fdd62775a5659c3a611"},
+    {file = "larch_pickle-1.4.3-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:d9de944a602fb8621e0ad841641924353dbf5594bfecb2c262742b3b26f2a83b"},
+    {file = "larch_pickle-1.4.3-cp310-cp310-win_amd64.whl", hash = "sha256:462be1dcaaaa88fef0d473d0ac8ae431f0e172778c44b080dbd68233731c3d51"},
+    {file = "larch_pickle-1.4.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:01bafdb4322c3d7cf111b9df5f4cbcdbfb5ffdd6ad3eecd4a40c57fedff52d5b"},
+    {file = "larch_pickle-1.4.3-cp311-cp311-win_amd64.whl", hash = "sha256:0af8866c6d2d6b7e211ea7ac7d202fe2fc8bfa15774dfec686cb1c75f9e0e2c6"},
+    {file = "larch_pickle-1.4.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:43aa630e586c564605325effe87fd3f38692b71cf3f960efe48c2df4f7967a06"},
+    {file = "larch_pickle-1.4.3-cp312-cp312-win_amd64.whl", hash = "sha256:18c74fde0bdd0382598745633b6a230a28707bbd382e695fae1518324d926b8a"},
+]
+
+[[package]]
 name = "libcst"
 version = "1.5.1"
 description = "A concrete syntax tree with AST-like properties for Python 3.0 through 3.13 programs."
@@ -2312,6 +2328,7 @@ files = [
     {file = "litellm-1.52.10-py3-none-any.whl", hash = "sha256:f2bf35b1409729253eb70a6d575cb8ccf71373358e109b0f4653b5bcd9a65467"},
     {file = "litellm-1.52.10.tar.gz", hash = "sha256:8ceaa016cd8ff3a11783d57f862f3157cd764947c60b8f0c4fb04d927d5fe4c1"},
 ]
+develop = false
 
 [package.dependencies]
 aiohttp = "*"
@@ -6351,4 +6368,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.12,<3.13"
-content-hash = "b285c4b4ba58272c3c3e6a8cb57538b37b5367a69c711275f1be3ba1e55a7d5a"
+content-hash = "6b4355e58ed4a00fbffb222be30208d27d3f539514ae47082df38061e8a74a23"

--- a/agents-api/pyproject.toml
+++ b/agents-api/pyproject.toml
@@ -51,6 +51,7 @@ anthropic = "^0.37.1"
 simsimd = "^5.9.4"
 langchain-core = "^0.3.14"
 litellm = {git = "https://github.com/julep-ai/litellm.git", rev = "fix_anthropic_tool_image_content"}
+larch-pickle = "^1.4.3"
 [tool.poetry.group.dev.dependencies]
 ipython = "^8.26.0"
 ruff = "^0.5.5"

--- a/integrations-service/gunicorn_conf.py
+++ b/integrations-service/gunicorn_conf.py
@@ -5,7 +5,7 @@ TESTING = os.getenv("TESTING", "false").lower() == "true"
 DEBUG = os.getenv("DEBUG", "false").lower() == "true"
 
 # Gunicorn config variables
-workers = multiprocessing.cpu_count() - 1 if not (TESTING or DEBUG) else 1
+workers = multiprocessing.cpu_count() // 2 if not (TESTING or DEBUG) else 1
 worker_class = "uvicorn.workers.UvicornWorker"
 bind = "0.0.0.0:8000"
 keepalive = 120

--- a/scheduler/docker-compose.yml
+++ b/scheduler/docker-compose.yml
@@ -1,7 +1,7 @@
 name: julep-scheduler
 
 x--temporal-base: &temporal-base
-  image: temporalio/auto-setup:1.25
+  image: temporalio/auto-setup:1.25.2
   hostname: temporal
   environment:
     - POSTGRES_PWD=${TEMPORAL_POSTGRES_PASSWORD}
@@ -43,6 +43,7 @@ services:
   temporal-db:
     image: postgres:16
     restart: unless-stopped
+    command: -c 'max_connections=1000'
     volumes:
       - temporal-db-data:/var/lib/postgresql/data
     profiles:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Switch to `larch.pickle` for serialization in `agents_api/worker/codec.py` to avoid `DeadlockError`, update Dockerfiles, Gunicorn configurations, and dependencies.
> 
>   - **Serialization**:
>     - Replace `pickle` with `larch.pickle` in `agents_api/worker/codec.py` to avoid `DeadlockError`.
>     - Add logging for serialization/deserialization time if it exceeds 1 second.
>   - **Docker**:
>     - Add `libboost-all-dev` to `agents-api/Dockerfile` and `Dockerfile.worker`.
>   - **Gunicorn Configuration**:
>     - Change worker count calculation to `multiprocessing.cpu_count() // 2` in `gunicorn_conf.py` and `integrations-service/gunicorn_conf.py`.
>   - **Dependencies**:
>     - Add `larch-pickle` to `pyproject.toml`.
>   - **Miscellaneous**:
>     - Update `temporalio/auto-setup` image to `1.25.2` in `scheduler/docker-compose.yml`.
>     - Increase `max_connections` to `1000` for `temporal-db` in `scheduler/docker-compose.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for a546477b949271e5b1d0f45a5cd33c83e0cf7694. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->