### PR TITLE
fix(agents-api): Allow consecutive `finish_branch` transitions

### DIFF
--- a/agents-api/agents_api/common/protocol/tasks.py
+++ b/agents-api/agents_api/common/protocol/tasks.py
@@ -109,7 +109,15 @@ valid_transitions: dict[TransitionType, list[TransitionType]] = {
         "finish_branch",
         "init_branch",
     ],
-    "finish_branch": ["wait", "error", "cancelled", "step", "finish", "init_branch"],
+    "finish_branch": [
+        "wait",
+        "error",
+        "cancelled",
+        "step",
+        "finish",
+        "init_branch",
+        "finish_branch",
+    ],
 }  # type: ignore
 
 valid_previous_statuses: dict[ExecutionStatus, list[ExecutionStatus]] = {


### PR DESCRIPTION
Fixes #956
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Allows consecutive `finish_branch` transitions in the state machine logic in `tasks.py`.
> 
>   - **Behavior**:
>     - Allows consecutive `finish_branch` transitions in the state machine logic in `tasks.py`.
>     - Updates `valid_transitions` dictionary to include `finish_branch` as a valid next state for `finish_branch`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 988036e3b12f5d4728483fb5ff4a589d205cf7d0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->