### PR TITLE
feat(agents-api,memory-store): Disallow creating docs with duplicate content

### DIFF
--- a/agents-api/agents_api/common/utils/db_exceptions.py
+++ b/agents-api/agents_api/common/utils/db_exceptions.py
@@ -52,6 +52,13 @@ def common_db_exceptions(
         return f"{base_msg} during {op_str}"
 
     exceptions = {
+        # Unique constraint violations - usually means a resource with same unique key exists
+        lambda e: isinstance(e, asyncpg.RaiseError)
+        and "content already exists" in str(e).lower(): partialclass(
+            HTTPException,
+            status_code=409,
+            detail=get_operation_message(f"A {resource_name} with this content already exists"),
+        ),
         # Foreign key violations - usually means a referenced resource doesn't exist
         asyncpg.ForeignKeyViolationError: partialclass(
             HTTPException,

--- a/agents-api/pyproject.toml
+++ b/agents-api/pyproject.toml
@@ -72,6 +72,7 @@ dev = [
     "sqlvalidator>=0.0.20",
     "testcontainers[postgres,localstack]>=4.9.0",
     "ward>=0.68.0b0",
+    "psycopg[binary]>=3.2.5",  # only for use inside tests for now
 ]
 
 [tool.setuptools]

--- a/agents-api/tests/test_docs_routes.py
+++ b/agents-api/tests/test_docs_routes.py
@@ -46,6 +46,41 @@ async def _(make_request=make_request, agent=test_agent):
         assert response.status_code == 201
 
 
+@test("route: create agent doc with duplicate title should fail")
+async def _(make_request=make_request, agent=test_agent, user=test_user):
+    async with patch_testing_temporal():
+        data = {
+            "title": "Test Duplicate Doc",
+            "content": ["This is a test duplicate document."],
+        }
+
+        response = make_request(
+            method="POST",
+            url=f"/agents/{agent.id}/docs",
+            json=data,
+        )
+
+        assert response.status_code == 201
+
+        # This should fail
+        response = make_request(
+            method="POST",
+            url=f"/agents/{agent.id}/docs",
+            json=data,
+        )
+
+        assert response.status_code == 409
+
+        # This should pass
+        response = make_request(
+            method="POST",
+            url=f"/users/{user.id}/docs",
+            json=data,
+        )
+
+        assert response.status_code == 201
+
+
 @test("route: delete doc")
 async def _(make_request=make_request, agent=test_agent):
     async with patch_testing_temporal():

--- a/agents-api/uv.lock
+++ b/agents-api/uv.lock
@@ -70,6 +70,7 @@ dev = [
     { name = "jupyterlab" },
     { name = "pip" },
     { name = "poethepoet" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "pyjwt" },
     { name = "pyright" },
     { name = "pytype" },
@@ -141,6 +142,7 @@ dev = [
     { name = "jupyterlab", specifier = ">=4.3.1" },
     { name = "pip", specifier = ">=24.3.1" },
     { name = "poethepoet", specifier = ">=0.31.1" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2.5" },
     { name = "pyjwt", specifier = ">=2.10.1" },
     { name = "pyright", specifier = ">=1.1.391" },
     { name = "pytype", specifier = ">=2024.10.11" },
@@ -552,7 +554,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -1031,7 +1033,7 @@ name = "ipykernel"
 version = "6.29.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "platform_system == 'Darwin'" },
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },
@@ -2189,6 +2191,42 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg"
+version = "3.2.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/cf/dc1a4d45e3c6222fe272a245c5cea9a969a7157639da606ac7f2ab5de3a1/psycopg-3.2.5.tar.gz", hash = "sha256:f5f750611c67cb200e85b408882f29265c66d1de7f813add4f8125978bfd70e8", size = 156158 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/f3/14a1370b1449ca875d5e353ef02cb9db6b70bd46ec361c236176837c0be1/psycopg-3.2.5-py3-none-any.whl", hash = "sha256:b782130983e5b3de30b4c529623d3687033b4dafa05bb661fc6bf45837ca5879", size = 198749 },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.2.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/eb/175a81bfd26734eeaaa39b651bc44a3c5e3fce1190963ace21e428c4d2ee/psycopg_binary-3.2.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a4321ee8180982d70458d3e8378e31448901bf0ee40fe0d410a87413578f4098", size = 3857964 },
+    { url = "https://files.pythonhosted.org/packages/ca/2e/0d57047372c3dd31becc1a48185862d7e6714ffbdc1401742a32f2294f79/psycopg_binary-3.2.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2cc86657c05e09c701e97f87132cd58e0d55381dd568520081ac1fe7580a9bbb", size = 3940056 },
+    { url = "https://files.pythonhosted.org/packages/c5/2f/339a18b28787d33fe892d1ae1fbaa83739c6274327cbf9ada4158322ad9d/psycopg_binary-3.2.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5244bebaa9734a236b7157fb57c065b6c0f2344281916187bd73f951df1899e0", size = 4499081 },
+    { url = "https://files.pythonhosted.org/packages/42/21/32d7115b2cbd87d043ad494254fd7c4c8652ac3c32f49bb571fd8111caf3/psycopg_binary-3.2.5-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:21b839f9bfd77ed074f7f71464a43f453400c57d038a0ba0716329a28e335897", size = 4307502 },
+    { url = "https://files.pythonhosted.org/packages/00/67/e99b58f616dd02c5e52c179b3df047d9683a9f699993cb1795ee435db598/psycopg_binary-3.2.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7376b13504396da9678b646f5338462347da01286b2a688a0d8493ec764683a2", size = 4547821 },
+    { url = "https://files.pythonhosted.org/packages/0d/64/9d13ee0fed78a47c506a93d1e67ee53cc7ffd75c1f5885b59d17810fe5cd/psycopg_binary-3.2.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:473f6827cf1faf3924eb77146d1e85126a1b5e48a88053b8d8b78dd29e971d78", size = 4259849 },
+    { url = "https://files.pythonhosted.org/packages/ea/f2/172b6ebcd60a1a86f5ce1a539cfb93ffbe42fc9bc7ab2e1ed79e99a75d71/psycopg_binary-3.2.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:28bd5cb2324567e5e70f07fe1d646398d6b0e210e28b49be0e69593590a59980", size = 3847280 },
+    { url = "https://files.pythonhosted.org/packages/0f/51/9cd26c6b862d499b4b25ea173ae6e21c9d460ddce6b09cbe9501dff66211/psycopg_binary-3.2.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:48f97936145cb7de18b95d85670b2d3e2c257277263272be05815b74fb0ef195", size = 3320262 },
+    { url = "https://files.pythonhosted.org/packages/51/7d/2dac61ff16476e77c6ce0a49a30b130e2ba6ad08c83c4950591b4bc49cf2/psycopg_binary-3.2.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8e6f2bef5aed021fbdf46323d3cd8847bf960efb56394698644a8ee2306f8892", size = 3400254 },
+    { url = "https://files.pythonhosted.org/packages/45/67/bd36932c24f96dc1bc21fb18b1bdebcda7b9791067f7151a1c5dc1193e6b/psycopg_binary-3.2.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3d2e57a1d06f3968e49e948ba374f21a7d8dcf44f37d582a4aeddeb7c85ce239", size = 3438916 },
+    { url = "https://files.pythonhosted.org/packages/00/ab/882b861cfcf83d7faffe583e1e092117cd66eacc86fb4517d27973e52f35/psycopg_binary-3.2.5-cp312-cp312-win_amd64.whl", hash = "sha256:2cbb8649cfdacbd14e17f5ab78edc52d33350013888518c73e90c5d17d7bea55", size = 2782504 },
+]
+
+[[package]]
 name = "ptyprocess"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3163,7 +3201,7 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
 wheels = [

--- a/memory-store/migrations/000029_duplicate_doc_prevention.down.sql
+++ b/memory-store/migrations/000029_duplicate_doc_prevention.down.sql
@@ -1,0 +1,24 @@
+BEGIN;
+
+-- Drop the duplicate doc owner check trigger
+DROP TRIGGER IF EXISTS trg_check_duplicate_doc_owner ON doc_owners;
+
+-- Drop the trigger function
+DROP FUNCTION IF EXISTS check_duplicate_doc_owner();
+
+-- Drop the content hash trigger
+DROP TRIGGER IF EXISTS trg_docs_content_hash ON docs;
+
+-- Drop the content hash function
+DROP FUNCTION IF EXISTS docs_update_content_hash();
+
+-- Drop the hash generation function
+DROP FUNCTION IF EXISTS generate_content_hash(TEXT, TEXT);
+
+-- Drop the index
+DROP INDEX IF EXISTS idx_docs_content_hash;
+
+-- Remove the content_hash column
+ALTER TABLE docs DROP COLUMN IF EXISTS content_hash;
+
+COMMIT; 

--- a/memory-store/migrations/000029_duplicate_doc_prevention.up.sql
+++ b/memory-store/migrations/000029_duplicate_doc_prevention.up.sql
@@ -12,7 +12,7 @@ RETURNS TEXT AS $$
 BEGIN
     -- Use MD5 hash of combined title and content
     -- This provides a good balance between performance and collision avoidance
-    RETURN MD5(title || '|' || content);
+    RETURN MD5(COALESCE(title, '') || '|' || COALESCE(content, ''));
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 

--- a/memory-store/migrations/000029_duplicate_doc_prevention.up.sql
+++ b/memory-store/migrations/000029_duplicate_doc_prevention.up.sql
@@ -1,0 +1,85 @@
+BEGIN;
+
+-- Add content_hash column to docs table
+ALTER TABLE docs ADD COLUMN IF NOT EXISTS content_hash TEXT;
+
+-- Create index on content_hash for fast lookups
+CREATE INDEX IF NOT EXISTS idx_docs_content_hash ON docs (developer_id, content_hash);
+
+-- Create a function to generate hash from title and content
+CREATE OR REPLACE FUNCTION generate_content_hash(title TEXT, content TEXT) 
+RETURNS TEXT AS $$
+BEGIN
+    -- Use MD5 hash of combined title and content
+    -- This provides a good balance between performance and collision avoidance
+    RETURN MD5(title || '|' || content);
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- Create trigger function to set content_hash on insert/update
+CREATE OR REPLACE FUNCTION docs_update_content_hash() 
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.content_hash := generate_content_hash(NEW.title, NEW.content);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create trigger to update content_hash automatically
+CREATE TRIGGER trg_docs_content_hash
+BEFORE INSERT OR UPDATE OF title, content ON docs
+FOR EACH ROW
+EXECUTE FUNCTION docs_update_content_hash();
+
+-- Update the content_hash for existing records
+UPDATE docs
+SET content_hash = generate_content_hash(title, content)
+WHERE content_hash IS NULL;
+
+-- Create function to check for duplicate docs by owner BEFORE assigning ownership
+CREATE OR REPLACE FUNCTION check_duplicate_doc_owner() 
+RETURNS TRIGGER AS $$
+DECLARE
+    v_content_hash TEXT;
+    v_doc_exists BOOLEAN;
+BEGIN
+    -- First get the content hash of the document being assigned
+    SELECT content_hash INTO v_content_hash
+    FROM docs
+    WHERE developer_id = NEW.developer_id AND doc_id = NEW.doc_id;
+    
+    -- If we can't find the document, let the insertion proceed
+    -- (There should be a foreign key constraint, but it's commented out in the original SQL)
+    IF v_content_hash IS NULL THEN
+        RETURN NEW;
+    END IF;
+    
+    -- Check if this owner already has a document with the same content hash
+    SELECT EXISTS (
+        SELECT 1 
+        FROM docs d
+        JOIN doc_owners o ON d.developer_id = o.developer_id AND d.doc_id = o.doc_id
+        WHERE d.developer_id = NEW.developer_id
+        AND d.content_hash = v_content_hash
+        AND o.owner_type = NEW.owner_type
+        AND o.owner_id = NEW.owner_id
+        AND o.doc_id != NEW.doc_id  -- Exclude the current document
+    ) INTO v_doc_exists;
+    
+    -- If a document with the same content already exists for this owner, reject the insertion
+    IF v_doc_exists THEN
+        RAISE EXCEPTION 'Document with similar content already exists for this owner (type: %, id: %)', 
+                         NEW.owner_type, NEW.owner_id;
+    END IF;
+    
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create trigger to check for duplicates when assigning ownership
+CREATE TRIGGER trg_check_duplicate_doc_owner
+BEFORE INSERT ON doc_owners
+FOR EACH ROW
+EXECUTE FUNCTION check_duplicate_doc_owner();
+
+COMMIT; 


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Added database constraints to prevent duplicate document content.

- Implemented triggers and functions for content hash generation.

- Introduced tests to verify duplicate content prevention.

- Updated dependencies for testing purposes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>db_exceptions.py</strong><dd><code>Handle duplicate content errors in database exceptions</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/common/utils/db_exceptions.py

<li>Added exception handling for duplicate content errors.<br> <li> Mapped specific database error to HTTP 409 response.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1199/files#diff-15e4c843422b852e647db8608631728d83cad8f06f579774dc3c7b5213fbee8f">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_docs_routes.py</strong><dd><code>Add tests for duplicate document prevention</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/tests/test_docs_routes.py

<li>Added test for creating documents with duplicate content.<br> <li> Verified HTTP 409 response for duplicate document creation.<br> <li> Ensured non-duplicate document creation works as expected.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1199/files#diff-d1de938cc8c2e3cd183efc6e8be6341d7e7160c463d9cc5f9907cfa2772bfef5">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Update dependencies for testing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/pyproject.toml

- Added `psycopg[binary]` dependency for testing purposes.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1199/files#diff-67d50d67e23dbd03841ef2bbff16e6c278842bcab87e0df385cb33f9af7b491f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>000029_duplicate_doc_prevention.down.sql</strong><dd><code>SQL script to rollback duplicate prevention</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

memory-store/migrations/000029_duplicate_doc_prevention.down.sql

<li>Added SQL script to remove duplicate document prevention mechanisms.<br> <li> Dropped triggers, functions, and indexes related to content hash.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1199/files#diff-9d0a6a28710516ff248a1a5ae4d68369ccfcf79727263cd992e03990b0d5486c">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>000029_duplicate_doc_prevention.up.sql</strong><dd><code>SQL script to enforce duplicate document prevention</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

memory-store/migrations/000029_duplicate_doc_prevention.up.sql

<li>Added SQL script to enforce duplicate document prevention.<br> <li> Introduced content hash column and related triggers/functions.<br> <li> Created index for efficient duplicate detection.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1199/files#diff-b945825c44f40d2315773034ca4a7c2c34a6769d82fa06d4f2e443051f067aac">+85/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevent creation of documents with duplicate content in `agents-api` and `memory-store` by adding content hash checks and related database triggers.
> 
>   - **Behavior**:
>     - Disallow creation of documents with duplicate content in `agents-api` by adding a unique constraint check in `db_exceptions.py`.
>     - New test in `test_docs_routes.py` to verify duplicate document creation fails with status code 409.
>   - **Database**:
>     - Add `content_hash` column to `docs` table in `memory-store`.
>     - Create `generate_content_hash()` function to hash document title and content.
>     - Add triggers `trg_docs_content_hash` and `trg_check_duplicate_doc_owner` to manage content hash and prevent duplicate ownership.
>   - **Dependencies**:
>     - Add `psycopg[binary]>=3.2.5` to `pyproject.toml` for testing purposes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for db80f561f6e591c6f68308861078dedf218d87b7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

---
# EntelligenceAI PR Summary 
 **Purpose**:
- Enhance duplicate document detection and handling.

**Changes**:
- **Enhancement**: Added content hash checks and database triggers to prevent duplicate documents.
- **New Feature**: Implemented exception handling to return a 409 status code for duplicates.
- **Test**: Developed test cases to ensure correct status code for duplicate content.
- **Chore**: Updated dependencies for testing and platform compatibility.

**Impact**:
- Improves user experience and system reliability by efficiently managing duplicate entries. 

