### PR TITLE
fix(agents-api): Fix cozo query retry logic

### DIFF
--- a/agents-api/gunicorn_conf.py
+++ b/agents-api/gunicorn_conf.py
@@ -4,7 +4,7 @@ import os
 debug = os.getenv("AGENTS_API_DEBUG", "false").lower() == "true"
 
 # Gunicorn config variables
-workers = (multiprocessing.cpu_count() - 1) if not debug else 1
+workers = (multiprocessing.cpu_count() // 2) if not debug else 1
 worker_class = "uvicorn.workers.UvicornWorker"
 bind = "0.0.0.0:8080"
 keepalive = 120


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves Cozo query retry logic and adjusts Gunicorn worker configuration.
> 
>   - **Retry Logic**:
>     - In `utils.py`, updated retry logic in `cozo_query` and `cozo_query_async` to handle `ConnectionError`, `Timeout`, `TimeoutException`, `NetworkError`, and `RequestError`.
>     - Increased retry attempts from 4 to 6 and adjusted exponential backoff parameters.
>   - **Gunicorn Configuration**:
>     - Changed worker count calculation in `gunicorn_conf.py` to use half of CPU count instead of CPU count minus one.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 1cb593201e70d47d1373aa613f12b7e798519bb8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->