### PR TITLE
X/migration fix: Fixed migrations and docs search route

### DIFF
--- a/agents-api/agents_api/queries/docs/search_docs_by_embedding.py
+++ b/agents-api/agents_api/queries/docs/search_docs_by_embedding.py
@@ -36,7 +36,7 @@ async def search_docs_by_embedding(
     embedding: list[float],
     k: int = 10,
     owners: list[tuple[Literal["user", "agent"], UUID]],
-    confidence: float = 0.5,
+    confidence: int | float = 0.5,
     metadata_filter: dict[str, Any] = {},
 ) -> tuple[str, list]:
     """

--- a/agents-api/agents_api/queries/docs/search_docs_hybrid.py
+++ b/agents-api/agents_api/queries/docs/search_docs_hybrid.py
@@ -46,7 +46,7 @@ async def search_docs_hybrid(
     alpha: float = 0.5,
     metadata_filter: dict[str, Any] = {},
     search_language: str = "english",
-    confidence: float = 0.5,
+    confidence: int | float = 0.5,
 ) -> tuple[str, list]:
     """
     Hybrid text-and-embedding doc search. We get top-K from each approach,

--- a/agents-api/tests/test_docs_routes.py
+++ b/agents-api/tests/test_docs_routes.py
@@ -69,7 +69,7 @@ async def _(make_request=make_request, agent=test_agent):
         assert response.status_code == 200
         assert response.json()["id"] == doc_id
         assert response.json()["title"] == "Test Agent Doc"
-        assert response.json()["content"] == "This is a test agent document."
+        assert response.json()["content"] == ["This is a test agent document."]
 
         response = make_request(
             method="DELETE",

--- a/memory-store/migrations/000021_fix_toolname_contraint.down.sql
+++ b/memory-store/migrations/000021_fix_toolname_contraint.down.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+-- Drop the updated unique constraint
+ALTER TABLE tools DROP CONSTRAINT IF EXISTS ct_unique_name_per_agent;
+
+-- Restore the original unique constraint (without developer_id)
+ALTER TABLE tools ADD CONSTRAINT ct_unique_name_per_agent 
+UNIQUE (agent_id, name, task_id);
+
+COMMIT;

--- a/memory-store/migrations/000021_fix_toolname_contraint.up.sql
+++ b/memory-store/migrations/000021_fix_toolname_contraint.up.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+-- Drop the existing unique constraint
+ALTER TABLE tools DROP CONSTRAINT IF EXISTS ct_unique_name_per_agent;
+
+-- Add the new unique constraint including developer_id
+ALTER TABLE tools ADD CONSTRAINT ct_unique_name_per_agent 
+UNIQUE (developer_id, agent_id, name, task_id);
+
+COMMIT;


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed type annotation for `confidence` parameter in search functions.

- Updated test to reflect changes in document content format.

- Added migration scripts to fix unique constraint on `tools` table.

- Improved documentation and search route functionality.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>search_docs_by_embedding.py</strong><dd><code>Update type annotation for `confidence` parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/queries/docs/search_docs_by_embedding.py

<li>Changed type annotation for <code>confidence</code> parameter to support <code>int | </code><br><code>float</code>.<br> <li> Minor adjustment to improve type flexibility in the function.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1026/files#diff-90ca5ac9fd587c97cb6020c5092ebb110e443eacb4ec62ace86d40266bc8d167">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>search_docs_hybrid.py</strong><dd><code>Update type annotation for `confidence` parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/queries/docs/search_docs_hybrid.py

<li>Changed type annotation for <code>confidence</code> parameter to support <code>int | </code><br><code>float</code>.<br> <li> Improved type flexibility in hybrid search function.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1026/files#diff-6295463a14ae8b5e675326a1737390965f4dbd1be0614371510d36904a514f78">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_docs_routes.py</strong><dd><code>Update test for document content format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/tests/test_docs_routes.py

<li>Updated test to reflect change in document content format.<br> <li> Ensured test consistency with updated API response structure.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1026/files#diff-d1de938cc8c2e3cd183efc6e8be6341d7e7160c463d9cc5f9907cfa2772bfef5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>000021_fix_toolname_contraint.down.sql</strong><dd><code>Add migration script to revert unique constraint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

memory-store/migrations/000021_fix_toolname_contraint.down.sql

<li>Added script to revert unique constraint changes on <code>tools</code> table.<br> <li> Restored original constraint excluding <code>developer_id</code>.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1026/files#diff-42fd48f8392f592273c565ec200994dcc8aec159c13138fb72f5dc6bcd964f8f">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>000021_fix_toolname_contraint.up.sql</strong><dd><code>Add migration script to update unique constraint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

memory-store/migrations/000021_fix_toolname_contraint.up.sql

<li>Added script to update unique constraint on <code>tools</code> table.<br> <li> Included <code>developer_id</code> in the new unique constraint.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1026/files#diff-f3452edd78681114333cf88f6da209f2e7904d0bef754516488c174601ac9fa7">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information