### PR TITLE
fix(memory-store): Change association structure of files and docs

### DIFF
--- a/memory-store/migrations/000005_files.down.sql
+++ b/memory-store/migrations/000005_files.down.sql
@@ -1,14 +1,12 @@
 BEGIN;
 
--- Drop agent_files table and its dependencies
-DROP TABLE IF EXISTS agent_files;
-
--- Drop user_files table and its dependencies
-DROP TABLE IF EXISTS user_files;
+-- Drop file_owners table and its dependencies
+DROP TRIGGER IF EXISTS trg_validate_file_owner ON file_owners;
+DROP FUNCTION IF EXISTS validate_file_owner();
+DROP TABLE IF EXISTS file_owners;
 
 -- Drop files table and its dependencies
 DROP TRIGGER IF EXISTS trg_files_updated_at ON files;
-
 DROP TABLE IF EXISTS files;
 
 COMMIT;

--- a/memory-store/migrations/000006_docs.down.sql
+++ b/memory-store/migrations/000006_docs.down.sql
@@ -1,41 +1,27 @@
 BEGIN;
 
+-- Drop doc_owners table and its dependencies
+DROP TRIGGER IF EXISTS trg_validate_doc_owner ON doc_owners;
+DROP FUNCTION IF EXISTS validate_doc_owner();
+DROP TABLE IF EXISTS doc_owners;
+
+-- Drop docs table and its dependencies
+DROP TRIGGER IF EXISTS trg_docs_search_tsv ON docs;
+DROP TRIGGER IF EXISTS trg_docs_updated_at ON docs;
+DROP FUNCTION IF EXISTS docs_update_search_tsv();
+
 -- Drop indexes
 DROP INDEX IF EXISTS idx_docs_content_trgm;
-
 DROP INDEX IF EXISTS idx_docs_title_trgm;
-
 DROP INDEX IF EXISTS idx_docs_search_tsv;
-
 DROP INDEX IF EXISTS idx_docs_metadata;
-
-DROP INDEX IF EXISTS idx_agent_docs_agent;
-
-DROP INDEX IF EXISTS idx_user_docs_user;
-
 DROP INDEX IF EXISTS idx_docs_developer;
-
 DROP INDEX IF EXISTS idx_docs_id_sorted;
 
--- Drop triggers
-DROP TRIGGER IF EXISTS trg_docs_search_tsv ON docs;
-
-DROP TRIGGER IF EXISTS trg_docs_updated_at ON docs;
-
--- Drop the constraint that depends on is_valid_language function
-ALTER TABLE IF EXISTS docs
-DROP CONSTRAINT IF EXISTS ct_docs_valid_language;
-
--- Drop functions
-DROP FUNCTION IF EXISTS docs_update_search_tsv ();
-
-DROP FUNCTION IF EXISTS is_valid_language (text);
-
--- Drop tables (in correct order due to foreign key constraints)
-DROP TABLE IF EXISTS agent_docs;
-
-DROP TABLE IF EXISTS user_docs;
-
+-- Drop docs table
 DROP TABLE IF EXISTS docs;
+
+-- Drop language validation function
+DROP FUNCTION IF EXISTS is_valid_language(text);
 
 COMMIT;


### PR DESCRIPTION
### **User description**
Signed-off-by: Diwank Singh Tomer <diwank.singh@gmail.com>


___

### **PR Type**
Enhancement


___

### **Description**
- Unified the ownership structure for both files and documents by replacing separate tables with single ownership tables (`file_owners` and `doc_owners`)
- Added type validation to ensure owner references are valid (either user or agent)
- Implemented triggers and functions to validate owner references on insert and update
- Created optimized indexes for querying by owner type and ID
- Simplified database schema while maintaining data integrity and relationships



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>000005_files.down.sql</strong><dd><code>Restructure file ownership tables cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

memory-store/migrations/000005_files.down.sql

<li>Replaced dropping of separate <code>agent_files</code> and <code>user_files</code> tables with <br>dropping of unified <code>file_owners</code> table<br> <li> Added dropping of validation trigger and function for file owners<br>


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/973/files#diff-f299b9d66cb77c77ba597bfd8c27d8cc7f913ecf923b60a682369223d0c1f5f3">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>000005_files.up.sql</strong><dd><code>Implement unified file ownership structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

memory-store/migrations/000005_files.up.sql

<li>Replaced separate <code>user_files</code> and <code>agent_files</code> tables with unified <br><code>file_owners</code> table<br> <li> Added owner type validation with trigger and function<br> <li> Created index on owner fields<br>


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/973/files#diff-cba1f125ed2bab5d9769de1a0c3432acadcd8475c1f95c010b3b596c59606ccb">+37/-19</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>000006_docs.down.sql</strong><dd><code>Update document ownership cleanup migration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

memory-store/migrations/000006_docs.down.sql

<li>Added cleanup for <code>doc_owners</code> table and its dependencies<br> <li> Reorganized drop statements for better clarity<br> <li> Removed drops for deprecated <code>agent_docs</code> and <code>user_docs</code> tables<br>


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/973/files#diff-a1135a8154abc6115c9accc6a553bd72519b67b62e34f7bc70b1981f3d9e6792">+14/-28</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>000006_docs.up.sql</strong><dd><code>Implement unified document ownership structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

memory-store/migrations/000006_docs.up.sql

<li>Replaced separate <code>user_docs</code> and <code>agent_docs</code> tables with unified <br><code>doc_owners</code> table<br> <li> Added owner type validation with trigger and function<br> <li> Created index on owner fields<br>


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/973/files#diff-6132303705f971e71d4f72778866e821d1e40a90cf380bf81911641535be33d2">+38/-18</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information