### PR TITLE
fix(agents-api, memory-store): Add migration for delete cascade + search docs fixes

### DIFF
--- a/agents-api/agents_api/autogen/Docs.py
+++ b/agents-api/agents_api/autogen/Docs.py
@@ -153,7 +153,7 @@ class HybridDocSearchRequest(BaseDocSearchRequest):
     model_config = ConfigDict(
         populate_by_name=True,
     )
-    confidence: Annotated[float, Field(ge=0.0, le=1.0)] = 0.5
+    confidence: Annotated[float, Field(ge=0.0, le=1.0)] = 0
     """
     The confidence cutoff level
     """
@@ -222,7 +222,7 @@ class VectorDocSearchRequest(BaseDocSearchRequest):
     model_config = ConfigDict(
         populate_by_name=True,
     )
-    confidence: Annotated[float, Field(ge=0.0, le=1.0)] = 0.5
+    confidence: Annotated[float, Field(ge=0.0, le=1.0)] = 0
     """
     The confidence cutoff level
     """

--- a/agents-api/agents_api/queries/docs/get_doc.py
+++ b/agents-api/agents_api/queries/docs/get_doc.py
@@ -44,9 +44,9 @@ LIMIT 1;
 
 
 def transform_get_doc(d: dict) -> dict:
-    content = d["content"][0] if len(d["content"]) == 1 else d["content"]
+    content = d["content"]
 
-    embeddings = d["embeddings"][0] if len(d["embeddings"]) == 1 else d["embeddings"]
+    embeddings = d["embeddings"]
 
     if isinstance(embeddings, str):
         embeddings = json.loads(embeddings)

--- a/agents-api/agents_api/queries/docs/list_docs.py
+++ b/agents-api/agents_api/queries/docs/list_docs.py
@@ -52,9 +52,9 @@ GROUP BY
 
 
 def transform_list_docs(d: dict) -> dict:
-    content = d["content"][0] if len(d["content"]) == 1 else d["content"]
+    content = d["content"]
 
-    embeddings = d["embeddings"][0] if len(d["embeddings"]) == 1 else d["embeddings"]
+    embeddings = d["embeddings"]
 
     if isinstance(embeddings, str):
         embeddings = json.loads(embeddings)

--- a/agents-api/agents_api/queries/docs/search_docs_by_embedding.py
+++ b/agents-api/agents_api/queries/docs/search_docs_by_embedding.py
@@ -74,7 +74,7 @@ async def search_docs_by_embedding(
             owner_types,
             owner_ids,
             k,
-            confidence,
+            1.0 - confidence,
             metadata_filter,
         ],
     )

--- a/agents-api/agents_api/queries/docs/search_docs_hybrid.py
+++ b/agents-api/agents_api/queries/docs/search_docs_hybrid.py
@@ -91,7 +91,7 @@ async def search_docs_hybrid(
             owner_ids,
             k,
             alpha,
-            confidence,
+            1.0 - confidence,
             metadata_filter,
             search_language,
         ],

--- a/integrations-service/integrations/autogen/Docs.py
+++ b/integrations-service/integrations/autogen/Docs.py
@@ -153,7 +153,7 @@ class HybridDocSearchRequest(BaseDocSearchRequest):
     model_config = ConfigDict(
         populate_by_name=True,
     )
-    confidence: Annotated[float, Field(ge=0.0, le=1.0)] = 0.5
+    confidence: Annotated[float, Field(ge=0.0, le=1.0)] = 0
     """
     The confidence cutoff level
     """
@@ -222,7 +222,7 @@ class VectorDocSearchRequest(BaseDocSearchRequest):
     model_config = ConfigDict(
         populate_by_name=True,
     )
-    confidence: Annotated[float, Field(ge=0.0, le=1.0)] = 0.5
+    confidence: Annotated[float, Field(ge=0.0, le=1.0)] = 0
     """
     The confidence cutoff level
     """

--- a/memory-store/migrations/000020_executions_task_cascade.down.sql
+++ b/memory-store/migrations/000020_executions_task_cascade.down.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+-- Remove cascading foreign key constraint
+ALTER TABLE executions
+    DROP CONSTRAINT IF EXISTS fk_executions_task;
+
+-- Restore original foreign key without cascading behavior
+ALTER TABLE executions
+    ADD CONSTRAINT fk_executions_task
+    FOREIGN KEY (developer_id, task_id, task_version)
+    REFERENCES tasks (developer_id, task_id, "version");
+
+COMMIT;

--- a/memory-store/migrations/000020_executions_task_cascade.up.sql
+++ b/memory-store/migrations/000020_executions_task_cascade.up.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+-- Temporarily remove foreign key to modify its behavior
+ALTER TABLE executions
+    DROP CONSTRAINT IF EXISTS fk_executions_task;
+
+-- Recreate foreign key with cascading deletes
+ALTER TABLE executions
+    ADD CONSTRAINT fk_executions_task
+    FOREIGN KEY (developer_id, task_id, task_version)
+    REFERENCES tasks (developer_id, task_id, "version")
+    ON DELETE CASCADE;
+
+COMMIT;

