### PR TITLE
feat(agents-api): make ``parallelism = task_max_parallelism`` the default for MapReduce

### DIFF
--- a/agents-api/agents_api/workflows/task_execution/__init__.py
+++ b/agents-api/agents_api/workflows/task_execution/__init__.py
@@ -59,6 +59,7 @@ with workflow.unsafe.imports_passed_through():
     from ...common.retry_policies import DEFAULT_RETRY_POLICY
     from ...env import (
         debug,
+        task_max_parallelism,
         temporal_heartbeat_timeout,
         temporal_schedule_to_close_timeout,
         testing,
@@ -304,7 +305,9 @@ class TaskExecutionWorkflow:
             return PartialTransition(output=None)
 
         parallelism = step.parallelism
-        if parallelism is None or parallelism == 1:
+        if parallelism is None:
+            parallelism = task_max_parallelism
+        if parallelism == 1:
             result = await execute_map_reduce_step(
                 context=self.context,
                 execution_input=self.context.execution_input,

--- a/agents-api/agents_api/workflows/task_execution/helpers.py
+++ b/agents-api/agents_api/workflows/task_execution/helpers.py
@@ -271,14 +271,14 @@ async def execute_map_reduce_step_parallel(
     reduce: str | None = None,
     parallelism: int = task_max_parallelism,
 ) -> Any:
-
     task = validate_execution_input(execution_input)
     workflow.logger.info(f"MapReduce step: Processing {len(items)} items")
     results = initial
 
     if isinstance(context.current_step.map, YieldStep):
-        raise ValueError("Subworkflow step not supported in parallel map reduce")
-    
+        msg = "Subworkflow step not supported in parallel map reduce"
+        raise ValueError(msg)
+
     parallelism = min(parallelism, task_max_parallelism)
     assert parallelism > 1, "Parallelism must be greater than 1"
 

--- a/agents-api/agents_api/workflows/task_execution/helpers.py
+++ b/agents-api/agents_api/workflows/task_execution/helpers.py
@@ -15,6 +15,7 @@ with workflow.unsafe.imports_passed_through():
         TransitionTarget,
         Workflow,
         WorkflowStep,
+        YieldStep,
     )
     from ...common.protocol.tasks import (
         ExecutionInput,
@@ -270,10 +271,14 @@ async def execute_map_reduce_step_parallel(
     reduce: str | None = None,
     parallelism: int = task_max_parallelism,
 ) -> Any:
+
     task = validate_execution_input(execution_input)
     workflow.logger.info(f"MapReduce step: Processing {len(items)} items")
     results = initial
 
+    if isinstance(context.current_step.map, YieldStep):
+        raise ValueError("Subworkflow step not supported in parallel map reduce")
+    
     parallelism = min(parallelism, task_max_parallelism)
     assert parallelism > 1, "Parallelism must be greater than 1"
 

--- a/agents-api/tests/test_workflow_helpers.py
+++ b/agents-api/tests/test_workflow_helpers.py
@@ -4,6 +4,8 @@ from unittest.mock import patch
 from agents_api.autogen.openapi_model import (
     Agent,
     MapReduceStep,
+    PromptItem,
+    PromptStep,
     TaskSpecDef,
     TransitionTarget,
     Workflow,
@@ -65,4 +67,53 @@ async def _():
                 execution_input=execution_input,
                 items=["1", "2", "3"],
                 current_input={},
+            )
+
+
+@test("execute_map_reduce_step_parallel: parallelism must be greater than 1")
+async def _():
+    async def _resp():
+        return "response"
+
+    subworkflow_step = PromptStep(prompt=[PromptItem(content="hi there", role="user")])
+
+    step = MapReduceStep(
+        kind_="map_reduce",
+        map=subworkflow_step,
+        over="$ [1, 2, 3]",
+        parallelism=1,
+    )
+
+    execution_input = ExecutionInput(
+        developer_id=uuid.uuid4(),
+        agent=Agent(
+            id=uuid.uuid4(), name="test agent", created_at=utcnow(), updated_at=utcnow()
+        ),
+        agent_tools=[],
+        arguments={},
+        task=TaskSpecDef(
+            name="task1",
+            tools=[],
+            workflows=[Workflow(name="main", steps=[step])],
+        ),
+    )
+
+    context = StepContext(
+        execution_input=execution_input,
+        current_input={"current_input": "value 1"},
+        cursor=TransitionTarget(
+            workflow="main",
+            step=0,
+        ),
+    )
+    with patch("agents_api.workflows.task_execution.helpers.workflow") as workflow:
+        workflow.execute_activity.return_value = await _resp()
+        with raises(AssertionError):
+            await execute_map_reduce_step_parallel(
+                context=context,
+                map_defn=step.map,
+                execution_input=execution_input,
+                items=["1", "2", "3"],
+                current_input={},
+                parallelism=1,
             )

--- a/agents-api/tests/test_workflow_helpers.py
+++ b/agents-api/tests/test_workflow_helpers.py
@@ -1,59 +1,21 @@
 import uuid
-from datetime import timedelta
-from unittest.mock import Mock, call, patch
+from unittest.mock import patch
 
-from agents_api.activities import task_steps
-from agents_api.activities.execute_api_call import execute_api_call
-from agents_api.activities.execute_integration import execute_integration
-from agents_api.activities.execute_system import execute_system
-from agents_api.activities.task_steps.base_evaluate import base_evaluate
 from agents_api.autogen.openapi_model import (
     Agent,
-    ApiCallDef,
-    BaseIntegrationDef,
-    CaseThen,
-    EvaluateStep,
-    Execution,
-    ForeachDo,
-    ForeachStep,
-    GetStep,
-    IfElseWorkflowStep,
-    LogStep,
     MapReduceStep,
-    PromptItem,
-    PromptStep,
-    ReturnStep,
-    SetStep,
-    SwitchStep,
-    SystemDef,
     TaskSpecDef,
-    TaskToolDef,
-    ToolCallStep,
-    Transition,
     TransitionTarget,
-    WaitForInputInfo,
-    WaitForInputStep,
     Workflow,
     YieldStep,
 )
 from agents_api.common.protocol.tasks import (
     ExecutionInput,
-    PartialTransition,
     StepContext,
-    StepOutcome,
 )
-from agents_api.common.retry_policies import DEFAULT_RETRY_POLICY
 from agents_api.common.utils.datetime import utcnow
-from agents_api.env import (
-    debug,
-    temporal_heartbeat_timeout,
-    temporal_schedule_to_close_timeout,
-    testing,
-)
-from agents_api.workflows.task_execution import TaskExecutionWorkflow
-from temporalio.exceptions import ApplicationError
-from ward import raises, test
 from agents_api.workflows.task_execution.helpers import execute_map_reduce_step_parallel
+from ward import raises, test
 
 
 @test("execute_map_reduce_step_parallel: subworkflow step not supported")
@@ -61,7 +23,9 @@ async def _():
     async def _resp():
         return "response"
 
-    subworkflow_step = YieldStep(kind_="yield", workflow='subworkflow', arguments={'test': '$ _'})
+    subworkflow_step = YieldStep(
+        kind_="yield", workflow="subworkflow", arguments={"test": "$ _"}
+    )
 
     step = MapReduceStep(
         kind_="map_reduce",

--- a/agents-api/tests/test_workflow_helpers.py
+++ b/agents-api/tests/test_workflow_helpers.py
@@ -1,0 +1,104 @@
+import uuid
+from datetime import timedelta
+from unittest.mock import Mock, call, patch
+
+from agents_api.activities import task_steps
+from agents_api.activities.execute_api_call import execute_api_call
+from agents_api.activities.execute_integration import execute_integration
+from agents_api.activities.execute_system import execute_system
+from agents_api.activities.task_steps.base_evaluate import base_evaluate
+from agents_api.autogen.openapi_model import (
+    Agent,
+    ApiCallDef,
+    BaseIntegrationDef,
+    CaseThen,
+    EvaluateStep,
+    Execution,
+    ForeachDo,
+    ForeachStep,
+    GetStep,
+    IfElseWorkflowStep,
+    LogStep,
+    MapReduceStep,
+    PromptItem,
+    PromptStep,
+    ReturnStep,
+    SetStep,
+    SwitchStep,
+    SystemDef,
+    TaskSpecDef,
+    TaskToolDef,
+    ToolCallStep,
+    Transition,
+    TransitionTarget,
+    WaitForInputInfo,
+    WaitForInputStep,
+    Workflow,
+    YieldStep,
+)
+from agents_api.common.protocol.tasks import (
+    ExecutionInput,
+    PartialTransition,
+    StepContext,
+    StepOutcome,
+)
+from agents_api.common.retry_policies import DEFAULT_RETRY_POLICY
+from agents_api.common.utils.datetime import utcnow
+from agents_api.env import (
+    debug,
+    temporal_heartbeat_timeout,
+    temporal_schedule_to_close_timeout,
+    testing,
+)
+from agents_api.workflows.task_execution import TaskExecutionWorkflow
+from temporalio.exceptions import ApplicationError
+from ward import raises, test
+from agents_api.workflows.task_execution.helpers import execute_map_reduce_step_parallel
+
+
+@test("execute_map_reduce_step_parallel: subworkflow step not supported")
+async def _():
+    async def _resp():
+        return "response"
+
+    subworkflow_step = YieldStep(kind_="yield", workflow='subworkflow', arguments={'test': '$ _'})
+
+    step = MapReduceStep(
+        kind_="map_reduce",
+        map=subworkflow_step,
+        over="$ [1, 2, 3]",
+        parallelism=3,
+    )
+
+    execution_input = ExecutionInput(
+        developer_id=uuid.uuid4(),
+        agent=Agent(
+            id=uuid.uuid4(), name="test agent", created_at=utcnow(), updated_at=utcnow()
+        ),
+        agent_tools=[],
+        arguments={},
+        task=TaskSpecDef(
+            name="task1",
+            tools=[],
+            workflows=[Workflow(name="main", steps=[step])],
+        ),
+    )
+
+    context = StepContext(
+        execution_input=execution_input,
+        current_input={"current_input": "value 1"},
+        cursor=TransitionTarget(
+            workflow="main",
+            step=0,
+        ),
+    )
+    with patch("agents_api.workflows.task_execution.helpers.workflow") as workflow:
+        workflow.execute_activity.return_value = await _resp()
+        with raises(ValueError):
+            await execute_map_reduce_step_parallel(
+                context=context,
+                map_defn=step.map,
+                execution_input=execution_input,
+                items=["1", "2", "3"],
+                current_input={},
+            )


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Set `parallelism = task_max_parallelism` as default for MapReduce.

- Raise `ValueError` for subworkflow in parallel MapReduce steps.

- Add tests for `parallelism` validation and subworkflow handling.

- Refactor and lint `agents-api` for improved readability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Default `parallelism` handling in MapReduce steps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/workflows/task_execution/__init__.py

<li>Set <code>parallelism</code> to <code>task_max_parallelism</code> if not specified.<br> <li> Adjusted logic for handling <code>parallelism</code> in MapReduce steps.<br> <li> Imported <code>task_max_parallelism</code> for use in MapReduce logic.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1158/files#diff-d12de13df920a717fe2e94addd7e85fbb6216144a71cd1aba10e84f44cecf9f1">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>helpers.py</strong><dd><code>Validation and constraints for parallel MapReduce</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/workflows/task_execution/helpers.py

<li>Added validation to raise <code>ValueError</code> for subworkflow in parallel <br>MapReduce.<br> <li> Ensured <code>parallelism</code> is capped at <code>task_max_parallelism</code>.<br> <li> Added assertion for <code>parallelism</code> to be greater than 1.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1158/files#diff-e07a50b10e52250df2258d6ebef066bdb95ad3dd0c17af0548684828418adcc0">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_workflow_helpers.py</strong><dd><code>Tests for MapReduce `parallelism` and subworkflow handling</code></dd></summary>
<hr>

agents-api/tests/test_workflow_helpers.py

<li>Added test for subworkflow handling in parallel MapReduce.<br> <li> Added test to ensure <code>parallelism</code> is greater than 1.<br> <li> Mocked dependencies for testing MapReduce functionality.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1158/files#diff-d11ce94e8183d1352f9e1159f749822b3aa8fee438a1417b7231dcd14de6ac03">+119/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>