### PR TITLE
fix: Add new hybrid search implementation

### DIFF
--- a/memory-store/migrations/000028_new_hybrid_search_implementation.down.sql
+++ b/memory-store/migrations/000028_new_hybrid_search_implementation.down.sql
@@ -1,0 +1,103 @@
+DROP FUNCTION IF EXISTS search_hybrid;
+CREATE OR REPLACE FUNCTION search_hybrid (
+    developer_id UUID,
+    query_text text,
+    query_embedding vector (1024),
+    owner_types TEXT[],
+    owner_ids UUID [],
+    k integer DEFAULT 3,
+    alpha float DEFAULT 0.7, -- Weight for embedding results
+    confidence float DEFAULT 0.5,
+    metadata_filter jsonb DEFAULT NULL,
+    search_language text DEFAULT 'english'
+) RETURNS SETOF doc_search_result AS $$
+DECLARE
+    text_weight float;
+    embedding_weight float;
+    intermediate_limit integer;
+BEGIN
+    -- Input validation
+    IF k <= 0 THEN
+        RAISE EXCEPTION 'k must be greater than 0';
+    END IF;
+
+    text_weight := 1.0 - alpha;
+    embedding_weight := alpha;
+    -- Get more intermediate results than final to allow for better fusion
+    intermediate_limit := k * 4;
+
+    RETURN QUERY
+    WITH text_results AS (
+        SELECT * FROM search_by_text(
+            developer_id,
+            query_text,
+            owner_types,
+            owner_ids,
+            search_language,
+            intermediate_limit,  -- Use larger intermediate limit
+            metadata_filter
+        )
+    ),
+    embedding_results AS (
+        SELECT * FROM search_by_vector(
+            developer_id,
+            query_embedding,
+            owner_types,
+            owner_ids,
+            intermediate_limit,  -- Use larger intermediate limit
+            confidence,
+            metadata_filter
+        )
+    ),
+    all_results AS (
+        SELECT DISTINCT doc_id, title, content, metadata, embedding,
+               index, owner_type, owner_id
+        FROM (
+            SELECT * FROM text_results
+            UNION
+            SELECT * FROM embedding_results
+        ) combined
+    ),
+    scores AS (
+        SELECT
+            r.doc_id,
+            r.title,
+            r.content,
+            r.metadata,
+            r.embedding,
+            r.index,
+            r.owner_type,
+            r.owner_id,
+            COALESCE(t.distance, 0.0) as text_score,
+            COALESCE(e.distance, 0.0) as embedding_score,
+            RANK() OVER (ORDER BY COALESCE(t.distance, 0.0) DESC) as text_rank,
+            RANK() OVER (ORDER BY COALESCE(e.distance, 0.0) DESC) as embedding_rank
+        FROM all_results r
+        LEFT JOIN text_results t ON r.doc_id = t.doc_id
+        LEFT JOIN embedding_results e ON r.doc_id = e.doc_id
+    ),
+    normalized_scores AS (
+        SELECT
+            *,
+            unnest(dbsf_normalize(array_agg(text_score) OVER ())) as norm_text_score,
+            unnest(dbsf_normalize(array_agg(embedding_score) OVER ())) as norm_embedding_score
+        FROM scores
+    )
+    SELECT
+        developer_id,
+        doc_id,
+        index,
+        title,
+        content,
+        1.0 - (text_weight * norm_text_score + embedding_weight * norm_embedding_score) as distance,
+        embedding,
+        metadata,
+        owner_type,
+        owner_id
+    FROM normalized_scores
+    ORDER BY distance ASC
+    LIMIT k;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION search_hybrid IS 'Hybrid search combining text and vector search using Distribution-Based Score Fusion (DBSF)';

