### PR TITLE
feat(cli): add agent flag to import and -h as an alias for help

### DIFF
--- a/cli/src/julep_cli/__init__.py
+++ b/cli/src/julep_cli/__init__.py
@@ -3,7 +3,7 @@ from .app import app
 from .auth import auth
 from .chat import chat
 from .executions import executions_app as executions_app
-from .importt import import_app as import_app
+from .importt import importt
 from .init import init
 from .logs import logs
 from .ls import ls
@@ -19,7 +19,7 @@ __all__ = [
     "chat",
     "executions_app",
     "get_config",
-    "import_app",
+    "importt",
     "init",
     "logs",
     "ls",

--- a/cli/src/julep_cli/app.py
+++ b/cli/src/julep_cli/app.py
@@ -14,27 +14,38 @@ error_console = Console(stderr=True, style="bold red")
 
 local_tz = tz.gettz(time.tzname[time.daylight])
 
-# Initialize typer app
+# Initialize typer app with -h as an alias for help
 app = WrappedTyper(
     name="julep",
     help="Command line interface for the Julep platform",
     no_args_is_help=True,
     pretty_exceptions_short=True,
+    context_settings={"help_option_names": ["-h", "--help"]},
 )
 
 init_tui(app)
 
-# Initialize subcommands
-agents_app = WrappedTyper(help="Manage AI agents")
-tasks_app = WrappedTyper(help="Manage tasks")
-tools_app = WrappedTyper(help="Manage tools")
-import_app = WrappedTyper(help="Import entities from the Julep platform")
-executions_app = WrappedTyper(help="Manage executions")
+# Initialize subcommands with help alias too
+agents_app = WrappedTyper(
+    help="Manage AI agents",
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+tasks_app = WrappedTyper(
+    help="Manage tasks",
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+tools_app = WrappedTyper(
+    help="Manage tools",
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+executions_app = WrappedTyper(
+    help="Manage executions",
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
 
 app.add_typer(agents_app, name="agents")
 app.add_typer(tasks_app, name="tasks")
 app.add_typer(tools_app, name="tools")
-app.add_typer(import_app, name="import")
 app.add_typer(executions_app, name="executions")
 
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added `-h` as an alias for `--help` across CLI commands.

- Refactored `import` command to support multiple entity types.

- Improved error handling for unsupported options in `import` command.

- Renamed `import_app` to `importt` for consistency.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Rename `import_app` to `importt` for consistency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/src/julep_cli/__init__.py

- Renamed `import_app` to `importt` in imports and `__all__`.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1133/files#diff-5cef2b4d81858458ce2e974d71135c522ac2f8cfc328217b030f82329d47e274">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>app.py</strong><dd><code>Add `-h` alias and update subcommands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/src/julep_cli/app.py

<li>Added <code>-h</code> as an alias for <code>--help</code> in CLI commands.<br> <li> Updated subcommands to include <code>-h</code> alias.<br> <li> Removed reference to <code>import_app</code>.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1133/files#diff-6605f700c5ea68d1d3aa97e7588a2d732aba8adc39a082a78b9ddfdd6e80aaef">+19/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>importt.py</strong><dd><code>Refactor `import` command and improve error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/src/julep_cli/importt.py

<li>Refactored <code>import</code> command to support multiple entity types.<br> <li> Added error handling for unsupported options like <code>tools</code> and <code>task</code>.<br> <li> Ensured <code>agent</code> option is mandatory with proper error messaging.<br> <li> Added help display when no agent ID is provided.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1133/files#diff-abc10886b617d5b73a5ad6cea596235af61e166bf21aedcfeddddc06979f8b46">+82/-19</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `import` command with `--agent` option and `-h` alias for help, renaming `import_app` to `importt`.
> 
>   - **Behavior**:
>     - Adds `import` command to `app.py` with `--agent`, `--task`, and `--tool` options in `importt.py`. Only `--agent` is supported.
>     - Adds `-h` as an alias for `--help` in `app.py` and subcommands.
>     - Errors for unsupported `--task` and `--tool` options in `importt.py`.
>     - Requires `--agent` option and agent ID for import in `importt.py`.
>   - **Renames**:
>     - Renames `import_app` to `importt`.
>   - **Misc**:
>     - Updates `__init__.py` to reflect `importt` rename.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 252fadba1ea9622df1063f327b56696be2c2eeb3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->