### PR TITLE
fix(agents-api): properly exit a subworkflow with return step

### DIFF
--- a/agents-api/agents_api/common/protocol/tasks.py
+++ b/agents-api/agents_api/common/protocol/tasks.py
@@ -136,13 +136,18 @@ transition_to_execution_status: dict[TransitionType | None, ExecutionStatus] = {
 class PartialTransition(create_partial_model(CreateTransitionRequest)):
     user_state: dict[str, Any] = Field(default_factory=dict)
 
+
 class WorkflowResult(BaseModel):
     """
     Represents the result of a workflow execution, including metadata about how it was completed.
     """
+
     state: PartialTransition
-    returned: bool = False  # True if execution of a sub-workflow ended due to a return statement
+    returned: bool = (
+        False  # True if execution of a sub-workflow ended due to a return statement
+    )
     metadata: dict[str, Any] = Field(default_factory=dict)
+
 
 class StepContext(BaseModel):
     loaded: bool = False

--- a/agents-api/agents_api/common/protocol/tasks.py
+++ b/agents-api/agents_api/common/protocol/tasks.py
@@ -136,6 +136,13 @@ transition_to_execution_status: dict[TransitionType | None, ExecutionStatus] = {
 class PartialTransition(create_partial_model(CreateTransitionRequest)):
     user_state: dict[str, Any] = Field(default_factory=dict)
 
+class WorkflowResult(BaseModel):
+    """
+    Represents the result of a workflow execution, including metadata about how it was completed.
+    """
+    state: PartialTransition
+    returned: bool = False  # True if execution of a sub-workflow ended due to a return statement
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
 class StepContext(BaseModel):
     loaded: bool = False

--- a/agents-api/agents_api/routers/tasks/create_task_execution.py
+++ b/agents-api/agents_api/routers/tasks/create_task_execution.py
@@ -94,6 +94,7 @@ async def start_execution(
                 current=TransitionTarget(
                     workflow="main",
                     step=0,
+                    scope_id=uuid7(),
                 ),
                 next=None,
             ),

--- a/agents-api/agents_api/workflows/task_execution/__init__.py
+++ b/agents-api/agents_api/workflows/task_execution/__init__.py
@@ -56,6 +56,7 @@ with workflow.unsafe.imports_passed_through():
         PartialTransition,
         StepContext,
         StepOutcome,
+        WorkflowResult,
     )
     from ...common.retry_policies import DEFAULT_RETRY_POLICY
     from ...env import (
@@ -211,11 +212,11 @@ class TaskExecutionWorkflow:
     ):
         workflow.logger.info(f"Log step: {step.log}")
         if self.outcome is None or self.context is None:
-            return PartialTransition(output=None)
+            return WorkflowResult(state=PartialTransition(output=None))
 
         # Set the output to the current input
         # Add the logged message to metadata
-        return PartialTransition(
+        partial_transition = PartialTransition(
             output=self.context.current_input,
             metadata={
                 "step_type": type(self.context.current_step).__name__,
@@ -223,31 +224,29 @@ class TaskExecutionWorkflow:
             },
         )
 
+        return WorkflowResult(state=partial_transition)
+
     async def _handle_ReturnStep(
         self,
         step: ReturnStep,
     ):
         if self.outcome is None or self.context is None:
-            return None
+            return WorkflowResult(state=PartialTransition(output=None))
 
         output = self.outcome.output
         workflow.logger.info("Return step: Finishing workflow with output")
         workflow.logger.debug(f"Return step: {output}")
-        await transition(
-            self.context,
-            output=output,
-            type="finish" if self.context.is_main else "finish_branch",
-            next=None,
-            last_error=self.last_error,
+        return WorkflowResult(
+            state=PartialTransition(output=output),
+            returned=True,
         )
-        return output
 
     async def _handle_SwitchStep(
         self,
         step: SwitchStep,
     ):
         if self.outcome is None or self.context is None:
-            return PartialTransition(output=None)
+            return WorkflowResult(state=PartialTransition(output=None))
 
         index = self.outcome.output
         if index >= 0:
@@ -258,19 +257,19 @@ class TaskExecutionWorkflow:
                 index=index,
                 current_input=self.context.current_input,
             )
-            return PartialTransition(output=result)
+            return WorkflowResult(state=result.state, returned=result.returned)
         if index < 0:
             workflow.logger.error("Switch step: Invalid negative index")
             msg = "Negative indices not allowed"
             raise ApplicationError(msg)
-        return None
+        return WorkflowResult(state=PartialTransition(output=None))
 
     async def _handle_IfElseWorkflowStep(
         self,
         step: IfElseWorkflowStep,
     ):
         if self.outcome is None or self.context is None:
-            return PartialTransition(output=None)
+            return WorkflowResult(state=PartialTransition(output=None))
 
         result = await execute_if_else_branch(
             context=self.context,
@@ -281,14 +280,14 @@ class TaskExecutionWorkflow:
             current_input=self.context.current_input,
         )
 
-        return PartialTransition(output=result)
+        return WorkflowResult(state=result.state, returned=result.returned)
 
     async def _handle_ForeachStep(
         self,
         step: ForeachStep,
     ):
         if self.outcome is None or self.context is None:
-            return PartialTransition(output=None)
+            return WorkflowResult(state=PartialTransition(output=None))
 
         result = await execute_foreach_step(
             context=self.context,
@@ -297,14 +296,14 @@ class TaskExecutionWorkflow:
             items=self.outcome.output,
             current_input=self.context.current_input,
         )
-        return PartialTransition(output=result)
+        return WorkflowResult(state=result.state, returned=result.returned)
 
     async def _handle_MapReduceStep(
         self,
         step: MapReduceStep,
     ):
         if self.outcome is None or self.context is None:
-            return PartialTransition(output=None)
+            return WorkflowResult(state=PartialTransition(output=None))
 
         parallelism = step.parallelism
         if parallelism is None:
@@ -331,7 +330,7 @@ class TaskExecutionWorkflow:
                 parallelism=parallelism,
             )
 
-        return PartialTransition(output=result)
+        return WorkflowResult(state=result.state, returned=result.returned)
 
     async def _handle_SleepStep(
         self,
@@ -351,18 +350,18 @@ class TaskExecutionWorkflow:
         if self.context is not None:
             result = await asyncio.sleep(total_seconds, result=self.context.current_input)
 
-        return PartialTransition(output=result)
+        return WorkflowResult(state=PartialTransition(output=result))
 
     async def _handle_EvaluateStep(
         self,
         step: EvaluateStep,
     ):
         if self.outcome is None:
-            return PartialTransition(output=None)
+            return WorkflowResult(state=PartialTransition(output=None))
 
         output = self.outcome.output
         workflow.logger.debug(f"Evaluate step: Completed evaluation with output: {output}")
-        return PartialTransition(output=output)
+        return WorkflowResult(state=PartialTransition(output=output))
 
     async def _handle_ErrorWorkflowStep(
         self,
@@ -386,7 +385,7 @@ class TaskExecutionWorkflow:
         step: YieldStep,
     ):
         if self.outcome is None or self.context is None:
-            return PartialTransition(output=None)
+            return WorkflowResult(state=PartialTransition(output=None))
 
         output = self.outcome.output
         if self.outcome.transition_to is None:
@@ -414,7 +413,7 @@ class TaskExecutionWorkflow:
             current_input=output,
         )
 
-        return PartialTransition(output=result)
+        return WorkflowResult(state=result.state, returned=False)
 
     async def _handle_WaitForInputStep(
         self,
@@ -422,7 +421,7 @@ class TaskExecutionWorkflow:
     ):
         workflow.logger.info("Wait for input step: Waiting for external input")
         if self.outcome is None:
-            return PartialTransition(type="resume", output=None)
+            return WorkflowResult(state=PartialTransition(type="resume", output=None))
 
         result = await workflow.execute_activity(
             task_steps.raise_complete_async,
@@ -432,14 +431,14 @@ class TaskExecutionWorkflow:
             heartbeat_timeout=timedelta(seconds=temporal_heartbeat_timeout),
         )
 
-        return PartialTransition(type="resume", output=result)
+        return WorkflowResult(state=PartialTransition(type="resume", output=result))
 
     async def _handle_PromptStep(
         self,
         step: PromptStep,
     ):
         if self.outcome is None:
-            return PartialTransition(output=None)
+            return WorkflowResult(state=PartialTransition(output=None))
 
         message = self.outcome.output
 
@@ -449,7 +448,7 @@ class TaskExecutionWorkflow:
             or message["choices"][0]["finish_reason"] != "tool_calls"
         ):
             workflow.logger.debug(f"Prompt step: Received response: {message}")
