### PR TITLE
fix(.github): Fix workflows libboost

### DIFF
--- a/.github/workflows/generate-openapi-code-from-typespec
+++ b/.github/workflows/generate-openapi-code-from-typespec
@@ -26,6 +26,9 @@ jobs:
           cache: npm
           cache-dependency-path: 'typespec/package-lock.json'
 
+      - name: Install libboost
+        run: sudo apt-get install -y libboost-all-dev
+
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
 

--- a/.github/workflows/lint-agents-api-pr.yml
+++ b/.github/workflows/lint-agents-api-pr.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install libboost
+        run: sudo apt-get install -y libboost-all-dev
+
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
 

--- a/.github/workflows/test-agents-api-pr.yml
+++ b/.github/workflows/test-agents-api-pr.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install libboost
+        run: sudo apt-get install -y libboost-all-dev
+
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
 

--- a/.github/workflows/typecheck-agents-api-pr.yml
+++ b/.github/workflows/typecheck-agents-api-pr.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install libboost
+        run: sudo apt-get install -y libboost-all-dev
+
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
 

--- a/agents-api/agents_api/__init__.py
+++ b/agents-api/agents_api/__init__.py
@@ -1,11 +1,10 @@
 """
-The `agents_api` module serves as the foundation of the agent management system within the `agents-api` project. This module is responsible for defining the structure and capabilities of the API that manages agents. It includes operations such as creating, updating, listing, and deleting agents, as well as managing documents and tools associated with these agents. This file, in particular, acts as a configuration and initialization point for the `agents_api` package, and as per the directive, should not contain any imports.
+The `agents_api` module serves as the foundation of the agent management system within the `agents-api` project.
+This module is responsible for defining the structure and capabilities of the API that manages agents.
+It includes operations such as creating, updating, listing, and deleting agents, as well as managing documents and tools associated with these agents.
 """
 
-#################################
-## Do NOT put any imports here ##
-#################################
-# Failed decoding arguments fixture
+# Failed decoding arguments fix
 from temporalio import workflow
 
 with workflow.unsafe.imports_passed_through():


### PR DESCRIPTION
Closes #891 

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `libboost-all-dev` installation step to four GitHub workflow files to ensure Boost libraries are available.
> 
>   - **Workflows**:
>     - Add `libboost-all-dev` installation step in `generate-openapi-code-from-typespec`, `lint-agents-api-pr.yml`, `test-agents-api-pr.yml`, and `typecheck-agents-api-pr.yml`.
>     - Ensures Boost libraries are available for subsequent steps in the workflows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for c95e9115f3ecfbb2b5ae2e44cc426831850f4777. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->