### PR TITLE
fix(memory-store): add a call to decompress transitions chunks

### DIFF
--- a/memory-store/migrations/000026_transition_cursor.up.sql
+++ b/memory-store/migrations/000026_transition_cursor.up.sql
@@ -1,5 +1,9 @@
 BEGIN;
 
+-- Decompress any existing compressed chunks
+SELECT decompress_chunk(c, true) 
+FROM show_chunks('transitions') c;
+
 -- Temporarily disable compression
 ALTER TABLE transitions SET (timescaledb.compress = false);
 


### PR DESCRIPTION

---
# EntelligenceAI PR Summary 
 The update involves adding a step to decompress existing data chunks before turning off compression in the SQL migration script. 


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Decompresses existing chunks in `transitions` table and updates schema to add `scope_id` with constraints in `000026_transition_cursor.up.sql`.
> 
>   - **Decompression**:
>     - Adds `SELECT decompress_chunk(c, true)` to decompress existing chunks in `transitions` table in `000026_transition_cursor.up.sql`.
>   - **Schema Changes**:
>     - Temporarily disables compression on `transitions` table.
>     - Adds `scope_id` attribute to `transition_cursor` type.
>     - Updates existing rows to set default `scope_id` where `NULL`.
>     - Adds check constraint to ensure `scope_id` is not `NULL` for future inserts/updates.
>     - Re-enables compression on `transitions` table.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 3582645067e1fcdfafac2e1cf81100dcd2d0222f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->