-            return PartialTransition(output=message)
+            return WorkflowResult(state=PartialTransition(output=message))
 
         choice = message["choices"][0]
         tool_calls_input = choice["message"]["tool_calls"]
@@ -480,7 +479,7 @@ class TaskExecutionWorkflow:
                 retry_policy=DEFAULT_RETRY_POLICY,
                 heartbeat_timeout=timedelta(seconds=temporal_heartbeat_timeout),
             )
-            return PartialTransition(output=new_response.output, type="resume")
+            return WorkflowResult(state=PartialTransition(output=new_response.output, type="resume"))
         if input_type == "integrations":
             workflow.logger.debug("Prompt step: Received INTEGRATION tool call")
             # FIXME: Implement integration tool calls
@@ -510,18 +509,18 @@ class TaskExecutionWorkflow:
         workflow.logger.debug(
             f"Prompt step: Received unknown tool call: {tool_calls_input[0]['type']}"
         )
-        return PartialTransition(output=message)
+        return WorkflowResult(state=PartialTransition(output=message))
 
     async def _handle_SetStep(
         self,
         step: SetStep,
     ):
         if self.outcome is None:
-            return PartialTransition(output=None)
+            return WorkflowResult(state=PartialTransition(output=None))
 
         output = self.outcome.output
         workflow.logger.debug(f"Set step: Completed evaluation with output: {output}")