--- a/memory-store/migrations/000028_new_hybrid_search_implementation.up.sql
+++ b/memory-store/migrations/000028_new_hybrid_search_implementation.up.sql
@@ -1,0 +1,145 @@
+DROP FUNCTION search_hybrid(uuid,text,vector,text[],uuid[],integer,double precision,double precision,jsonb,text);
+CREATE OR REPLACE FUNCTION search_hybrid (
+    p_developer_id UUID,
+    p_query_text text,
+    p_query_embedding vector(1024),
+    p_owner_types TEXT[],
+    p_owner_ids UUID[],
+    p_k integer DEFAULT 3,
+    p_alpha float DEFAULT 0.7,
+    p_confidence float DEFAULT 0.5,
+    p_metadata_filter jsonb DEFAULT NULL,
+    p_search_language text DEFAULT 'english'
+)
+RETURNS SETOF doc_search_result
+LANGUAGE plpgsql AS
+$$
+DECLARE
+    text_weight float := 1.0 - p_alpha;
+    embedding_weight float := p_alpha;
+    intermediate_limit integer := p_k * 4;
+BEGIN
+    /*
+       1) Get top-N results from text search.
+       2) Get top-N results from vector search.
+       3) UNION them and pick the highest-distance row per doc_id (DISTINCT ON).
+       4) Join those rows back to each sub-result to get text_score and embedding_score.
+       5) Aggregate text & embedding scores once, dbsf_normalize once, then map them back by row_number.
+    */
+
+    RETURN QUERY
+    WITH text_results AS (
+        SELECT *
+        FROM search_by_text(
+            p_developer_id,
+            p_query_text,
+            p_owner_types,
+            p_owner_ids,
+            p_search_language,
+            intermediate_limit,
+            p_metadata_filter
+        )
+    ),
+    embedding_results AS (
+        SELECT *
+        FROM search_by_vector(
+            p_developer_id,
+            p_query_embedding,
+            p_owner_types,
+            p_owner_ids,
+            intermediate_limit,
+            p_confidence,
+            p_metadata_filter
+        )
+    ),
+
+    -- UNION both sets, pick highest distance row per doc_id
+    all_results AS (
+        SELECT DISTINCT ON (doc_id)
+               developer_id,
+               doc_id,
+               index,
+               title,
+               content,
+               distance,
+               embedding,
+               metadata,
+               owner_type,
+               owner_id
+        FROM (
+            SELECT * FROM text_results
+            UNION ALL
+            SELECT * FROM embedding_results
+        ) combined
+        ORDER BY doc_id, distance DESC
+    ),
+
+    -- Gather text_score & embedding_score for each doc
+    scores AS (
+        SELECT
+            a.developer_id,
+            a.doc_id,
+            a.index,
+            a.title,
+            a.content,
+            a.embedding,
+            a.metadata,
+            a.owner_type,
+            a.owner_id,
+            COALESCE(t.distance, 0.0) AS text_score,
+            COALESCE(e.distance, 0.0) AS embedding_score
+        FROM all_results a
+        LEFT JOIN text_results      t ON a.doc_id = t.doc_id
+        LEFT JOIN embedding_results e ON a.doc_id = e.doc_id
+    ),
+
+    -- Give each row a stable ordering
+    scores_ordered AS (
+        SELECT
+            s.*,
+            ROW_NUMBER() OVER (ORDER BY s.doc_id) AS rn
+        FROM scores s
+    ),
+
+    -- Aggregate all text/embedding scores into arrays
+    aggregated AS (
+        SELECT
+            array_agg(text_score ORDER BY rn)      AS text_scores,
+            array_agg(embedding_score ORDER BY rn) AS embedding_scores
+        FROM scores_ordered
+    ),
+
+    -- Normalize once for each array
+    normed_arrays AS (
+        SELECT
+            dbsf_normalize(text_scores)      AS norm_text_scores,
+            dbsf_normalize(embedding_scores) AS norm_embedding_scores
+        FROM aggregated
+    ),
+
+    -- Join normalized arrays back using row_number
+    final AS (
+        SELECT
+            s.developer_id,
+            s.doc_id,
+            s.index,
+            s.title,
+            s.content,
+            1.0 - (
+                text_weight      * norm_text_scores[s.rn] +
+                embedding_weight * norm_embedding_scores[s.rn]
+            ) AS distance,
+            s.embedding,
+            s.metadata,
+            s.owner_type,
+            s.owner_id
+        FROM scores_ordered s
+        CROSS JOIN normed_arrays
+        ORDER BY distance ASC
+        LIMIT p_k
+    )
+    SELECT * FROM final;
+END;
+$$;
+
+COMMENT ON FUNCTION search_hybrid IS 'Hybrid search combining text and vector search using Distribution-Based Score Fusion (DBSF)';


### PR DESCRIPTION
### **User description**
---
# EntelligenceAI PR Summary 
 **Purpose**:
- Enhance search functionality with a hybrid system combining text and vector search, ensuring reversibility.

**Changes**:
- **New Feature**: Added `search_hybrid` function for optimized document results using a distance metric, supporting developer ID, query text, embeddings, owner types, and metadata filters.
- **Chore**: Included SQL scripts for implementing and reverting the `search_hybrid` function, ensuring seamless integration and reversibility.

**Impact**:
- Streamlines search operations, improves result relevance, and enhances user experience while maintaining system resilience.


___

### **PR Type**
Enhancement


___

### **Description**
- Introduced a new `search_hybrid` function for hybrid search.

- Combines text and vector search for improved relevance.

- Added SQL scripts for function creation and rollback.

- Ensures seamless integration and reversibility of the feature.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>000028_new_hybrid_search_implementation.down.sql</strong><dd><code>SQL script for hybrid search rollback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

memory-store/migrations/000028_new_hybrid_search_implementation.down.sql

<li>Added SQL script to drop the <code>search_hybrid</code> function.<br> <li> Ensures reversibility of the hybrid search implementation.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1197/files#diff-d4144a402e1fd19ed6211b3c1d7515b0332ca3c92084411aa58378c922645d82">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>000028_new_hybrid_search_implementation.up.sql</strong><dd><code>SQL script for hybrid search implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

memory-store/migrations/000028_new_hybrid_search_implementation.up.sql

<li>Added <code>search_hybrid</code> function for hybrid search.<br> <li> Combines text and vector search results.<br> <li> Implements normalization and scoring for relevance.<br> <li> Supports various parameters like filters and confidence.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1197/files#diff-690f6b8bcc209f229871590b660146796c7ab2e0f9a055cb5bd9bcbdbba490cf">+142/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `search_hybrid` function for hybrid text and vector search with rollback support via SQL scripts.
> 
>   - **New Feature**:
>     - Adds `search_hybrid` function in `000028_new_hybrid_search_implementation.up.sql` for hybrid search combining text and vector results.
>     - Supports parameters like `developer_id`, `query_text`, `query_embedding`, `owner_types`, `owner_ids`, `k`, `alpha`, `confidence`, `metadata_filter`, and `search_language`.
>     - Implements score normalization and ranking using Distribution-Based Score Fusion (DBSF).
>   - **Rollback Support**:
>     - Provides `000028_new_hybrid_search_implementation.down.sql` to drop `search_hybrid` function, ensuring reversibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 548919312ab649848622de2565edc1018b5ac1d7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->