### PR TITLE
fix: Fix Grafana dashboards and set temporal metrics port statically

### DIFF
--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -29,6 +29,8 @@ services:
     volumes:
       - grafana_data:/var/lib/grafana
       - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/provisioning/dashboards:/var/lib/grafana/dashboards
+      - ./grafana/dashboard.yaml:/etc/grafana/provisioning/dashboards/main.yaml
     profiles:
       - multi-tenant
 

--- a/monitoring/grafana/dashboard.yaml
+++ b/monitoring/grafana/dashboard.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: "Dashboard provider"
+    orgId: 1
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: true

--- a/scheduler/docker-compose.yml
+++ b/scheduler/docker-compose.yml
@@ -23,7 +23,7 @@ x--temporal-base: &temporal-base
     - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/temporal-postgres.yaml
     - DB=postgres12
     - LOG_LEVEL=${TEMPORAL_LOG_LEVEL:-info}
-    - PROMETHEUS_ENDPOINT=${TEMPORAL_PROMETHEUS_ENDPOINT:-0.0.0.0:15000}
+    - PROMETHEUS_ENDPOINT=0.0.0.0:15000
   volumes:
     - ./dynamicconfig:/etc/temporal/config/dynamicconfig
     - ./cert:/cert


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes Grafana dashboard provisioning and sets Temporal metrics port statically in Docker Compose configurations.
> 
>   - **Grafana Dashboard Fixes**:
>     - Added volume mappings in `monitoring/docker-compose.yml` for Grafana dashboards.
>     - Created `monitoring/grafana/dashboard.yaml` to configure dashboard provisioning.
>   - **Temporal Metrics Port**:
>     - Set `PROMETHEUS_ENDPOINT` to `0.0.0.0:15000` in `scheduler/docker-compose.yml` for static port assignment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for a5f3f7d0470253629e52415dbf1a65ef06bde603. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->