### PR TITLE
X/openai embed: Changed embedding from Voyage to OpenAI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,8 +47,7 @@ GOOGLE_APPLICATION_CREDENTIALS=.keys/julep-vertexai-svc.json
 ### > Set to either "voyage/voyage-3" or "Alibaba-NLP/gte-large-en-v1.5"
 ### > Use Alibaba-NLP/gte-large-en-v1.5 with local embedding server
 
-EMBEDDING_MODEL_ID=voyage/voyage-3
-EMBEDDING_MODEL_ID=Alibaba-NLP/gte-large-en-v1.5
+EMBEDDING_MODEL_ID=openai/text-embedding-3-large
 
 AGENTS_API_HOSTNAME=localhost
 AGENTS_API_PROTOCOL=http

--- a/agents-api/agents_api/clients/litellm.py
+++ b/agents-api/agents_api/clients/litellm.py
@@ -78,9 +78,8 @@ async def aembedding(
     custom_api_key: str | None = None,
     **settings,
 ) -> list[list[float]]:
-    # Temporarily commented out (causes errors when using voyage/voyage-3)
-    # if not custom_api_key:
-    # model = f"openai/{model}"  # FIXME: Is this still needed for litellm?
+    if not custom_api_key:
+        model = f"openai/{model}"  # This is needed for litellm
 
     input = (
         [inputs]

--- a/agents-api/agents_api/env.py
+++ b/agents-api/agents_api/env.py
@@ -83,7 +83,7 @@ litellm_master_key: str = env.str("LITELLM_MASTER_KEY", default="")
 
 # Embedding service
 # -----------------
-embedding_model_id: str = env.str("EMBEDDING_MODEL_ID", default="Alibaba-NLP/gte-large-en-v1.5")
+embedding_model_id: str = env.str("EMBEDDING_MODEL_ID", default="openai/text-embedding-3-large")
 
 embedding_dimensions: int = env.int("EMBEDDING_DIMENSIONS", default=1024)
 

--- a/agents-api/agents_api/queries/docs/create_doc.py
+++ b/agents-api/agents_api/queries/docs/create_doc.py
@@ -69,7 +69,7 @@ async def create_doc(
     owner_type: Literal["user", "agent"],
     owner_id: UUID,
     modality: Literal["text", "image", "mixed"] | None = "text",
-    embedding_model: str | None = "voyage-3",
+    embedding_model: str | None = "text-embedding-3-large",
     embedding_dimensions: int | None = 1024,
     language: str | None = "english",
     index: int | None = 0,

--- a/agents-api/docker-compose.yml
+++ b/agents-api/docker-compose.yml
@@ -10,7 +10,7 @@ x--shared-environment: &shared-environment
   AGENTS_API_URL: ${AGENTS_API_URL:-http://agents-api:8080}
   PG_DSN: ${PG_DSN:-postgres://postgres:postgres@memory-store:5432/postgres}
   DEBUG: ${AGENTS_API_DEBUG:-False}
-  EMBEDDING_MODEL_ID: ${EMBEDDING_MODEL_ID:-Alibaba-NLP/gte-large-en-v1.5}
+  EMBEDDING_MODEL_ID: ${EMBEDDING_MODEL_ID:-openai/text-embedding-3-large}
   INTEGRATION_SERVICE_URL: ${INTEGRATION_SERVICE_URL:-http://integrations:8000}
   LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY}
   LITELLM_URL: ${LITELLM_URL:-http://litellm:4000}

--- a/agents-api/tests/utils.py
+++ b/agents-api/tests/utils.py
@@ -132,8 +132,8 @@ def get_pg_dsn(start_vectorizer: bool = False):
                 pg_dsn.replace("localhost", postgres.get_container_host_ip()),
             )
             .with_env(
-                "VOYAGE_API_KEY",
-                os.environ.get("VOYAGE_API_KEY"),
+                "OPENAI_API_KEY",
+                os.environ.get("OPENAI_API_KEY"),
             )
         ) as vectorizer:
             wait_for_logs(

--- a/agents-api/tests/utils.py
+++ b/agents-api/tests/utils.py
@@ -125,7 +125,7 @@ def get_pg_dsn(start_vectorizer: bool = False):
 
         # ELSE:
         with (
-            DockerContainer("timescale/pgai-vectorizer-worker:v0.3.0")
+            DockerContainer("timescale/pgai-vectorizer-worker:latest")
             .with_network(postgres._network)  # noqa: SLF001
             .with_env(
                 "PGAI_VECTORIZER_WORKER_DB_URL",

--- a/deploy/simple-docker-compose.yaml
+++ b/deploy/simple-docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       AGENTS_API_PROTOCOL: http
       AGENTS_API_PUBLIC_PORT: "80"
       AGENTS_API_URL: http://agents-api:8080
-      EMBEDDING_MODEL_ID: voyage/voyage-3
+      EMBEDDING_MODEL_ID: openai/text-embedding-3-large
       INTEGRATION_SERVICE_URL: http://integrations:8000
       LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY}
       LITELLM_URL: http://litellm:4000
@@ -32,6 +32,10 @@ services:
         target: 8080
         published: "8080"
         protocol: tcp
+    deploy:
+      resources:
+        limits:
+          memory: 4G
 
   integrations:
     image: julepai/integrations:${TAG:-dev}
@@ -128,11 +132,49 @@ services:
         target: /data
         volume: {}
 
-  # TODO: Add memory-store with postgres
-  # memory-store:
+  memory-store:
+    image: timescale/timescaledb-ha:pg16
+    environment:
+      POSTGRES_PASSWORD: ${MEMORY_STORE_PASSWORD:-postgres}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+    ports:
+      - "5432:5432"
+    volumes:
+      - memory_store_data:/home/postgres/pgdata/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
-  # TODO: Add memory-store-backup-cron  
-  # memory-store-backup-cron:
+  vectorizer:
+    image: timescale/pgai-vectorizer-worker:v0.2.1
+    environment:
+      PGAI_VECTORIZER_WORKER_DB_URL: postgres://postgres:${MEMORY_STORE_PASSWORD:-postgres}@memory-store:5432/postgres
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+    command: [ "--poll-interval", "2s" ]
+    ports:
+      - "8501:8501"
+    volumes:
+      - vectorizer_data:/app/data
+    depends_on:
+      memory-store:
+        condition: service_healthy
+
+  memory-store-backup-cron:
+    image: appropriate/curl
+    command: >
+      sh -c "while true; do
+      pg_dump -h memory-store -U postgres -F c -b -v -f /backup/memory-store-$(date +\%Y-\%m-\%d-\%H-\%M-\%S).backup;
+      sleep 86400;
+      done"
+    environment:
+      PGPASSWORD: ${MEMORY_STORE_PASSWORD:-postgres}
+    volumes:
+      - memory_store_backup:/backup
+    depends_on:
+      memory-store:
+        condition: service_healthy
 
   temporal:
     depends_on:
@@ -223,7 +265,7 @@ services:
       AGENTS_API_PUBLIC_PORT: "80"
       AGENTS_API_URL: http://agents-api:8080
       PG_DSN: ${PG_DSN:-postgres://postgres:postgres@memory-store:5432/postgres}
-      EMBEDDING_MODEL_ID: voyage/voyage-3
+      EMBEDDING_MODEL_ID: openai/text-embedding-3-large
       INTEGRATION_SERVICE_URL: http://integrations:8000
       LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY}
       LITELLM_URL: http://litellm:4000
@@ -249,3 +291,9 @@ volumes:
     name: julep_litellm-redis-data
   temporal-db-data:
     name: julep_temporal-db-data
+  memory_store_data:
+    name: julep_memory_store_data
+  memory_store_backup:
+    name: julep_memory_store_backup
+  vectorizer_data:
+    name: julep_vectorizer_data

--- a/memory-store/docker-compose.yml
+++ b/memory-store/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     # See: https://github.com/timescale/timescaledb-docker?tab=readme-ov-file#notes-on-timescaledb-tune
     environment:
       - POSTGRES_PASSWORD=${MEMORY_STORE_PASSWORD:-postgres}
-      - VOYAGE_API_KEY=${VOYAGE_API_KEY}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
     ports:
       - "5432:5432"
     volumes:
@@ -29,8 +29,8 @@ services:
     image: timescale/pgai-vectorizer-worker:v0.3.0
     environment:
       - PGAI_VECTORIZER_WORKER_DB_URL=postgres://postgres:${MEMORY_STORE_PASSWORD:-postgres}@memory-store:5432/postgres
-      - VOYAGE_API_KEY=${VOYAGE_API_KEY}
-    command: [ "--poll-interval", "5s" ]
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+    command: [ "--poll-interval", "2s" ]
     depends_on:
       memory-store:
         condition: service_healthy

--- a/memory-store/docker-compose.yml
+++ b/memory-store/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     # See: https://github.com/timescale/timescaledb-docker?tab=readme-ov-file#notes-on-timescaledb-tune
     environment:
       - POSTGRES_PASSWORD=${MEMORY_STORE_PASSWORD:-postgres}
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:?OPENAI_API_KEY is required}
       - TS_TUNE_MAX_CONNS=${TS_TUNE_MAX_CONNS:-1000}
     ports:
       - "5432:5432"
@@ -30,8 +30,8 @@ services:
     image: timescale/pgai-vectorizer-worker:latest
     environment:
       - PGAI_VECTORIZER_WORKER_DB_URL=postgres://postgres:${MEMORY_STORE_PASSWORD:-postgres}@memory-store:5432/postgres
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
-    command: [ "--poll-interval", "2s" ]
+      - OPENAI_API_KEY=${OPENAI_API_KEY:?OPENAI_API_KEY is required}
+    command: [ "--poll-interval", "5s" ]
     depends_on:
       memory-store:
         condition: service_healthy

--- a/memory-store/docker-compose.yml
+++ b/memory-store/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     environment:
       - POSTGRES_PASSWORD=${MEMORY_STORE_PASSWORD:-postgres}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - TS_TUNE_MAX_CONNS=${TS_TUNE_MAX_CONNS:-1000}
     ports:
       - "5432:5432"
     volumes:
@@ -26,7 +27,7 @@ services:
       retries: 5
 
   vectorizer-worker:
-    image: timescale/pgai-vectorizer-worker:v0.3.0
+    image: timescale/pgai-vectorizer-worker:latest
     environment:
       - PGAI_VECTORIZER_WORKER_DB_URL=postgres://postgres:${MEMORY_STORE_PASSWORD:-postgres}@memory-store:5432/postgres
       - OPENAI_API_KEY=${OPENAI_API_KEY}

--- a/memory-store/migrations/000007_ann.up.sql
+++ b/memory-store/migrations/000007_ann.up.sql
@@ -10,7 +10,7 @@ SELECT
     ai.create_vectorizer (
         source => 'docs',
         destination => 'docs_embeddings',
-        embedding => ai.embedding_voyageai ('voyage-3', 1024, 'document'), -- need to parameterize this
+        embedding => ai.embedding_openai ('text-embedding-3-large', 1024, 'document'), -- need to parameterize this
         -- actual chunking is managed by the docs table
         -- this is to prevent running out of context window
         chunking => ai.chunking_recursive_character_text_splitter (

--- a/memory-store/migrations/000012_transitions.down.sql
+++ b/memory-store/migrations/000012_transitions.down.sql
@@ -14,6 +14,16 @@ DROP INDEX IF EXISTS idx_transitions_next;
 DROP INDEX IF EXISTS idx_transitions_current;
 
 -- Drop the transitions table (this will also remove it from hypertables)
+DO $$
+BEGIN
+    BEGIN
+        DELETE FROM transitions;
+    EXCEPTION
+        WHEN others THEN
+            RAISE NOTICE 'An error occurred during deleting all from transitions: %, %', SQLSTATE, SQLERRM;
+    END;
+END $$;
+
 DROP TABLE IF EXISTS transitions;
 
 -- Drop custom types if they exist

--- a/memory-store/migrations/000012_transitions.up.sql
+++ b/memory-store/migrations/000012_transitions.up.sql
@@ -158,7 +158,7 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- Create a trigger on the transitions table
-CREATE TRIGGER validate_transition BEFORE INSERT ON transitions FOR EACH ROW
+CREATE OR REPLACE TRIGGER validate_transition BEFORE INSERT ON transitions FOR EACH ROW
 EXECUTE FUNCTION check_valid_transition ();
 
 COMMIT;

--- a/memory-store/migrations/000013_executions_continuous_view.down.sql
+++ b/memory-store/migrations/000013_executions_continuous_view.down.sql
@@ -1,8 +1,16 @@
 BEGIN;
 
 -- Drop the continuous aggregate policy
-SELECT
-    remove_continuous_aggregate_policy ('latest_transitions');
+DO $$
+BEGIN
+    BEGIN
+        SELECT
+            remove_continuous_aggregate_policy ('latest_transitions');
+    EXCEPTION
+        WHEN others THEN
+            RAISE NOTICE 'An error occurred during remove_continuous_aggregate_policy(latest_transitions): %, %', SQLSTATE, SQLERRM;
+    END;
+END $$;
 
 -- Drop the views
 DROP VIEW IF EXISTS latest_executions;

--- a/memory-store/migrations/000017_compression.down.sql
+++ b/memory-store/migrations/000017_compression.down.sql
@@ -1,17 +1,49 @@
 BEGIN;
 
-SELECT
-    remove_compression_policy ('entries');
+DO $$
+BEGIN
+    BEGIN
+        SELECT
+            remove_compression_policy ('entries');
+    EXCEPTION
+        WHEN others THEN
+            RAISE NOTICE 'An error occurred during remove_compression_policy(entries): %, %', SQLSTATE, SQLERRM;
+    END;
+END $$;
 
-SELECT
-    remove_compression_policy ('transitions');
+DO $$
+BEGIN
+    BEGIN
+        SELECT
+            remove_compression_policy ('transitions');
+    EXCEPTION
+        WHEN others THEN
+            RAISE NOTICE 'An error occurred during remove_compression_policy(transitions): %, %', SQLSTATE, SQLERRM;
+    END;
+END $$;
 
-ALTER TABLE entries
-SET
-    (timescaledb.compress = FALSE);
+DO $$
+BEGIN
+    BEGIN
+        ALTER TABLE entries
+        SET
+            (timescaledb.compress = FALSE);
+    EXCEPTION
+        WHEN others THEN
+            RAISE NOTICE 'An error occurred during unsetting entries.compress: %, %', SQLSTATE, SQLERRM;
+    END;
+END $$;
 
-ALTER TABLE transitions
-SET
-    (timescaledb.compress = FALSE);
+DO $$
+BEGIN
+    BEGIN
+        ALTER TABLE transitions
+        SET
+            (timescaledb.compress = FALSE);
+    EXCEPTION
+        WHEN others THEN
+            RAISE NOTICE 'An error occurred during unsetting transitions.compress: %, %', SQLSTATE, SQLERRM;
+    END;
+END $$;
 
 COMMIT;

--- a/memory-store/migrations/000017_compression.up.sql
+++ b/memory-store/migrations/000017_compression.up.sql
@@ -7,26 +7,57 @@
 
 BEGIN;
 
-ALTER TABLE entries
-SET
-    (
-        timescaledb.compress = TRUE,
-        timescaledb.compress_segmentby = 'session_id',
-        timescaledb.compress_orderby = 'created_at DESC, entry_id DESC'
-    );
+DO $$
+BEGIN
+    BEGIN
+        ALTER TABLE entries
+            SET (
+                timescaledb.compress = TRUE,
+                timescaledb.compress_segmentby = 'session_id',
+                timescaledb.compress_orderby = 'created_at DESC, entry_id DESC'
+            );
+    EXCEPTION
+        WHEN others THEN
+            RAISE NOTICE 'An error occurred during entries.compress: %, %', SQLSTATE, SQLERRM;
+    END;
+END $$;
 
-SELECT
-    add_compression_policy ('entries', INTERVAL '7 days');
+DO $$
+BEGIN
+    BEGIN
+        SELECT
+            add_compression_policy ('entries', INTERVAL '7 days');
+    EXCEPTION
+        WHEN others THEN
+            RAISE NOTICE 'An error occurred during add_compression_policy(entries): %, %', SQLSTATE, SQLERRM;
+    END;
+END $$;
 
-ALTER TABLE transitions
-SET
-    (
-        timescaledb.compress = TRUE,
-        timescaledb.compress_segmentby = 'execution_id',
-        timescaledb.compress_orderby = 'created_at DESC, transition_id DESC'
-    );
+DO $$
+BEGIN
+    BEGIN
+        ALTER TABLE transitions
+        SET
+            (
+                timescaledb.compress = TRUE,
+                timescaledb.compress_segmentby = 'execution_id',
+                timescaledb.compress_orderby = 'created_at DESC, transition_id DESC'
+            );
+    EXCEPTION
+        WHEN others THEN
+            RAISE NOTICE 'An error occurred during transitions.compress: %, %', SQLSTATE, SQLERRM;
+    END;
+END $$;
 
-SELECT
-    add_compression_policy ('transitions', INTERVAL '7 days');
+DO $$
+BEGIN
+    BEGIN
+        SELECT
+            add_compression_policy ('transitions', INTERVAL '7 days');
+    EXCEPTION
+        WHEN others THEN
+            RAISE NOTICE 'An error occurred during add_compression_policy(transitions): %, %', SQLSTATE, SQLERRM;
+    END;
+END $$;
 
 COMMIT;

--- a/memory-store/migrations/000018_doc_search.up.sql
+++ b/memory-store/migrations/000018_doc_search.up.sql
@@ -25,8 +25,8 @@ declare
     cached_embedding vector(1024);
     model_input_md5 text;
 begin
-    if _provider != 'voyageai' then
-        raise exception 'Only voyageai provider is supported';
+    if _provider != 'openai' then
+        raise exception 'Only openai provider is supported';
     end if;
 
     model_input_md5 := md5(_provider || '++' || _model || '++' || _input_text || '++' || _input_type);
@@ -40,7 +40,7 @@ begin
     end if;
 
     -- Not found in cache, call AI embedding function
-    cached_embedding := ai.voyageai_embed(
+    cached_embedding := ai.openai_embed(
         _model,
         _input_text,
         _input_type,
@@ -185,8 +185,8 @@ OR REPLACE FUNCTION embed_and_search_by_vector (
     k integer DEFAULT 3,
     confidence float DEFAULT 0.5,
     metadata_filter jsonb DEFAULT NULL,
-    embedding_provider text DEFAULT 'voyageai',
-    embedding_model text DEFAULT 'voyage-3',
+    embedding_provider text DEFAULT 'openai',
+    embedding_model text DEFAULT 'text-embedding-3-large',
     input_type text DEFAULT 'query',
     api_key text DEFAULT NULL,
     api_key_name text DEFAULT NULL
@@ -469,8 +469,8 @@ OR REPLACE FUNCTION embed_and_search_hybrid (
     confidence float DEFAULT 0.5,
     metadata_filter jsonb DEFAULT NULL,
     search_language text DEFAULT 'english',
-    embedding_provider text DEFAULT 'voyageai',
-    embedding_model text DEFAULT 'voyage-3',
+    embedding_provider text DEFAULT 'openai',
+    embedding_model text DEFAULT 'text-embedding-3-large',
     input_type text DEFAULT 'query',
     api_key text DEFAULT NULL,
     api_key_name text DEFAULT NULL

--- a/memory-store/migrations/000019_system_developer.down.sql
+++ b/memory-store/migrations/000019_system_developer.down.sql
@@ -21,6 +21,10 @@ DELETE FROM users
 WHERE developer_id = '00000000-0000-0000-0000-000000000000'::uuid;
 
 -- Remove the system developer
+DELETE FROM "sessions"
+WHERE developer_id = '00000000-0000-0000-0000-000000000000'::uuid;
+
+-- Remove the system developer
 DELETE FROM developers
 WHERE developer_id = '00000000-0000-0000-0000-000000000000'::uuid;
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Updated embedding model from `voyage` to `openai` across multiple files.

- Replaced `VOYAGE_API_KEY` with `OPENAI_API_KEY` in configurations.

- Adjusted vectorizer-worker polling interval in `docker-compose.yml`.

- Updated SQL migrations to use OpenAI embedding functions and parameters.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create_doc.py</strong><dd><code>Updated default embedding model in `create_doc`.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/queries/docs/create_doc.py

- Changed default embedding model to `text-embedding-3-large`.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1031/files#diff-a13a4010bdf480b8e790b9a4ce301e2119deace70adb63147a4624edc57c12ef">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>000007_ann.up.sql</strong><dd><code>Switched embedding function to OpenAI in migration.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

memory-store/migrations/000007_ann.up.sql

- Updated embedding function to use OpenAI parameters.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1031/files#diff-3062ddad4e1a8a056917385bbd71751509576355c9c12459a529eae6d39dae1d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>000018_doc_search.up.sql</strong><dd><code>Migrated embedding logic to OpenAI in SQL migration.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

memory-store/migrations/000018_doc_search.up.sql

<li>Replaced <code>voyageai</code> with <code>openai</code> in provider checks.<br> <li> Updated embedding function calls to OpenAI.<br> <li> Changed default embedding provider and model to OpenAI.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1031/files#diff-1b8f7f1bc54e6b0c0090b952201ef0bd12d6484b1b88b97c84d4c425b2fe867c">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Updated API key environment variable in tests.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/tests/utils.py

- Replaced `VOYAGE_API_KEY` with `OPENAI_API_KEY`.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1031/files#diff-f57e08363e297b9a26b89a750f00ff1dbcbfdba9189591c528f35691d58a7432">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Updated API key and polling interval in Docker configuration.</code></dd></summary>
<hr>

memory-store/docker-compose.yml

<li>Replaced <code>VOYAGE_API_KEY</code> with <code>OPENAI_API_KEY</code>.<br> <li> Adjusted vectorizer-worker polling interval to 2 seconds.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1031/files#diff-be7d4bf397f2de2121c7c5de65342dd80a470f5060e85ce8194006d26c39227f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Updated embedding model from Voyage to OpenAI, adjusted API keys, and modified configurations across multiple files.
> 
>   - **Embedding Model Update**:
>     - Changed embedding model from `voyage` to `openai` in `create_doc.py` and `docker-compose.yml`.
>     - Updated SQL migrations (`000007_ann.up.sql`, `000018_doc_search.up.sql`) to use OpenAI embedding functions.
>   - **API Key Changes**:
>     - Replaced `VOYAGE_API_KEY` with `OPENAI_API_KEY` in `utils.py` and `docker-compose.yml`.
>   - **Configuration Adjustments**:
>     - Adjusted vectorizer-worker polling interval to 2 seconds in `docker-compose.yml`.
>   - **Miscellaneous**:
>     - Removed `drafts/cozo` submodule.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for c923f78a320e494dca84da3a8ab9c85f1218c53d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->