### PR TITLE
x/memory-store: revert docker cozo

### DIFF
--- a/memory-store/Dockerfile
+++ b/memory-store/Dockerfile
@@ -16,8 +16,8 @@ RUN apt-get update && apt-get install -y \
 
 # Build cozo-ce-bin from crates.io
 WORKDIR /usr/src
-RUN cargo install cozo-ce-bin@0.7.13-alpha.3 --features "requests graph-algo storage-new-rocksdb storage-sqlite jemalloc io-uring malloc-usable-size"
-# RUN cargo install --git https://github.com/cozo-community/cozo.git --branch f/publish-crate --rev 592f49b --profile release -F graph-algo -F  jemalloc -F io-uring -F storage-new-rocksdb -F malloc-usable-size --target x86_64-unknown-linux-gnu cozo-ce-bin
+# RUN cargo install cozo-ce-bin@0.7.13-alpha.3 --features "requests graph-algo storage-new-rocksdb storage-sqlite jemalloc io-uring malloc-usable-size"
+RUN cargo install --git https://github.com/cozo-community/cozo.git --branch f/publish-crate --rev 592f49b --profile release -F graph-algo -F  jemalloc -F io-uring -F storage-new-rocksdb -F malloc-usable-size --target x86_64-unknown-linux-gnu cozo-ce-bin
 
 # Copy the built binary to /usr/local/bin
 RUN cp /usr/local/cargo/bin/cozo-ce-bin /usr/local/bin/cozo


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Revert `cozo-ce-bin` installation method in `memory-store/Dockerfile` to use a specific git commit instead of a crates.io version.
> 
>   - **Dockerfile Changes**:
>     - Revert `cozo-ce-bin` installation method in `memory-store/Dockerfile` from crates.io version `0.7.13-alpha.3` to a git-based installation from `https://github.com/cozo-community/cozo.git` on branch `f/publish-crate` at commit `592f49b`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 3c33939647a17de931c8e76034e92db5e6caf5b9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->