### PR TITLE
feat(monitoring): add portainer to monitor memory consumption

### DIFF
--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -32,8 +32,24 @@ services:
     profiles:
       - multi-tenant
 
+  portainer:
+    image: portainer/portainer-ce:latest
+    container_name: portainer
+    ports:
+      - 8383:9000
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - portainer_data:/data
+    environment:
+      - ADMIN_USERNAME=${PORTAINER_ADMIN_USER}
+      - ADMIN_PASSWORD=${PORTAINER_ADMIN_PASSWORD}
+    profiles:
+      - monitor
+
 volumes:
   prometheus_data:
     external: true
   grafana_data:
+    external: true
+  portainer_data:
     external: true


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds Portainer service to `docker-compose.yml` for monitoring memory consumption with external volume support.
> 
>   - **New Service**:
>     - Adds `portainer` service to `docker-compose.yml` for monitoring memory consumption.
>     - Uses `portainer/portainer-ce:latest` image.
>     - Maps port `8383` to `9000`.
>     - Mounts `/var/run/docker.sock` and `portainer_data` volume.
>     - Configures with `ADMIN_USERNAME` and `ADMIN_PASSWORD` from environment variables.
>   - **Volumes**:
>     - Adds `portainer_data` as an external volume in `docker-compose.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 1a65d5f6dcf891a8bd47a9c2189bd4ec3807d8f8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->