### PR TITLE
fix: Add safety clause to text seaerch altering query

### DIFF
--- a/memory-store/migrations/000006_docs.up.sql
+++ b/memory-store/migrations/000006_docs.up.sql
@@ -122,22 +122,27 @@ DO $$
 DECLARE
     lang text;
 BEGIN
-    FOR lang IN (SELECT cfgname FROM pg_ts_config WHERE cfgname IN (
-        'arabic', 'danish', 'dutch', 'english', 'finnish', 'french',
-        'german', 'greek', 'hungarian', 'indonesian', 'irish', 'italian',
-        'lithuanian', 'nepali', 'norwegian', 'portuguese', 'romanian',
-        'russian', 'spanish', 'swedish', 'tamil', 'turkish'
-    ))
-    LOOP
-        -- Configure integer dictionary
-        EXECUTE format('ALTER TEXT SEARCH CONFIGURATION %I
-            ALTER MAPPING FOR int, uint WITH intdict', lang);
+    BEGIN
+        FOR lang IN (SELECT cfgname FROM pg_ts_config WHERE cfgname IN (
+            'arabic', 'danish', 'dutch', 'english', 'finnish', 'french',
+            'german', 'greek', 'hungarian', 'indonesian', 'irish', 'italian',
+            'lithuanian', 'nepali', 'norwegian', 'portuguese', 'romanian',
+            'russian', 'spanish', 'swedish', 'tamil', 'turkish'
+        ))
+        LOOP
+            -- Configure integer dictionary
+            EXECUTE format('ALTER TEXT SEARCH CONFIGURATION %I
+                ALTER MAPPING FOR int, uint WITH intdict', lang);
 
-        -- Configure synonym and stemming
-        EXECUTE format('ALTER TEXT SEARCH CONFIGURATION %I
-            ALTER MAPPING FOR asciihword, hword_asciipart, hword, hword_part, word, asciiword
-            WITH xsyn, %I_stem', lang, lang);
-    END LOOP;
+            -- Configure synonym and stemming
+            EXECUTE format('ALTER TEXT SEARCH CONFIGURATION %I
+                ALTER MAPPING FOR asciihword, hword_asciipart, hword, hword_part, word, asciiword
+                WITH xsyn, %I_stem', lang, lang);
+        END LOOP;
+    EXCEPTION
+        WHEN others THEN
+            RAISE NOTICE 'An error occurred during altering search configurations: %, %', SQLSTATE, SQLERRM;
+    END;
 END
 $$;
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added safety clause to handle exceptions in text search configuration.

- Ensured robust error handling during text search alterations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>000006_docs.up.sql</strong><dd><code>Added error handling for text search configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

memory-store/migrations/000006_docs.up.sql

<li>Wrapped text search configuration loop in a <code>BEGIN...EXCEPTION</code> block.<br> <li> Added error handling to log SQLSTATE and SQLERRM on failure.<br> <li> Ensured robustness by catching all exceptions during configuration <br>updates.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1037/files#diff-6132303705f971e71d4f72778866e821d1e40a90cf380bf81911641535be33d2">+21/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information