-        return PartialTransition(output=output)
+        return WorkflowResult(state=PartialTransition(output=output))
 
     async def _handle_GetStep(
         self,
@@ -532,7 +531,7 @@ class TaskExecutionWorkflow:
         value = workflow.memo_value(key, default=None)
         workflow.logger.debug(f"Retrieved value: {value}")
 
-        return PartialTransition(output=value)
+        return WorkflowResult(state=PartialTransition(output=value))
 
     async def _handle_ParallelStep(
         self,
@@ -558,7 +557,7 @@ class TaskExecutionWorkflow:
                 heartbeat_timeout=timedelta(seconds=temporal_heartbeat_timeout),
             )
 
-            return PartialTransition(output=tool_call_response, type="resume")
+            return WorkflowResult(state=PartialTransition(output=tool_call_response, type="resume"))
 
         if tool_call["type"] == "integration":
             # MANUAL TOOL CALL INTEGRATION
@@ -597,7 +596,7 @@ class TaskExecutionWorkflow:
                 heartbeat_timeout=timedelta(seconds=temporal_heartbeat_timeout),
             )
 
-            return PartialTransition(output=tool_call_response)
+            return WorkflowResult(state=PartialTransition(output=tool_call_response))
 
         if tool_call["type"] == "api_call":
             # MANUAL TOOL CALL API_CALL
@@ -636,7 +635,7 @@ class TaskExecutionWorkflow:
                 heartbeat_timeout=timedelta(seconds=temporal_heartbeat_timeout),
             )
 
-            return PartialTransition(output=tool_call_response)
+            return WorkflowResult(state=PartialTransition(output=tool_call_response))
 
         if tool_call["type"] == "system":
             # MANUAL TOOL CALL SYSTEM
@@ -653,10 +652,10 @@ class TaskExecutionWorkflow:
                 heartbeat_timeout=timedelta(seconds=temporal_heartbeat_timeout),
             )
 
-            return PartialTransition(output=tool_call_response)
+            return WorkflowResult(state=PartialTransition(output=tool_call_response))
         return None
 
-    async def handle_step(self, step: WorkflowStep):
+    async def handle_step(self, step: WorkflowStep) -> WorkflowResult:
         meth = getattr(self, f"_handle_{type(step).__name__}", None)
         if not meth:
             step_name = (
@@ -682,7 +681,7 @@ class TaskExecutionWorkflow:
         execution_input: ExecutionInput,
         start: TransitionTarget,
         current_input: Any,
-    ) -> Any:
+    ) -> WorkflowResult:
         if not execution_input.task:
             msg = "execution_input.task cannot be None"
             raise ApplicationError(msg)
@@ -770,9 +769,10 @@ class TaskExecutionWorkflow:
 
         self.outcome = outcome
         try:
-            state = await self.handle_step(
+            workflow_result = await self.handle_step(
                 step=context.current_step,
             )
+            state = workflow_result.state
         except BaseException as e:
             while isinstance(e, ActivityError) and getattr(e, "__cause__", None):
                 e = e.__cause__
@@ -787,8 +787,15 @@ class TaskExecutionWorkflow:
             msg = f"Step {type(context.current_step).__name__} threw error: {e}"
             raise ApplicationError(msg) from e
 
-        if isinstance(context.current_step, ReturnStep):
-            return state
+        if workflow_result.returned:
+            await transition(
+                self.context,
+                output=state.output,
+                type="finish" if self.context.is_main else "finish_branch",
+                next=None,
+                last_error=self.last_error,
+            )
+            return workflow_result
 
         # 4. Transition to the next step
         workflow.logger.info(f"Transitioning after step {context.cursor.step}")
@@ -806,7 +813,7 @@ class TaskExecutionWorkflow:
         # 5a. End if the last step
         if final_state.type in ("finish", "finish_branch", "cancelled", "error"):
             workflow.logger.info(f"Workflow finished with state: {final_state.type}")
-            return final_state.output
+            return WorkflowResult(state=PartialTransition(output=final_state.output))
 
         # 5b. Recurse to the next step
         if not final_state.next:

--- a/agents-api/agents_api/workflows/task_execution/__init__.py
+++ b/agents-api/agents_api/workflows/task_execution/__init__.py
@@ -479,7 +479,9 @@ class TaskExecutionWorkflow:
                 retry_policy=DEFAULT_RETRY_POLICY,
                 heartbeat_timeout=timedelta(seconds=temporal_heartbeat_timeout),
             )
-            return WorkflowResult(state=PartialTransition(output=new_response.output, type="resume"))
+            return WorkflowResult(
+                state=PartialTransition(output=new_response.output, type="resume")
+            )
         if input_type == "integrations":
             workflow.logger.debug("Prompt step: Received INTEGRATION tool call")
             # FIXME: Implement integration tool calls
