### PR TITLE
feat(agents-api): treat leaf nodes as fstrings

### DIFF
--- a/agents-api/agents_api/activities/task_steps/base_evaluate.py
+++ b/agents-api/agents_api/activities/task_steps/base_evaluate.py
@@ -47,7 +47,7 @@ def _recursive_evaluate(expr, evaluator: SimpleEval):
             if isinstance(expr, str) and expr.startswith("$ "):
                 expr = expr[2:].strip()
             else:
-                return expr
+                expr = f"f'''{expr}'''"
             return evaluator.eval(expr)
         except Exception as e:
             evaluate_error = EvaluateError(e, expr, evaluator.names)

--- a/agents-api/tests/test_base_evaluate.py
+++ b/agents-api/tests/test_base_evaluate.py
@@ -44,6 +44,10 @@ async def _():
     result = await base_evaluate(exprs, values={})
     assert result == "hello world"
 
+    exprs = "I forgot to put a dollar sign, can you still calculate {x + 5}?"
+    result = await base_evaluate(exprs, values={"x": 5})
+    assert result == "I forgot to put a dollar sign, can you still calculate 10?"
+
 
 @test("utility: base_evaluate - dict")
 async def _():


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `_recursive_evaluate` to treat leaf nodes as f-strings and update tests to verify this behavior.
> 
>   - **Behavior**:
>     - Modify `_recursive_evaluate` in `base_evaluate.py` to treat leaf nodes as f-strings by wrapping them with `f'''{expr}'''`.
>     - Handles expressions without a dollar sign by evaluating them as f-strings.
>   - **Tests**:
>     - Add test case in `test_base_evaluate.py` to verify evaluation of expressions without a dollar sign as f-strings.
>     - Ensure existing tests cover new behavior for expressions with and without dollar signs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 00360ebfe61af31a50f27d48aec63f673991dbff. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->