### PR TITLE
fix(agents-api): Fix timestamp type in entries

### DIFF
--- a/agents-api/agents_api/autogen/Entries.py
+++ b/agents-api/agents_api/autogen/Entries.py
@@ -69,7 +69,7 @@ class BaseEntry(BaseModel):
     """
     The tool call id of the tool call this message is a response to
     """
-    timestamp: Annotated[float, Field(ge=0.0)]
+    timestamp: AwareDatetime
     """
     This is the time that this event refers to.
     """

--- a/agents-api/agents_api/autogen/openapi_model.py
+++ b/agents-api/agents_api/autogen/openapi_model.py
@@ -372,7 +372,7 @@ class CreateTransitionRequest(Transition):
 
 
 class CreateEntryRequest(BaseEntry):
-    timestamp: Annotated[float, Field(ge=0.0, default_factory=lambda: utcnow().timestamp())]
+    timestamp: Annotated[AwareDatetime, Field(default_factory=lambda: utcnow())]
 
     @classmethod
     def from_model_input(

--- a/agents-api/agents_api/queries/entries/create_entries.py
+++ b/agents-api/agents_api/queries/entries/create_entries.py
@@ -104,7 +104,7 @@ async def create_entries(
             item.get("token_count"),  # $11
             select_tokenizer(item.get("model"))["type"],  # $12
             item.get("created_at") or utcnow(),  # $13
-            utcnow().timestamp(),  # $14
+            utcnow(),  # $14
         ]
         for item in data_dicts
     ]

--- a/integrations-service/integrations/autogen/Entries.py
+++ b/integrations-service/integrations/autogen/Entries.py
@@ -69,7 +69,7 @@ class BaseEntry(BaseModel):
     """
     The tool call id of the tool call this message is a response to
     """
-    timestamp: Annotated[float, Field(ge=0.0)]
+    timestamp: AwareDatetime
     """
     This is the time that this event refers to.
     """

--- a/typespec/entries/models.tsp
+++ b/typespec/entries/models.tsp
@@ -116,8 +116,7 @@ model BaseEntry {
     tool_call_id?: string | null = null;
 
     /** This is the time that this event refers to. */
-    @minValue(0)
-    timestamp: float;
+    timestamp: utcDateTime;
 }
 
 model Entry extends BaseEntry {

--- a/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
+++ b/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
@@ -3350,8 +3350,8 @@ components:
           description: The tool call id of the tool call this message is a response to
           default: null
         timestamp:
-          type: number
-          minimum: 0
+          type: string
+          format: date-time
           description: This is the time that this event refers to.
     Entries.ChatMLRole:
       type: string


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Updated `timestamp` type from `float` to `AwareDatetime` across multiple files.

- Adjusted default factory for `timestamp` to use `utcnow()` directly.

- Updated OpenAPI and TypeSpec definitions to reflect the new `timestamp` type.

- Ensured consistency in `timestamp` handling across APIs and integrations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Entries.py</strong><dd><code>Update `timestamp` type in `BaseEntry`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/autogen/Entries.py

<li>Changed <code>timestamp</code> type from <code>float</code> to <code>AwareDatetime</code>.<br> <li> Updated docstring to reflect the new type.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1018/files#diff-dc9423552ffc4e369366be909f29a09cf1b38f57467cac244f2325b724939714">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>openapi_model.py</strong><dd><code>Update `timestamp` type in `CreateEntryRequest`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/autogen/openapi_model.py

<li>Changed <code>timestamp</code> type from <code>float</code> to <code>AwareDatetime</code> in <br><code>CreateEntryRequest</code>.<br> <li> Updated default factory for <code>timestamp</code> to use <code>utcnow()</code>.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1018/files#diff-b4908fde0ee2c2d8853f798d6ae2b3e9122cbd30ca1cd8e1dc4ada653c74e631">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Entries.py</strong><dd><code>Update `timestamp` type in `BaseEntry` for integrations</code>&nbsp; &nbsp; </dd></summary>
<hr>

integrations-service/integrations/autogen/Entries.py

<li>Changed <code>timestamp</code> type from <code>float</code> to <code>AwareDatetime</code>.<br> <li> Updated docstring to reflect the new type.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1018/files#diff-87437ca26aad1f85501f273d45493b939b35ce3f26b24f0ebfde2509a60dd341">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>models.tsp</strong><dd><code>Update `timestamp` type in TypeSpec model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

typespec/entries/models.tsp

<li>Changed <code>timestamp</code> type from <code>float</code> to <code>utcDateTime</code>.<br> <li> Removed <code>@minValue(0)</code> annotation for <code>timestamp</code>.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1018/files#diff-567cbbbf1e86d78d1a5e0d273fc0b746ee493d579007418a64aa5a7b53ca9552">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>openapi-1.0.0.yaml</strong><dd><code>Update OpenAPI schema for `timestamp` type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml

<li>Changed <code>timestamp</code> type from <code>number</code> to <code>string</code> with <code>date-time</code> format.<br> <li> Updated OpenAPI schema to reflect the new <code>timestamp</code> type.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1018/files#diff-cc33ca315e1bd4501d3b3bcf1ca4af5628c16524390d8a8031b09a17f065d285">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create_entries.py</strong><dd><code>Adjust `timestamp` handling in `create_entries`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/queries/entries/create_entries.py

<li>Replaced <code>utcnow().timestamp()</code> with <code>utcnow()</code> for <code>timestamp</code>.<br> <li> Ensured consistency in <code>timestamp</code> handling.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1018/files#diff-43d3b97b8ebe5c439ef4c67fd5dadca77b6cf370dec0135662ec67e37e0a7599">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `timestamp` type from `float` to `AwareDatetime` in `BaseEntry` and related classes, updating database and OpenAPI schema accordingly.
> 
>   - **Behavior**:
>     - Change `timestamp` type from `float` to `AwareDatetime` in `BaseEntry` in `Entries.py` and `CreateEntryRequest` in `openapi_model.py`.
>     - Update `create_entries()` in `create_entries.py` to use `utcnow()` instead of `utcnow().timestamp()`.
>   - **Models**:
>     - Update `timestamp` type to `utcDateTime` in `BaseEntry` in `models.tsp`.
>   - **OpenAPI**:
>     - Change `timestamp` schema type from `number` to `string` with `date-time` format in `openapi-1.0.0.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for ef99be147238c7b4ca23e83a09da49ab1d513663. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->