### PR TITLE
fix(agents-api): resolve ``dummy_tool`` issue

### DIFF
--- a/agents-api/agents_api/clients/litellm.py
+++ b/agents-api/agents_api/clients/litellm.py
@@ -56,6 +56,10 @@ async def acompletion(
             {"role": message["role"], "content": message["content"]} for message in messages
         ]
 
+    for message in messages:
+        if "tool_calls" in message and message["tool_calls"] == []:
+            message.pop("tool_calls")
+
     model_response = await _acompletion(
         model=model,
         messages=messages,

--- a/agents-api/tests/test_litellm_utils.py
+++ b/agents-api/tests/test_litellm_utils.py
@@ -1,0 +1,25 @@
+from unittest.mock import patch
+
+from agents_api.clients.litellm import acompletion
+from litellm.types.utils import ModelResponse
+from ward import test
+
+
+@test("litellm_utils: acompletion - no tools")
+async def _():
+    with patch("agents_api.clients.litellm._acompletion") as mock_acompletion:
+        mock_acompletion.return_value = ModelResponse(
+            id="test-id",
+            choices=[{"message": {"content": "test"}}],
+            model="gpt-4",
+            usage={"total_tokens": 10},
+        )
+
+        messages = [{"role": "user", "content": "test", "tool_calls": []}]
+
+        await acompletion(model="gpt-4", messages=messages)
+
+        # Check that tool_calls was removed from the message
+        mock_acompletion.assert_called_once()
+        called_messages = mock_acompletion.call_args[1]["messages"]
+        assert "tool_calls" not in called_messages[0]


### PR DESCRIPTION
### **User description**
closes #1177


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed issue where `dummy_tool` was sent to LLMs unnecessarily.

- Added logic to remove empty `tool_calls` from messages in `acompletion`.

- Introduced a test to validate `tool_calls` removal in `acompletion`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>litellm.py</strong><dd><code>Remove empty `tool_calls` from messages in `acompletion`</code>&nbsp; </dd></summary>
<hr>

agents-api/agents_api/clients/litellm.py

<li>Added logic to remove <code>tool_calls</code> if it is empty.<br> <li> Ensured messages are cleaned before being sent to <code>_acompletion</code>.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1191/files#diff-09573e4e5766575081152c80e3a78b28ca3a0cee3f07a448abcb4db7566edaab">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_litellm_utils.py</strong><dd><code>Add test for `tool_calls` removal in `acompletion`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/tests/test_litellm_utils.py

<li>Added a test to verify <code>tool_calls</code> is removed when empty.<br> <li> Mocked <code>_acompletion</code> to simulate LLM response.<br> <li> Validated that <code>tool_calls</code> is not present in processed messages.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1191/files#diff-ac36c41bb4c1338f587e3963e340fb71d8e53f4b935c3447f63f556c621a1fef">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

---
# EntelligenceAI PR Summary 
 The recent update refines the `acompletion` function in `litellm.py` by removing unnecessary `tool_calls`, optimizing data handling. A new test in `test_litellm_utils.py` confirms this enhancement, boosting the function's reliability. 

