### PR TITLE
feat: Make csv stdlib module available in Python expressions

### DIFF
--- a/agents-api/agents_api/activities/utils.py
+++ b/agents-api/agents_api/activities/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import csv
 import datetime as dt
 import json
 import math
@@ -251,6 +252,30 @@ ALLOWED_FUNCTIONS = {
 }
 
 
+class stdlib_csv:
+    reader = csv.reader
+    writer = csv.writer
+    register_dialect = csv.register_dialect
+    unregister_dialect = csv.unregister_dialect
+    get_dialect = csv.get_dialect
+    list_dialects = csv.list_dialects
+    field_size_limit = csv.field_size_limit
+    DictReader = csv.DictReader
+    DictWriter = csv.DictWriter
+    Dialect = csv.Dialect
+    excel = csv.excel
+    excel_tab = csv.excel_tab
+    unix_dialect = csv.unix_dialect
+    Sniffer = csv.Sniffer
+    QUOTE_ALL = csv.QUOTE_ALL
+    QUOTE_MINIMAL = csv.QUOTE_MINIMAL
+    QUOTE_NONNUMERIC = csv.QUOTE_NONNUMERIC
+    QUOTE_NONE = csv.QUOTE_NONE
+    QUOTE_NOTNULL = csv.QUOTE_NOTNULL
+    QUOTE_STRINGS = csv.QUOTE_STRINGS
+    Error = csv.Error
+
+
 # Safe regex operations (using re2)
 class stdlib_re:
     fullmatch = re2.fullmatch
