### PR TITLE
hotfix: switch query table to transitions

### DIFF
--- a/agents-api/agents_api/queries/executions/get_paused_execution_token.py
+++ b/agents-api/agents_api/queries/executions/get_paused_execution_token.py
@@ -6,9 +6,10 @@ from beartype import beartype
 from ...common.utils.db_exceptions import common_db_exceptions
 from ..utils import pg_query, rewrap_exceptions, wrap_in_class
 
+# FIXME: We should use latest_transitions instead of transitions
 # Query to get a paused execution token
 get_paused_execution_token_query = """
-SELECT * FROM latest_transitions
+SELECT * FROM transitions
 WHERE
     execution_id = $1
         AND type = 'wait'


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed query to use `transitions` table instead of `latest_transitions`.

- Updated SQL query for paused execution token retrieval.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>get_paused_execution_token.py</strong><dd><code>Corrected SQL query table for paused execution token</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/queries/executions/get_paused_execution_token.py

<li>Changed SQL query to use <code>transitions</code> table.<br> <li> Added a FIXME comment suggesting the use of <code>latest_transitions</code>.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1050/files#diff-4eea35b55589364151f8e94587ed07ab70493127fb6c5690d46a6fdddd46030a">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switch SQL query in `get_paused_execution_token.py` to use `transitions` table instead of `latest_transitions`.
> 
>   - **Behavior**:
>     - Change SQL query in `get_paused_execution_token.py` to use `transitions` table instead of `latest_transitions` for paused execution tokens.
>     - FIXME comment added to indicate potential future change back to `latest_transitions`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 05f10a393185c202e0a34b90708ace999f31c7df. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->