### PR TITLE
feat(agents-api): enable self recursion

### DIFF
--- a/agents-api/agents_api/queries/executions/create_execution_transition.py
+++ b/agents-api/agents_api/queries/executions/create_execution_transition.py
@@ -69,7 +69,7 @@ def validate_transition_targets(data: CreateTransitionRequest) -> None:
         case "resume" | "step":
             assert data.next is not None, "Next target must be provided for resume/step"
 
-            if data.next.workflow == data.current.workflow:
+            if data.next.scope_id == data.current.scope_id:
                 assert data.next.step > data.current.step, (
                     "Next step must be greater than current"
                 )

--- a/agents-api/tests/test_execution_queries.py
+++ b/agents-api/tests/test_execution_queries.py
@@ -138,6 +138,49 @@ async def _(dsn=pg_dsn, developer_id=test_developer_id, execution=test_execution
     assert result.type == "init_branch"
     assert result.output == {"result": "test"}
 
+@test("query: create execution transition - validate transition targets")
+async def _(dsn=pg_dsn, developer_id=test_developer_id, execution=test_execution):
+    pool = await create_db_pool(dsn=dsn)
+    scope_id = uuid7()
+    await create_execution_transition(
+        developer_id=developer_id,
+        execution_id=execution.id,
+        data=CreateTransitionRequest(
+            type="init_branch",
+            output={"result": "test"},
+            current={"workflow": "subworkflow", "step": 0, "scope_id": scope_id},
+            next={"workflow": "subworkflow", "step": 0, "scope_id": scope_id},
+        ),
+        connection_pool=pool,
+    )
+
+    await create_execution_transition(
+        developer_id=developer_id,
+        execution_id=execution.id,
+        data=CreateTransitionRequest(
+            type="step",
+            output={"result": "test"},
+            current={"workflow": "subworkflow", "step": 0, "scope_id": scope_id},
+            next={"workflow": "subworkflow", "step": 1, "scope_id": scope_id},
+        ),
+        connection_pool=pool,
+    )
+
+    result = await create_execution_transition(
+        developer_id=developer_id,
+        execution_id=execution.id,
+        data=CreateTransitionRequest(
+            type="step",
+            output={"result": "test"},
+            current={"workflow": "subworkflow", "step": 1, "scope_id": scope_id},
+            next={"workflow": "subworkflow", "step": 0, "scope_id": uuid7()},
+        ),
+        connection_pool=pool,
+    )
+
+    assert result is not None
+    assert result.type == "step"
+    assert result.output == {"result": "test"}
 
 @test("query: create execution transition with execution update")
 async def _(

--- a/agents-api/tests/test_execution_queries.py
+++ b/agents-api/tests/test_execution_queries.py
@@ -138,6 +138,7 @@ async def _(dsn=pg_dsn, developer_id=test_developer_id, execution=test_execution
     assert result.type == "init_branch"
     assert result.output == {"result": "test"}
 
+
 @test("query: create execution transition - validate transition targets")
 async def _(dsn=pg_dsn, developer_id=test_developer_id, execution=test_execution):
     pool = await create_db_pool(dsn=dsn)
@@ -181,6 +182,7 @@ async def _(dsn=pg_dsn, developer_id=test_developer_id, execution=test_execution
     assert result is not None
     assert result.type == "step"
     assert result.output == {"result": "test"}
+
 
 @test("query: create execution transition with execution update")
 async def _(


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Updated validation logic for execution transitions.

- Enhanced validation to use `scope_id` instead of `workflow`.

- Added new test cases for transition validation.

- Ensured proper handling of `scope_id` in transitions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create_execution_transition.py</strong><dd><code>Update validation logic for execution transitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/queries/executions/create_execution_transition.py

<li>Updated validation logic to compare <code>scope_id</code> instead of <code>workflow</code>.<br> <li> Ensured <code>next.step</code> is greater than <code>current.step</code> for transitions.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1185/files#diff-feae3b1bf6bf6aa864b610dcc899fbb3ba722208426f2c1a0021c9f9650ddbb3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_execution_queries.py</strong><dd><code>Add tests for execution transition validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/tests/test_execution_queries.py

<li>Added new test for validating execution transition targets.<br> <li> Tested transitions with <code>scope_id</code> and step comparisons.<br> <li> Verified correct handling of <code>scope_id</code> in transitions.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1185/files#diff-51519c833a02178e0e9fb808b57af5c0607450bb228800f9be7d8d984c33af83">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

---
# EntelligenceAI PR Summary 
 The update refines the transition validation logic by comparing `scope_id` instead of `workflow` in `create_execution_transition.py`, ensuring correct step progression. New test cases in `test_execution_queries.py` verify this logic. 

