### PR TITLE
feat(agents-api): enable backwards compatibility for old syntax

### DIFF
--- a/agents-api/agents_api/activities/task_steps/base_evaluate.py
+++ b/agents-api/agents_api/activities/task_steps/base_evaluate.py
@@ -18,6 +18,8 @@ from ..utils import get_evaluator
 
 
 def backwards_compatibility(expr: str) -> str:
+    expr = expr.strip()
+
     if expr.startswith("$ "):
         return expr
 

--- a/agents-api/agents_api/activities/task_steps/base_evaluate.py
+++ b/agents-api/agents_api/activities/task_steps/base_evaluate.py
@@ -17,10 +17,31 @@ from ...common.protocol.tasks import StepContext
 from ..utils import get_evaluator
 
 
+def backwards_compatibility(expr: str) -> str:
+    if expr.startswith("$ "):
+        return expr
+
+    if "{{" in expr:
+        return "$ f'''" + expr.replace("{{", "{").replace("}}", "}") + "'''"
+
+    if (
+        (expr.startswith("[") and expr.endswith("]"))
+        or (expr.startswith("_[") and expr.endswith("]"))
+        or (expr.startswith("_.") and expr.endswith("]"))
+        or "outputs[" in expr
+        or "inputs[" in expr
+        or expr == "_"
+    ):
+        return "$ " + expr
+
+    return expr
+
+
 # Recursive evaluation helper function
 def _recursive_evaluate(expr, evaluator: SimpleEval):
     if isinstance(expr, str):
         try:
+            expr = backwards_compatibility(expr)
             if isinstance(expr, str) and expr.startswith("$ "):
                 expr = expr[2:].strip()
             else:

--- a/agents-api/agents_api/common/protocol/tasks.py
+++ b/agents-api/agents_api/common/protocol/tasks.py
@@ -264,6 +264,8 @@ class StepContext(BaseModel):
             steps[i] = step
 
         dump["steps"] = steps
+        dump["inputs"] = {i: step["input"] for i, step in steps.items()}
+        dump["outputs"] = {i: step["output"] for i, step in steps.items() if "output" in step}
         return dump | {"_": current_input}
 
 

--- a/agents-api/tests/test_base_evaluate.py
+++ b/agents-api/tests/test_base_evaluate.py
@@ -1,7 +1,10 @@
 import uuid
 from unittest.mock import patch
 
-from agents_api.activities.task_steps.base_evaluate import base_evaluate, backwards_compatibility
+from agents_api.activities.task_steps.base_evaluate import (
+    backwards_compatibility,
+    base_evaluate,
+)
 from agents_api.autogen.openapi_model import (
     Agent,
     TaskSpecDef,
@@ -137,6 +140,7 @@ async def _():
         )
         assert result == 15
 
+
 @test("utility: base_evaluate - backwards compatibility")
 async def _():
     exprs = "[[x + 5]]"
@@ -170,6 +174,7 @@ async def _():
     exprs = "_[0]"
     result = await base_evaluate(exprs, values={"_": [7]})
     assert result == 7
+
 
 @test("utility: backwards_compatibility")
 async def _():

--- a/agents-api/tests/test_base_evaluate.py
+++ b/agents-api/tests/test_base_evaluate.py
@@ -227,3 +227,8 @@ async def _():
     exprs = "hello world"
     result = backwards_compatibility(exprs)
     assert result == "hello world"
+
+    # Test spaces at the beginning and end
+    exprs = "  _[0]  "
+    result = backwards_compatibility(exprs)
+    assert result == "$ _[0]"


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added `backwards_compatibility` function to handle old syntax.

- Integrated backwards compatibility in `_recursive_evaluate` function.

- Enhanced `prepare_for_step` to include `inputs` and `outputs` in the dump.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_evaluate.py</strong><dd><code>Add backwards compatibility handling in evaluation logic</code>&nbsp; </dd></summary>
<hr>

agents-api/agents_api/activities/task_steps/base_evaluate.py

<li>Introduced <code>backwards_compatibility</code> function for old syntax handling.<br> <li> Modified <code>_recursive_evaluate</code> to use <code>backwards_compatibility</code>.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1151/files#diff-05b346521c23f568c9804ac59931eb4fd5a61ec88110a783debb1ed329b47470">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tasks.py</strong><dd><code>Enhance step preparation with inputs and outputs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/common/protocol/tasks.py

<li>Updated <code>prepare_for_step</code> to include <code>inputs</code> and <code>outputs</code>.<br> <li> Enhanced step data structure for better compatibility.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1151/files#diff-8a1abcedcd95d0217595a53a9c503fa4dec969579ce9cf9a120193413758fbef">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces backwards compatibility for old syntax in evaluation logic and enhances step preparation to include inputs and outputs.
> 
>   - **Behavior**:
>     - Added `backwards_compatibility` function in `base_evaluate.py` to handle old syntax.
>     - Integrated `backwards_compatibility` into `_recursive_evaluate` in `base_evaluate.py`.
>     - Enhanced `prepare_for_step` in `tasks.py` to include `inputs` and `outputs` in the dump.
>   - **Tests**:
>     - Added tests for `backwards_compatibility` and `base_evaluate` in `test_base_evaluate.py` to verify handling of old syntax and new input/output structure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 3c3de649691f3a74f1c1175aca93323547015430. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->