### PR TITLE
Update README.md

### DIFF
--- a/cookbooks/README.md
+++ b/cookbooks/README.md
@@ -16,7 +16,7 @@ Each notebook explores a unique use case, demonstrating different aspects of Jul
 | `03-trip-planning-assistant.ipynb` | [Colab Link](https://colab.research.google.com/github/julep-ai/julep/blob/dev/cookbooks/03-trip-planning-assistant.ipynb) | Plans trips using weather data and location information | Yes |
 | `04-hook-generator-trending-reels.ipynb` | [Colab Link](https://colab.research.google.com/github/julep-ai/julep/blob/dev/cookbooks/04-hook-generator-trending-reels.ipynb) | Generates engaging hooks for trending social media reels | Yes |
 | `05-video-processing-with-natural-language.ipynb` | [Colab Link](https://colab.research.google.com/github/julep-ai/julep/blob/dev/cookbooks/05-video-processing-with-natural-language.ipynb) | Processes videos using natural language commands | Yes |
-| `06-browser-use.ipynb` | [Colab Link](https://colab.research.google.com/github/julep-ai/julep/blob/dev/cookbooks/`06-browser-use.ipynb) | Demonstrates browser automation capabilities | Yes |
+| `06-browser-use.ipynb` | [Colab Link](https://colab.research.google.com/github/julep-ai/julep/blob/dev/cookbooks/06-browser-use.ipynb) | Demonstrates browser automation capabilities | Yes |
 
 
 ## Potential Cookbooks for Contributors


### PR DESCRIPTION
### **User description**
Backtick in the colab link URL (decompiles as UTF8 %60 in the URL)

This created an invalid path to the Google Colab File

just a single backtick edit. that's it ⛵


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed broken Google Colab link for the `06-browser-use.ipynb` notebook by removing an erroneous backtick character in the URL
- This resolves the issue where the link was being incorrectly decoded as UTF8 %60, making the path invalid



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Fix broken Colab notebook link in documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cookbooks/README.md

<li>Fixed invalid Google Colab URL by removing backtick character from the <br>link to <code>06-browser-use.ipynb</code><br>


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/980/files#diff-cce89eb8537756dd5be89ad0f03055f85fc9ff1f1bd64077c4eeb1020f4536da">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information