@@ -557,7 +559,9 @@ class TaskExecutionWorkflow:
                 heartbeat_timeout=timedelta(seconds=temporal_heartbeat_timeout),
             )
 
-            return WorkflowResult(state=PartialTransition(output=tool_call_response, type="resume"))
+            return WorkflowResult(
+                state=PartialTransition(output=tool_call_response, type="resume")
+            )
 
         if tool_call["type"] == "integration":
             # MANUAL TOOL CALL INTEGRATION

--- a/agents-api/agents_api/workflows/task_execution/helpers.py
+++ b/agents-api/agents_api/workflows/task_execution/helpers.py
@@ -274,7 +274,7 @@ async def execute_map_reduce_step(
 
         if workflow_result.returned:
             return workflow_result
-        
+
         result = await workflow.execute_activity(
             task_steps.base_evaluate,
             args=[reduce, None, {"results": result, "_": workflow_result.state.output}],
@@ -282,7 +282,6 @@ async def execute_map_reduce_step(
             retry_policy=DEFAULT_RETRY_POLICY,
             heartbeat_timeout=timedelta(seconds=temporal_heartbeat_timeout),
         )
-
 
     return WorkflowResult(state=PartialTransition(output=result))
 
@@ -357,8 +356,10 @@ async def execute_map_reduce_step_parallel(
             batch_results = await asyncio.gather(*batch_pending)
 
             if any(batch_result.returned for batch_result in batch_results):
-                return next(batch_result for batch_result in batch_results if batch_result.returned)
-            
+                return next(
+                    batch_result for batch_result in batch_results if batch_result.returned
+                )
+
             batch_results = [batch_result.state.output for batch_result in batch_results]
 
             # Reduce the results of the batch
@@ -374,7 +375,6 @@ async def execute_map_reduce_step_parallel(
                 retry_policy=DEFAULT_RETRY_POLICY,
                 heartbeat_timeout=timedelta(seconds=temporal_heartbeat_timeout),
             )
-
 
         except BaseException as e:
             workflow.logger.error(f"Error in batch {i}: {e}")

--- a/agents-api/agents_api/workflows/task_execution/helpers.py
+++ b/agents-api/agents_api/workflows/task_execution/helpers.py
@@ -355,12 +355,20 @@ async def execute_map_reduce_step_parallel(
         try:
             batch_results = await asyncio.gather(*batch_pending)
 
-            if any(batch_result.returned for batch_result in batch_results):
-                return next(
-                    batch_result for batch_result in batch_results if batch_result.returned
-                )
-
-            batch_results = [batch_result.state.output for batch_result in batch_results]
+            # Process batch results in a single pass
+            returned_result = None
+            batch_outputs = []
+            
+            for batch_result in batch_results:
+                if batch_result.returned:
+                    returned_result = batch_result
+                    break
+                batch_outputs.append(batch_result.state.output)
+                
+            if returned_result:
+                return returned_result
+                
+            batch_results = batch_outputs
 
             # Reduce the results of the batch
             results = await workflow.execute_activity(

--- a/agents-api/agents_api/workflows/task_execution/helpers.py
+++ b/agents-api/agents_api/workflows/task_execution/helpers.py
@@ -19,7 +19,9 @@ with workflow.unsafe.imports_passed_through():
     )
     from ...common.protocol.tasks import (
         ExecutionInput,
+        PartialTransition,
         StepContext,
+        WorkflowResult,
     )
     from ...common.utils.workflows import PAR_PREFIX, SEPARATOR
     from ...env import task_max_parallelism, temporal_heartbeat_timeout
@@ -221,9 +223,13 @@ async def execute_foreach_step(
             item,
             user_state=user_state,
         )
-        results.append(result)
 
-    return results
+        if result.returned:
+            return result
+
+        results.append(result.state.output)
+
+    return WorkflowResult(state=PartialTransition(output=results))
 
 
 async def execute_map_reduce_step(
@@ -259,22 +265,26 @@ async def execute_map_reduce_step(
             workflow=workflow_name, step=0, scope_id=context.current_scope_id
         )
 
-        output = await continue_as_child(
+        workflow_result = await continue_as_child(
             map_reduce_execution_input,
             map_reduce_next_target,
             item,
             user_state=user_state,
         )
 
+        if workflow_result.returned:
+            return workflow_result
+        
         result = await workflow.execute_activity(
             task_steps.base_evaluate,
-            args=[reduce, None, {"results": result, "_": output}],
+            args=[reduce, None, {"results": result, "_": workflow_result.state.output}],
             schedule_to_close_timeout=timedelta(seconds=30),
             retry_policy=DEFAULT_RETRY_POLICY,
             heartbeat_timeout=timedelta(seconds=temporal_heartbeat_timeout),
         )
 
-    return result
+
+    return WorkflowResult(state=PartialTransition(output=result))
 
 
 async def execute_map_reduce_step_parallel(
@@ -346,6 +356,11 @@ async def execute_map_reduce_step_parallel(
         try:
             batch_results = await asyncio.gather(*batch_pending)
 
+            if any(batch_result.returned for batch_result in batch_results):
+                return next(batch_result for batch_result in batch_results if batch_result.returned)
+            
+            batch_results = [batch_result.state.output for batch_result in batch_results]
+
             # Reduce the results of the batch
             results = await workflow.execute_activity(
                 task_steps.base_evaluate,
@@ -360,9 +375,10 @@ async def execute_map_reduce_step_parallel(
                 heartbeat_timeout=timedelta(seconds=temporal_heartbeat_timeout),
             )
 
+
         except BaseException as e:
             workflow.logger.error(f"Error in batch {i}: {e}")
             msg = f"Error in batch {i}: {e}"
             raise ApplicationError(msg) from e
 
-    return results
+    return WorkflowResult(state=PartialTransition(output=results))

--- a/agents-api/agents_api/workflows/task_execution/helpers.py
+++ b/agents-api/agents_api/workflows/task_execution/helpers.py
@@ -358,16 +358,16 @@ async def execute_map_reduce_step_parallel(
             # Process batch results in a single pass
             returned_result = None
             batch_outputs = []
-            
+
             for batch_result in batch_results:
                 if batch_result.returned:
                     returned_result = batch_result
                     break
                 batch_outputs.append(batch_result.state.output)
-                
+
             if returned_result:
                 return returned_result
-                
+
             batch_results = batch_outputs
 
             # Reduce the results of the batch

--- a/agents-api/tests/test_task_execution_workflow.py
+++ b/agents-api/tests/test_task_execution_workflow.py
@@ -41,6 +41,7 @@ from agents_api.common.protocol.tasks import (
     PartialTransition,
     StepContext,
     StepOutcome,
+    WorkflowResult,
 )
 from agents_api.common.retry_policies import DEFAULT_RETRY_POLICY
 from agents_api.common.utils.datetime import utcnow
@@ -96,7 +97,7 @@ async def _():
         result = await wf.handle_step(
             step=step,
         )
-        assert result == PartialTransition(type="resume", output="function_tool_call_response")
+        assert result == WorkflowResult(state=PartialTransition(type="resume", output="function_tool_call_response"))
         workflow.execute_activity.assert_called_once_with(
             task_steps.raise_complete_async,
             args=[context, output],
@@ -153,7 +154,7 @@ async def _():
         result = await wf.handle_step(
             step=step,
         )
-        assert result == PartialTransition(output="integration_tool_call_response")
+        assert result == WorkflowResult(state=PartialTransition(output="integration_tool_call_response"))
         provider = "dummy"
         method = None
         integration = BaseIntegrationDef(
@@ -278,7 +279,7 @@ async def _():
         result = await wf.handle_step(
             step=step,
         )
-        assert result == PartialTransition(output="api_call_tool_call_response")
+        assert result == WorkflowResult(state=PartialTransition(output="api_call_tool_call_response"))
         api_call = ApiCallDef(
             method="GET",
             url="http://url1.com",
@@ -361,7 +362,7 @@ async def _():
         result = await wf.handle_step(
             step=step,
         )
-        assert result == PartialTransition(output="system_tool_call_response")
+        assert result == WorkflowResult(state=PartialTransition(output="system_tool_call_response"))
         system_call = SystemDef(
             resource="agent",
             operation="create",
@@ -410,13 +411,13 @@ async def _():
     with patch(
         "agents_api.workflows.task_execution.execute_switch_branch"
     ) as execute_switch_branch:
-        execute_switch_branch.return_value = "switch_response"
+        execute_switch_branch.return_value = WorkflowResult(state=PartialTransition(output="switch_response"))
         wf.context = context
         wf.outcome = outcome
         result = await wf.handle_step(
             step=step,
         )
-        assert result == PartialTransition(output="switch_response")
+        assert result == WorkflowResult(state=PartialTransition(output="switch_response"))
 
 
 @test("task execution workflow: handle switch step, index is negative")
@@ -492,13 +493,13 @@ async def _():
     with patch(
         "agents_api.workflows.task_execution.execute_switch_branch"
     ) as execute_switch_branch:
-        execute_switch_branch.return_value = "switch_response"
+        execute_switch_branch.return_value = WorkflowResult(state=PartialTransition(output="switch_response"))
         wf.context = context
         wf.outcome = outcome
         result = await wf.handle_step(
             step=step,
         )
-        assert result == PartialTransition(output="switch_response")
+        assert result == WorkflowResult(state=PartialTransition(output="switch_response"))
 
 
 @test("task execution workflow: handle prompt step, unwrap is True")
@@ -538,7 +539,7 @@ async def _():
         workflow.logger = Mock()
         workflow.execute_activity.return_value = "activity"
 
-        assert await wf.handle_step(step=step) == PartialTransition(output=message)
+        assert await wf.handle_step(step=step) == WorkflowResult(state=PartialTransition(output=message))
         workflow.execute_activity.assert_not_called()
 
 
@@ -579,7 +580,7 @@ async def _():
         workflow.logger = Mock()
         workflow.execute_activity.return_value = "activity"
 
-        assert await wf.handle_step(step=step) == PartialTransition(output=message)
+        assert await wf.handle_step(step=step) == WorkflowResult(state=PartialTransition(output=message))
         workflow.execute_activity.assert_not_called()
 
 
@@ -622,7 +623,7 @@ async def _():
         workflow.logger = Mock()
         workflow.execute_activity.return_value = "activity"
 
-        assert await wf.handle_step(step=step) == PartialTransition(output=message)
+        assert await wf.handle_step(step=step) == WorkflowResult(state=PartialTransition(output=message))
         workflow.execute_activity.assert_not_called()
 
 
@@ -670,9 +671,9 @@ async def _():
         workflow.logger = Mock()
         workflow.execute_activity.side_effect = [_resp(), _resp()]
 
-        assert await wf.handle_step(step=step) == PartialTransition(
+        assert await wf.handle_step(step=step) == WorkflowResult(state=PartialTransition(
             output="function_call", type="resume"
-        )
+        ))
         workflow.execute_activity.assert_has_calls([
             call(
                 task_steps.raise_complete_async,

--- a/agents-api/tests/test_task_execution_workflow.py
+++ b/agents-api/tests/test_task_execution_workflow.py
@@ -97,7 +97,9 @@ async def _():
         result = await wf.handle_step(
             step=step,
         )
-        assert result == WorkflowResult(state=PartialTransition(type="resume", output="function_tool_call_response"))
+        assert result == WorkflowResult(
+            state=PartialTransition(type="resume", output="function_tool_call_response")
+        )
         workflow.execute_activity.assert_called_once_with(
             task_steps.raise_complete_async,
             args=[context, output],
@@ -154,7 +156,9 @@ async def _():
         result = await wf.handle_step(
             step=step,
         )
-        assert result == WorkflowResult(state=PartialTransition(output="integration_tool_call_response"))
+        assert result == WorkflowResult(
+            state=PartialTransition(output="integration_tool_call_response")
+        )
         provider = "dummy"
         method = None
         integration = BaseIntegrationDef(
@@ -279,7 +283,9 @@ async def _():
         result = await wf.handle_step(
             step=step,
         )
-        assert result == WorkflowResult(state=PartialTransition(output="api_call_tool_call_response"))
+        assert result == WorkflowResult(
+            state=PartialTransition(output="api_call_tool_call_response")
+        )
         api_call = ApiCallDef(
             method="GET",
             url="http://url1.com",
@@ -362,7 +368,9 @@ async def _():
         result = await wf.handle_step(
             step=step,
         )
-        assert result == WorkflowResult(state=PartialTransition(output="system_tool_call_response"))
+        assert result == WorkflowResult(
+            state=PartialTransition(output="system_tool_call_response")
+        )
         system_call = SystemDef(
             resource="agent",
             operation="create",
@@ -411,7 +419,9 @@ async def _():
     with patch(
         "agents_api.workflows.task_execution.execute_switch_branch"
     ) as execute_switch_branch:
-        execute_switch_branch.return_value = WorkflowResult(state=PartialTransition(output="switch_response"))
+        execute_switch_branch.return_value = WorkflowResult(
+            state=PartialTransition(output="switch_response")
+        )
         wf.context = context
         wf.outcome = outcome
         result = await wf.handle_step(
@@ -493,7 +503,9 @@ async def _():
     with patch(
         "agents_api.workflows.task_execution.execute_switch_branch"
     ) as execute_switch_branch:
-        execute_switch_branch.return_value = WorkflowResult(state=PartialTransition(output="switch_response"))
+        execute_switch_branch.return_value = WorkflowResult(
+            state=PartialTransition(output="switch_response")
+        )
         wf.context = context
         wf.outcome = outcome
         result = await wf.handle_step(
@@ -539,7 +551,9 @@ async def _():
         workflow.logger = Mock()
         workflow.execute_activity.return_value = "activity"
 
-        assert await wf.handle_step(step=step) == WorkflowResult(state=PartialTransition(output=message))
+        assert await wf.handle_step(step=step) == WorkflowResult(
+            state=PartialTransition(output=message)
+        )
         workflow.execute_activity.assert_not_called()
 
 
@@ -580,7 +594,9 @@ async def _():
         workflow.logger = Mock()
         workflow.execute_activity.return_value = "activity"
 
-        assert await wf.handle_step(step=step) == WorkflowResult(state=PartialTransition(output=message))
+        assert await wf.handle_step(step=step) == WorkflowResult(
+            state=PartialTransition(output=message)
+        )
         workflow.execute_activity.assert_not_called()
 
 
@@ -623,7 +639,9 @@ async def _():
         workflow.logger = Mock()
         workflow.execute_activity.return_value = "activity"
 
-        assert await wf.handle_step(step=step) == WorkflowResult(state=PartialTransition(output=message))
+        assert await wf.handle_step(step=step) == WorkflowResult(
+            state=PartialTransition(output=message)
+        )
         workflow.execute_activity.assert_not_called()
 
 
@@ -671,9 +689,9 @@ async def _():
         workflow.logger = Mock()
         workflow.execute_activity.side_effect = [_resp(), _resp()]
 
-        assert await wf.handle_step(step=step) == WorkflowResult(state=PartialTransition(
-            output="function_call", type="resume"
-        ))
+        assert await wf.handle_step(step=step) == WorkflowResult(
+            state=PartialTransition(output="function_call", type="resume")
+        )
         workflow.execute_activity.assert_has_calls([
             call(
                 task_steps.raise_complete_async,

--- a/agents-api/tests/test_workflow_helpers.py
+++ b/agents-api/tests/test_workflow_helpers.py
@@ -12,7 +12,9 @@ from agents_api.autogen.openapi_model import (
 )
 from agents_api.common.protocol.tasks import (
     ExecutionInput,
+    PartialTransition,
     StepContext,
+    WorkflowResult,
 )
 from agents_api.common.utils.datetime import utcnow
 from agents_api.workflows.task_execution.helpers import execute_map_reduce_step_parallel
@@ -57,7 +59,7 @@ async def _():
         ),
     )
     with patch("agents_api.workflows.task_execution.helpers.workflow") as workflow:
-        workflow.execute_activity.return_value = await _resp()
+        workflow.execute_activity.return_value = _resp()
         with raises(AssertionError):
             await execute_map_reduce_step_parallel(
                 context=context,
@@ -67,3 +69,155 @@ async def _():
                 current_input={},
                 parallelism=1,
             )
+
+
+@test("execute_map_reduce_step_parallel: returned true")
+async def _():
+    async def _resp():
+        return "response"
+
+    async def mock_continue_as_child(*args, **kwargs):
+        # Return different workflow results based on the item being processed
+        if args[2] == 1:  # first item
+            return WorkflowResult(
+                returned=False,
+                state=PartialTransition(output="response 1"),
+            )
+        # second item
+        return WorkflowResult(
+            returned=True,
+            state=PartialTransition(output="response 2"),
+        )
+
+    subworkflow_step = PromptStep(prompt=[PromptItem(content="hi there", role="user")])
+
+    step = MapReduceStep(
+        kind_="map_reduce",
+        map=subworkflow_step,
+        over="$ [1, 2]",
+        parallelism=100,
+    )
+
+    execution_input = ExecutionInput(
+        developer_id=uuid.uuid4(),
+        agent=Agent(
+            id=uuid.uuid4(), name="test agent", created_at=utcnow(), updated_at=utcnow()
+        ),
+        agent_tools=[],
+        arguments={},
+        task=TaskSpecDef(
+            name="task1",
+            tools=[],
+            workflows=[Workflow(name="main", steps=[step])],
+        ),
+    )
+
+    context = StepContext(
+        execution_input=execution_input,
+        current_input={"current_input": "value 1"},
+        cursor=TransitionTarget(
+            workflow="main",
+            step=0,
+            scope_id=uuid.uuid4(),
+        ),
+    )
+    with (
+        patch("agents_api.workflows.task_execution.helpers.workflow") as workflow,
+        patch(
+            "agents_api.workflows.task_execution.helpers.continue_as_child"
+        ) as continue_as_child,
+    ):
+        workflow.execute_activity.return_value = _resp()
+        continue_as_child.side_effect = mock_continue_as_child
+
+        result = await execute_map_reduce_step_parallel(
+            context=context,
+            map_defn=step.map,
+            execution_input=execution_input,
+            items=[1, 2],
+            current_input={},
+            parallelism=100,
+        )
+
+        workflow_result = WorkflowResult(
+            returned=True,
+            state=PartialTransition(output="response 2"),
+        )
+
+        assert result == workflow_result
+
+
+@test("execute_map_reduce_step_parallel: returned false")
+async def _():
+    async def _resp():
+        return ["response 1", "response 2"]
+
+    async def mock_continue_as_child(*args, **kwargs):
+        # Return different workflow results based on the item being processed
+        if args[2] == 1:  # first item
+            return WorkflowResult(
+                returned=False,
+                state=PartialTransition(output="response 1"),
+            )
+        # second item
+        return WorkflowResult(
+            returned=False,
+            state=PartialTransition(output="response 2"),
+        )
+
+    subworkflow_step = PromptStep(prompt=[PromptItem(content="hi there", role="user")])
+
+    step = MapReduceStep(
+        kind_="map_reduce",
+        map=subworkflow_step,
+        over="$ [1, 2]",
+        parallelism=100,
+    )
+
+    execution_input = ExecutionInput(
+        developer_id=uuid.uuid4(),
+        agent=Agent(
+            id=uuid.uuid4(), name="test agent", created_at=utcnow(), updated_at=utcnow()
+        ),
+        agent_tools=[],
+        arguments={},
+        task=TaskSpecDef(
+            name="task1",
+            tools=[],
+            workflows=[Workflow(name="main", steps=[step])],
+        ),
+    )
+
+    context = StepContext(
+        execution_input=execution_input,
+        current_input={"current_input": "value 1"},
+        cursor=TransitionTarget(
+            workflow="main",
+            step=0,
+            scope_id=uuid.uuid4(),
+        ),
+    )
+    with (
+        patch("agents_api.workflows.task_execution.helpers.workflow") as workflow,
+        patch(
+            "agents_api.workflows.task_execution.helpers.continue_as_child"
+        ) as continue_as_child,
+    ):
+        workflow.execute_activity.return_value = _resp()
+        continue_as_child.side_effect = mock_continue_as_child
+
+        result = await execute_map_reduce_step_parallel(
+            context=context,
+            map_defn=step.map,
+            execution_input=execution_input,
+            items=[1, 2],
+            current_input={},
+            parallelism=100,
+        )
+
+        workflow_result = WorkflowResult(
+            returned=False,
+            state=PartialTransition(output=["response 1", "response 2"]),
+        )
+
+        assert result == workflow_result


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Introduced a new `WorkflowResult` model to encapsulate workflow execution results.

- Replaced `PartialTransition` with `WorkflowResult` across workflow handling methods.

- Enhanced subworkflow handling to properly exit with return steps.

- Updated and added tests to validate `WorkflowResult` integration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tasks.py</strong><dd><code>Introduced `WorkflowResult` model for workflow results</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/common/protocol/tasks.py

<li>Added <code>WorkflowResult</code> model to represent workflow execution results.<br> <li> Included metadata and return state in <code>WorkflowResult</code>.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1186/files#diff-8a1abcedcd95d0217595a53a9c503fa4dec969579ce9cf9a120193413758fbef">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>create_task_execution.py</strong><dd><code>Added `scope_id` to transition initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/routers/tasks/create_task_execution.py

- Added `scope_id` to `TransitionTarget` initialization.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1186/files#diff-a74e8d5234c1aa3d0a5e6a4f6a66444dbb1824060591afd2353a383446c0d88b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Refactored workflow execution to use `WorkflowResult`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/workflows/task_execution/__init__.py

<li>Replaced <code>PartialTransition</code> with <code>WorkflowResult</code> in step handlers.<br> <li> Enhanced subworkflow return handling with <code>WorkflowResult</code>.<br> <li> Updated <code>run</code> method to handle <code>WorkflowResult</code> transitions.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1186/files#diff-d12de13df920a717fe2e94addd7e85fbb6216144a71cd1aba10e84f44cecf9f1">+50/-43</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>helpers.py</strong><dd><code>Updated helpers to integrate `WorkflowResult`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/workflows/task_execution/helpers.py

<li>Updated helper methods to return <code>WorkflowResult</code>.<br> <li> Added handling for subworkflow returns in foreach and map-reduce <br>steps.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1186/files#diff-e07a50b10e52250df2258d6ebef066bdb95ad3dd0c17af0548684828418adcc0">+22/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_task_execution_workflow.py</strong><dd><code>Updated tests for `WorkflowResult` integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/tests/test_task_execution_workflow.py

<li>Updated tests to validate <code>WorkflowResult</code> usage.<br> <li> Replaced <code>PartialTransition</code> assertions with <code>WorkflowResult</code>.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1186/files#diff-90d03c9dad92cb6056e99f07aa50711df681cefe722f051bdca0a129cb86b909">+14/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduced `WorkflowResult` model to encapsulate workflow execution results, enhancing subworkflow handling and updating tests for integration.
> 
>   - **Behavior**:
>     - Introduced `WorkflowResult` model in `tasks.py` to encapsulate workflow execution results, replacing `PartialTransition`.
>     - Enhanced subworkflow handling in `__init__.py` to properly exit with return steps using `WorkflowResult`.
>   - **Enhancements**:
>     - Added `scope_id` to `TransitionTarget` initialization in `create_task_execution.py`.
>   - **Tests**:
>     - Updated tests in `test_task_execution_workflow.py` to validate `WorkflowResult` integration, replacing `PartialTransition` assertions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for e247a50e2f68f694e82c886a27a2223bd0f3dc89. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---
# EntelligenceAI PR Summary 
 **Purpose**:
- Enhance task execution workflow by standardizing clarity, consistency, and detail of execution results.

**Changes**:
- **Enhancement**: Introduced `WorkflowResult` class to encapsulate workflow execution results, replacing `PartialTransition` returns.
- **Refactor**: Added `scope_id` to `TransitionTarget` for improved tracking of workflow execution context.
- **Test**: Updated test cases to align with new execution logic, ensuring assertions for `WorkflowResult`.

**Impact**:
- Improved management of execution metadata and handling of sub-workflow returns, enhancing reliability and maintainability. 