@@ -394,6 +419,7 @@ stdlib = {
     "urllib": stdlib_urllib,
     "random": stdlib_random,
     "time": stdlib_time,
+    "csv": stdlib_csv,
 }
 
 constants = {

--- a/agents-api/agents_api/activities/utils.py
+++ b/agents-api/agents_api/activities/utils.py
@@ -346,15 +346,15 @@ def csv_dictwriter(
 
 
 class stdlib_csv:
-    reader = csv_reader
-    writer = csv_writer
+    reader = staticmethod(csv_reader)
+    writer = staticmethod(csv_writer)
     register_dialect = csv.register_dialect
     unregister_dialect = csv.unregister_dialect
     get_dialect = csv.get_dialect
     list_dialects = csv.list_dialects
     field_size_limit = csv.field_size_limit
-    DictReader = csv_dictreader
-    DictWriter = csv_dictwriter
+    DictReader = staticmethod(csv_dictreader)
+    DictWriter = staticmethod(csv_dictwriter)
     Dialect = csv.Dialect
     excel = csv.excel
     excel_tab = csv.excel_tab

--- a/agents-api/agents_api/activities/utils.py
+++ b/agents-api/agents_api/activities/utils.py
@@ -1,3 +1,4 @@
+import io
 import asyncio
 import base64
 import csv
@@ -252,16 +253,108 @@ ALLOWED_FUNCTIONS = {
 }
 
 
+def csv_reader(
+    data: str, 
+    dialect="excel",
+    delimiter: str = ",",
+    quotechar: str | None = '"',
+    escapechar: str | None = None,
+    doublequote: bool = True,
+    skipinitialspace: bool = False,
+    lineterminator: str = "\r\n",
+    quoting=0,
+    strict: bool = False,
+):
+    return csv.reader(
+        io.StringIO(data),
+        dialect,
+        delimiter=delimiter,
+        quotechar=quotechar,
+        escapechar=escapechar,
+        doublequote=doublequote,
+        skipinitialspace=skipinitialspace,
+        lineterminator=lineterminator,
+        quoting=quoting,
+        strict=strict,
+    )
+
+
+def csv_writer(
+    data: str, 
+    dialect="excel",
+    delimiter: str = ",",
+    quotechar: str | None = '"',
+    escapechar: str | None = None,
+    doublequote: bool = True,
+    skipinitialspace: bool = False,
+    lineterminator: str = "\r\n",
+    quoting=0,
+    strict: bool = False,
+):
+    return csv.writer(
+        io.StringIO(data),
+        dialect,
+        delimiter=delimiter,
+        quotechar=quotechar,
+        escapechar=escapechar,
+        doublequote=doublequote,
+        skipinitialspace=skipinitialspace,
+        lineterminator=lineterminator,
+        quoting=quoting,
+        strict=strict,
+    )
+
+
+def csv_dictreader(
+    data: str, 
+    fieldnames=None, 
+    restkey=None, 
+    restval=None, 
+    dialect="excel", 
+    *args, 
+    **kwds,
+):
+    return csv.DictReader(
+        io.StringIO(data),
+        fieldnames=fieldnames, 
+        restkey=restkey, 
+        restval=restval, 
+        dialect=dialect, 
+        *args, 
+        **kwds,
+    )
+
+
+def csv_dictwriter(
+    data: str,
+    fieldnames, 
+    restval="", 
+    extrasaction="raise",
+    dialect="excel", 
+    *args, 
+    **kwds,
+):
+    return csv.DictWriter(
+        io.StringIO(data),
+        fieldnames,
+        restval=restval,
+        extrasaction=extrasaction,
+        dialect=dialect,
+        *args,
+        **kwds,
+    )
+
+
 class stdlib_csv:
-    reader = csv.reader
-    writer = csv.writer
+    reader = csv_reader
+    writer = csv_writer
     register_dialect = csv.register_dialect
     unregister_dialect = csv.unregister_dialect
     get_dialect = csv.get_dialect
     list_dialects = csv.list_dialects
     field_size_limit = csv.field_size_limit
-    DictReader = csv.DictReader
-    DictWriter = csv.DictWriter
+    DictReader = csv_dictreader
+    DictWriter = csv_dictwriter
     Dialect = csv.Dialect
     excel = csv.excel
     excel_tab = csv.excel_tab

--- a/agents-api/agents_api/activities/utils.py
+++ b/agents-api/agents_api/activities/utils.py
@@ -1,8 +1,8 @@
-import io
 import asyncio
 import base64
 import csv
 import datetime as dt
+import io
 import json
 import math
 import random
@@ -254,7 +254,7 @@ ALLOWED_FUNCTIONS = {
 
 
 def csv_reader(
-    data: str, 
+    data: str,
     dialect="excel",
     delimiter: str = ",",
     quotechar: str | None = '"',
@@ -280,7 +280,7 @@ def csv_reader(
 
 
 def csv_writer(
-    data: str, 
+    data: str,
     dialect="excel",
     delimiter: str = ",",
     quotechar: str | None = '"',
@@ -306,32 +306,32 @@ def csv_writer(
 
 
 def csv_dictreader(
-    data: str, 
-    fieldnames=None, 
-    restkey=None, 
-    restval=None, 
-    dialect="excel", 
-    *args, 
+    data: str,
+    fieldnames=None,
+    restkey=None,
+    restval=None,
+    dialect="excel",
+    *args,
     **kwds,
 ):
     return csv.DictReader(
         io.StringIO(data),
-        fieldnames=fieldnames, 
-        restkey=restkey, 
-        restval=restval, 
-        dialect=dialect, 
-        *args, 
+        fieldnames=fieldnames,
+        restkey=restkey,
+        restval=restval,
+        dialect=dialect,
+        *args,
         **kwds,
     )
 
 
 def csv_dictwriter(
     data: str,
-    fieldnames, 
-    restval="", 
+    fieldnames,
+    restval="",
     extrasaction="raise",
-    dialect="excel", 
-    *args, 
+    dialect="excel",
+    *args,
     **kwds,
 ):
     return csv.DictWriter(

--- a/agents-api/tests/test_activities_utils.py
+++ b/agents-api/tests/test_activities_utils.py
@@ -1,12 +1,12 @@
-from ward import test
 from agents_api.activities.utils import get_evaluator
+from ward import test
 
 
 @test("evaluator: csv reader")
 def _():
     e = get_evaluator({})
     result = e.eval('[r for r in csv.reader("a,b,c\\n1,2,3")]')
-    assert result == [['a', 'b', 'c'], ['1', '2', '3']]
+    assert result == [["a", "b", "c"], ["1", "2", "3"]]
 
 
 @test("evaluator: csv writer")

--- a/agents-api/tests/test_activities_utils.py
+++ b/agents-api/tests/test_activities_utils.py
@@ -1,0 +1,17 @@
+from ward import test
+from agents_api.activities.utils import get_evaluator
+
+
+@test("evaluator: csv reader")
+def _():
+    e = get_evaluator({})
+    result = e.eval('[r for r in csv.reader("a,b,c\\n1,2,3")]')
+    assert result == [['a', 'b', 'c'], ['1', '2', '3']]
+
+
+@test("evaluator: csv writer")
+def _():
+    e = get_evaluator({})
+    result = e.eval('csv.writer("a,b,c\\n1,2,3").writerow(["4", "5", "6"])')
+    # at least no exceptions
+    assert result == 7

--- a/documentation/docs/advanced/python-expression.mdx
+++ b/documentation/docs/advanced/python-expression.mdx
@@ -108,6 +108,92 @@ Example using these functions in an evaluate step:
     extracted_content: extract_json('Here is some JSON: ```json\n{"key": "value"}\n```')
 ```
 
+### CSV Functions
+- `reader`: `def reader(data: str, dialect="excel", delimiter: str = ",", quotechar: str | None = '"', escapechar: str | None = None, doublequote: bool = True, skipinitialspace: bool = False, lineterminator: str = "\r\n", quoting=0, strict: bool = False) -> csv._reader`
+
+  Creates a CSV reader.
+
+- `writer`: `def writer(data: str, dialect="excel", delimiter: str = ",", quotechar: str | None = '"', escapechar: str | None = None, doublequote: bool = True, skipinitialspace: bool = False, lineterminator: str = "\r\n", quoting=0, strict: bool = False) -> csv._writer`
+
+  Creates a CSV writer.
+
+- `DictReader`: `class DictReader(data: str, fieldnames=None, restkey=None, restval=None, dialect="excel", *args, **kwds)`
+
+  Create an object that operates like a regular reader but maps the information in each row to a dict.
+
+- `DictWriter`: `class DictWriter(data: str, fieldnames, restval="", extrasaction="raise", dialect="excel", *args, **kwds)`
+
+  Create an object which operates like a regular writer but maps dictionaries onto output rows.
+
+- `register_dialect`: `def register_dialect(name: str, dialect: type[Dialect] = ..., *, delimiter: str = ",", quotechar: str | None = '"', escapechar: str | None = None, doublequote: bool = True, skipinitialspace: bool = False, lineterminator: str = "\r\n", quoting: _QuotingType = 0, strict: bool = False) -> csv._reader`
+
+  Associate dialect with name.
+
+- `unregister_dialect`: `def unregister_dialect(name: str) -> None`
+
+  Delete the dialect associated with name from the dialect registry.
+
+- `get_dialect`: `def get_dialect(name: str) -> Dialect`
+
+  Return the dialect associated with name.
+
+- `list_dialects`: `def list_dialects() -> list[str]`
+
+  Return the names of all registered dialects.
+
+- `field_size_limit`: `def field_size_limit(new_limit: int = ...) -> int`
+
+  Returns the current maximum field size allowed by the parser.
+
+- `Dialect`: `class Dialect()`
+
+  The Dialect class is a container class whose attributes contain information for how to handle doublequotes, whitespace, delimiters, etc.
+
+- `excel`: `class excel()`
+
+  The excel class defines the usual properties of an Excel-generated CSV file.
+
+- `excel_tab`: `class excel_tab()`
+
+  The excel_tab class defines the usual properties of an Excel-generated TAB-delimited file.
+
+- `unix_dialect`: `class unix_dialect()`
+
+  The unix_dialect class defines the usual properties of a CSV file generated on UNIX systems, i.e. using '\n' as line terminator and quoting all fields.
+
+- `Sniffer`: `class Sniffer`
+
+  The Sniffer class is used to deduce the format of a CSV file.
+
+- `QUOTE_ALL` - Instructs writer objects to quote all fields.
+
+- `QUOTE_MINIMAL` - Instructs writer objects to only quote those fields which contain special characters such as delimiter, quotechar or any of the characters in lineterminator.
+
+- `QUOTE_NONNUMERIC` - Instructs writer objects to quote all non-numeric fields. Instructs reader objects to convert all non-quoted fields to type float.
+
+- `QUOTE_NONE` - Instructs writer objects to never quote fields.
+
+- `QUOTE_NOTNULL` - Instructs writer objects to quote all fields which are not None.
+
+- `QUOTE_STRINGS` - Instructs writer objects to always place quotes around fields which are strings.
+
+- `Error`: `class Error()`
+
+  Raised by any of the functions when an error is detected.
+
+This module tries to mimic `csv` module from the standard Python library. You can find additional information [here](https://docs.python.org/3/library/csv.html)
+
+## Example Usage
+
+```yaml
+name: Data Processing Task
+
+main:
+  # Using _ as input
+  - evaluate:
+      csv_data: [row for row in csv.reader("a,b,c\n1,2,3")]
+```
+
 ### Standard Library Modules
 - `re`: Regular expressions (using re2)
 - `json`: JSON operations
@@ -120,6 +206,7 @@ Example using these functions in an evaluate step:
 - `urllib.parse`: URL parsing operations
 - `random`: Random number generation
 - `time`: Time operations
+- `csv`: CSV operations
 
 For the complete list of available functions and their safe implementations, refer to the [utils.py](https://github.com/julep-ai/julep/blob/main/agents-api/agents_api/activities/utils.py) file in the source code.
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds CSV functionality to Python expressions with a new `stdlib_csv` class, tests, and documentation updates.
> 
>   - **Behavior**:
>     - Adds `stdlib_csv` class in `utils.py` to mimic Python's `csv` module.
>     - Includes `csv_reader`, `csv_writer`, `csv_dictreader`, and `csv_dictwriter` functions.
>     - Supports CSV operations like `register_dialect`, `unregister_dialect`, `get_dialect`, and `list_dialects`.
>   - **Testing**:
>     - Adds tests in `test_activities_utils.py` for `csv.reader` and `csv.writer` using `get_evaluator()`.
>   - **Documentation**:
>     - Updates `python-expression.mdx` to include CSV functions and usage examples.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for f1f8fcc50faf87895259fea2f3e57ceac528f3b1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->