### PR TITLE
fix(agents-api): Fix None-valued `passed_settings` from overriding agent's settings in `prompt` step

### DIFF
--- a/agents-api/agents_api/activities/task_steps/prompt_step.py
+++ b/agents-api/agents_api/activities/task_steps/prompt_step.py
@@ -184,6 +184,9 @@ async def prompt_step(context: StepContext) -> StepOutcome:
             for message in prompt
         ]
 
+    # Remove None values from passed_settings (avoid overwriting agent's settings)
+    passed_settings = {k: v for k, v in passed_settings.items() if v is not None}
+
     # Use litellm for other models
     completion_data: dict = {
         "model": agent_model,


### PR DESCRIPTION
Fixes #954
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Filters out `None` values from `passed_settings` in `prompt_step()` to prevent overwriting agent settings.
> 
>   - **Behavior**:
>     - In `prompt_step()` in `prompt_step.py`, filters out `None` values from `passed_settings` to prevent them from overwriting existing agent settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 02cd9f3b697b6000de6bddfa5e5e9af21bc54e18. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->