### PR TITLE
chore: Update default heartbeat timeout

### DIFF
--- a/agents-api/agents_api/env.py
+++ b/agents-api/agents_api/env.py
@@ -103,7 +103,7 @@ temporal_task_queue: Any = env.str("TEMPORAL_TASK_QUEUE", default="julep-task-qu
 temporal_schedule_to_close_timeout: int = env.int(
     "TEMPORAL_SCHEDULE_TO_CLOSE_TIMEOUT", default=3600
 )
-temporal_heartbeat_timeout: int = env.int("TEMPORAL_HEARTBEAT_TIMEOUT", default=5)
+temporal_heartbeat_timeout: int = env.int("TEMPORAL_HEARTBEAT_TIMEOUT", default=900)
 temporal_metrics_bind_host: str = env.str(
     "TEMPORAL_METRICS_BIND_HOST", default="0.0.0.0"
 )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update default `temporal_heartbeat_timeout` from 5 to 900 in `env.py`.
> 
>   - **Behavior**:
>     - Update default `temporal_heartbeat_timeout` from 5 to 900 in `env.py`.
>     - Affects Temporal task heartbeat timeout handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 317bf0b0572cb0530f44152e9616f18bcd11bbb3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->