### PR TITLE
chore: Bump up litellm version to latest stable release

### DIFF
--- a/llm-proxy/docker-compose.yml
+++ b/llm-proxy/docker-compose.yml
@@ -1,7 +1,7 @@
 name: julep-llm-proxy
 
 x--litellm-base: &litellm-base
-  image: ghcr.io/berriai/litellm-database:main-v1.57.0
+  image: ghcr.io/berriai/litellm-database:main-v1.61.7
   restart: unless-stopped
   hostname: litellm
   ports:


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Updated the `litellm` Docker image to version `v1.61.7`.

- Ensured the latest stable release is used in the `docker-compose.yml`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Update `litellm` Docker image version in configuration</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

llm-proxy/docker-compose.yml

<li>Updated the <code>litellm</code> Docker image version.<br> <li> Changed from <code>v1.57.0</code> to <code>v1.61.7</code>.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1176/files#diff-00149b150e95349b2fab7789ee187da818d0cc1f2e25b19f1e59e23868b6507e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `litellm-database` image version in `docker-compose.yml` to `main-v1.61.7`.
> 
>   - **Version Update**:
>     - Update `litellm-database` image version from `main-v1.57.0` to `main-v1.61.7` in `docker-compose.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 6f318009ccc106119e8f80e446ec91065546472a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

---
# EntelligenceAI PR Summary 
 The Docker image version in the `llm-proxy` configuration has been updated to `main-v1.61.7`. 