--- a/typespec/docs/models.tsp
+++ b/typespec/docs/models.tsp
@@ -127,7 +127,7 @@ model VectorDocSearchRequest extends BaseDocSearchRequest {
     /** The confidence cutoff level */
     @minValue(0)
     @maxValue(1)
-    confidence: float = 0.5;
+    confidence: float = 0;
 
     /** Vector to use in the search. Must be the same dimensions as the embedding model or else an error will be thrown. */
     vector: float[];
@@ -148,7 +148,7 @@ model HybridDocSearchRequest extends BaseDocSearchRequest {
     /** The confidence cutoff level */
     @minValue(0)
     @maxValue(1)
-    confidence: float = 0.5;
+    confidence: float = 0;
 
     /** The weight to apply to BM25 vs Vector search results. 0 => pure BM25; 1 => pure vector; */
     @minValue(0)

--- a/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
+++ b/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
@@ -2986,7 +2986,7 @@ components:
           minimum: 0
           maximum: 1
           description: The confidence cutoff level
-          default: 0.5
+          default: 0
         alpha:
           type: number
           minimum: 0
@@ -3069,7 +3069,7 @@ components:
           minimum: 0
           maximum: 1
           description: The confidence cutoff level
-          default: 0.5
+          default: 0
         vector:
           type: array
           items:


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added cascading delete behavior to `fk_executions_task` foreign key in `memory-store`.

- Updated confidence default value to 0 in multiple search request models.

- Fixed transformation logic for content and embeddings in `get_doc` and `list_docs`.

- Adjusted confidence calculation in hybrid and embedding-based search queries.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>Docs.py</strong><dd><code>Updated confidence default value in search request models</code></dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1023/files#diff-c805366f3ec7dffcb40e3ebe97555fa27de42fcd9e5a595bf54cdedae7fee19e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Docs.py</strong><dd><code>Updated confidence default value in search request models</code></dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1023/files#diff-12d5222f9c3db2ffac3f9ba4dc35a58edd3eb097ac832a81fe8659d97ce94124">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>000020_executions_task_cascade.down.sql</strong><dd><code>Added migration to remove cascading delete behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1023/files#diff-391219d4220bde79094f9d76c0359700c09ccb6dd9ec06ebd37479ef0b14abc7">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>000020_executions_task_cascade.up.sql</strong><dd><code>Added migration to enable cascading delete behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1023/files#diff-462b8f83e256e4549d39d8cabfe4fb1325790bb9d4a620b82320d7176cdb7cd0">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>models.tsp</strong><dd><code>Updated confidence default value in TypeSpec models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1023/files#diff-fac5bff09ad2d16696a5f025df643ec595def61c35504a8943096e81702c26cd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>openapi-1.0.0.yaml</strong><dd><code>Updated confidence default value in OpenAPI spec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1023/files#diff-cc33ca315e1bd4501d3b3bcf1ca4af5628c16524390d8a8031b09a17f065d285">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>get_doc.py</strong><dd><code>Fixed content and embeddings transformation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1023/files#diff-9c0264615896292cc993d540be24e25c070ccaa2929a87579675e815c36e4319">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>list_docs.py</strong><dd><code>Fixed content and embeddings transformation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1023/files#diff-8abede8e9aab32f6622b45ba6e76f699b4b3baa69c70ba8ad89ab689db9ea468">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>search_docs_by_embedding.py</strong><dd><code>Adjusted confidence calculation in embedding-based search</code></dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1023/files#diff-90ca5ac9fd587c97cb6020c5092ebb110e443eacb4ec62ace86d40266bc8d167">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>search_docs_hybrid.py</strong><dd><code>Adjusted confidence calculation in hybrid search</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1023/files#diff-6295463a14ae8b5e675326a1737390965f4dbd1be0614371510d36904a514f78">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds migration for cascading deletes in `executions` and updates document search confidence handling.
> 
>   - **Database Migration**:
>     - Adds `000020_executions_task_cascade.up.sql` to implement cascading deletes for `executions` table foreign key `fk_executions_task`.
>     - Adds `000020_executions_task_cascade.down.sql` to revert cascading delete changes.
>   - **Document Search**:
>     - Sets default `confidence` to `0` in `HybridDocSearchRequest` and `VectorDocSearchRequest` in `Docs.py` and `models.tsp`.
>     - Adjusts `confidence` calculation in `search_docs_by_embedding.py` and `search_docs_hybrid.py` to use `1.0 - confidence`.
>   - **Transform Functions**:
>     - Simplifies `transform_get_doc()` and `transform_list_docs()` in `get_doc.py` and `list_docs.py` by removing single-item extraction logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for e1b406c5d440685ea38110f8b112d8eff8ddef8d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->