### PR TITLE
feat(agents-api): render endpoint for debugging sessions

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,116 @@
+# Git
+.git/
+.github/workflows/
+.gitmodules
+
+# Build and distribution directories
+**/dist/
+**/build/
+**/.ruff_cache/
+**/node_modules/
+**/__pycache__/
+**/.pytest_cache/
+**/.mypy_cache/
+**/.tox/
+**/.coverage/
+**/.venv/
+**/venv/
+**/.next/
+**/.nuxt/
+**/out/
+**/coverage/
+
+# Environment and configuration files
+.env
+.env.*
+**/.env.local
+**/.env.development.local
+**/.env.test.local
+**/.env.production.local
+
+# Large data files
+**/*.csv
+**/*.json
+**/*.parquet
+**/*.arrow
+**/*.pickle
+**/*.pkl
+**/*.db
+**/*.sqlite
+**/*.sqlite3
+
+# Generated documentation
+**/docs/_build/
+**/site/
+**/public/
+
+# Package-manager files
+**/yarn-error.log
+**/npm-debug.log
+**/package-lock.json
+**/yarn.lock
+**/pnpm-lock.yaml
+**/pnpm-workspace.yaml
+**/poetry.lock
+**/Pipfile.lock
+**/requirements-frozen.txt
+**/uv.lock
+
+# Logs
+**/logs/
+**/*.log
+
+# Cache directories
+**/.cache/
+**/.npm/
+**/.pnpm/
+**/.yarn/
+**/.pnp/
+
+# IDE and editor files
+**/.vscode/
+**/.idea/
+**/.DS_Store
+**/.ipynb_checkpoints/
+**/*.swp
+
+# Compiled binaries
+**/*.so
+**/*.dll
+**/*.dylib
+**/*.exe
+**/*.whl
+**/*.egg-info/
+**/*.egg
+
+# Large media files
+**/*.mp4
+**/*.mp3
+**/*.wav
+**/*.avi
+**/*.mov
+**/*.png
+**/*.jpg
+**/*.jpeg
+**/*.gif
+**/*.svg
+**/*.ico
+**/*.pdf
+
+# Container and deployment files
+**/*.tfvars
+**/*.tfstate
+**/*.tfstate.backup
+
+# Temporary files
+**/tmp/
+**/temp/
+**/*.tmp
+**/*.temp
+
+# Large generated files
+gaga.json
+openapi.yaml
+openapi*.yaml
+openapi*.yml
+openapi*.json

--- a/.cursorindexignore
+++ b/.cursorindexignore
@@ -1,0 +1,100 @@
+# Git
+.git/
+.github/
+
+# Build and distribution directories
+**/dist/
+**/build/
+**/.ruff_cache/
+**/node_modules/
+**/__pycache__/
+**/.pytest_cache/
+**/.mypy_cache/
+**/.tox/
+**/.coverage/
+**/.venv/
+**/venv/
+**/.next/
+**/.nuxt/
+**/out/
+**/coverage/
+
+# Environment files (may contain sensitive information)
+**/.env
+**/.env.*
+**/*.pem
+**/*.key
+**/*.cert
+**/*.crt
+
+# Large data files and binaries (to avoid loading and indexing them)
+**/*.csv
+**/*.json
+**/*.parquet
+**/*.arrow
+**/*.pickle
+**/*.pkl
+**/*.db
+**/*.sqlite
+**/*.sqlite3
+**/*.so
+**/*.dll
+**/*.dylib
+**/*.exe
+**/*.whl
+**/*.tar.gz
+**/*.zip
+**/*.jar
+**/*.war
+**/*.ear
+
+# Lock files (usually don't need indexing)
+**/yarn.lock
+**/package-lock.json
+**/pnpm-lock.yaml
+**/poetry.lock
+**/Pipfile.lock
+**/requirements-frozen.txt
+**/uv.lock
+
+# Generated documentation or third-party code
+**/docs/_build/
+**/site/
+**/public/
+**/vendor/
+**/third_party/
+
+# Large media files
+**/*.mp4
+**/*.mp3
+**/*.wav
+**/*.avi
+**/*.mov
+**/*.png
+**/*.jpg
+**/*.jpeg
+**/*.gif
+**/*.svg
+**/*.ico
+**/*.pdf
+
+# Logs and temporary files
+**/logs/
+**/*.log
+**/tmp/
+**/temp/
+**/*.tmp
+**/*.temp
+
+# IDE and editor files
+**/.vscode/
+**/.idea/
+**/.DS_Store
+**/.ipynb_checkpoints/
+
+# Large generated files
+gaga.json
+openapi.yaml
+openapi*.yaml
+openapi*.yml
+openapi*.json

--- a/agents-api/agents_api/autogen/Chat.py
+++ b/agents-api/agents_api/autogen/Chat.py
@@ -90,7 +90,7 @@ class ChatInputData(BaseModel):
     """
     A list of new input messages comprising the conversation so far.
     """
-    tools: list[CreateToolRequest] = []
+    tools: list[CreateToolRequest] | None = None
     """
     (Advanced) List of tools that are provided in addition to agent's default set of tools.
     """
@@ -441,6 +441,16 @@ class MultipleChatOutput(BaseChatOutput):
     messages: Annotated[
         list[MessageModel], Field(json_schema_extra={"readOnly": True}, min_length=1)
     ]
+
+
+class RenderResponse(ChatInputData):
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+    docs: Annotated[list[DocReference], Field(json_schema_extra={"readOnly": True})] = []
+    """
+    Documents referenced for this request (for citation purposes).
+    """
 
 
 class SchemaCompletionResponseFormat(BaseModel):

--- a/agents-api/agents_api/autogen/Sessions.py
+++ b/agents-api/agents_api/autogen/Sessions.py
@@ -89,7 +89,7 @@ class CreateSessionRequest(BaseModel):
     """
     Whether to forward tool calls to the model
     """
-    recall_options: VectorDocSearch | TextOnlyDocSearch | HybridDocSearch | None = None
+    recall_options: HybridDocSearch | None = None
     """
     Recall options for the session
     """
@@ -180,9 +180,7 @@ class PatchSessionRequest(BaseModel):
     """
     Whether to forward tool calls to the model
     """
-    recall_options: (
-        VectorDocSearchUpdate | TextOnlyDocSearchUpdate | HybridDocSearchUpdate | None
-    ) = None
+    recall_options: HybridDocSearchUpdate | None = None
     """
     Recall options for the session
     """
@@ -229,7 +227,7 @@ class Session(BaseModel):
     """
     Whether to forward tool calls to the model
     """
-    recall_options: VectorDocSearch | TextOnlyDocSearch | HybridDocSearch | None = None
+    recall_options: HybridDocSearch | None = None
     """
     Recall options for the session
     """
@@ -332,7 +330,7 @@ class UpdateSessionRequest(BaseModel):
     """
     Whether to forward tool calls to the model
     """
-    recall_options: VectorDocSearch | TextOnlyDocSearch | HybridDocSearch | None = None
+    recall_options: HybridDocSearch | None = None
     """
     Recall options for the session
     """
@@ -422,7 +420,7 @@ class CreateOrUpdateSessionRequest(CreateSessionRequest):
     """
     Whether to forward tool calls to the model
     """
-    recall_options: VectorDocSearch | TextOnlyDocSearch | HybridDocSearch | None = None
+    recall_options: HybridDocSearch | None = None
     """
     Recall options for the session
     """

--- a/agents-api/agents_api/common/utils/template.py
+++ b/agents-api/agents_api/common/utils/template.py
@@ -72,12 +72,12 @@ async def render_template_nested[T: (str, dict, list[dict | list[dict]], None)](
 
 
 @beartype
-async def render_template(
-    input: str | list[dict],
+async def render_template[T: str | list[dict]](
+    input: T,
     variables: dict,
     check: bool = False,
     skip_vars: list[str] | None = None,
-) -> str | list[dict]:
+) -> T:
     variables = {
         name: val
         for name, val in variables.items()

--- a/agents-api/agents_api/routers/sessions/__init__.py
+++ b/agents-api/agents_api/routers/sessions/__init__.py
@@ -8,5 +8,6 @@ from .get_session import get_session
 from .get_session_history import get_session_history
 from .list_sessions import list_sessions
 from .patch_session import patch_session
+from .render import render
 from .router import router
 from .update_session import update_session

--- a/agents-api/agents_api/routers/sessions/chat.py
+++ b/agents-api/agents_api/routers/sessions/chat.py
@@ -121,7 +121,6 @@ async def chat(
         docs=doc_references,
         usage=model_response.usage.model_dump(),
         choices=[choice.model_dump() for choice in model_response.choices],
-        internal_debug_rendered=payload,  # if debug else None,
     )
 
     total_tokens_per_user.labels(str(developer.id)).inc(

--- a/agents-api/agents_api/routers/sessions/render.py
+++ b/agents-api/agents_api/routers/sessions/render.py
@@ -110,17 +110,14 @@ async def render_chat_input(
             "role": "system",
             "content": system_template,
         }
-
-        system_messages: list[dict] = await render_template[list[dict]](
-            [system_message], variables=env
-        )
+        system_messages: list[dict] = await render_template([system_message], variables=env)
         past_messages = system_messages + past_messages
 
     # Render the incoming messages
     new_raw_messages = [msg.model_dump(mode="json") for msg in chat_input.messages]
 
     if chat_context.session.render_templates:
-        new_messages = await render_template[list[dict]](new_raw_messages, variables=env)
+        new_messages = await render_template(new_raw_messages, variables=env)
     else:
         new_messages = new_raw_messages
 

--- a/agents-api/agents_api/routers/sessions/render.py
+++ b/agents-api/agents_api/routers/sessions/render.py
@@ -1,0 +1,199 @@
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import Depends, HTTPException, status
+from starlette.status import HTTP_200_OK
+
+from ...autogen.openapi_model import (
+    ChatInput,
+    DocReference,
+    RenderResponse,
+)
+from ...common.protocol.developers import Developer
+from ...common.protocol.sessions import ChatContext
+from ...common.utils.template import render_template
+from ...dependencies.developer_id import get_developer_data
+from ...env import max_free_sessions
+from ...queries.chat.gather_messages import gather_messages
+from ...queries.chat.prepare_chat_context import prepare_chat_context
+from ...queries.sessions.count_sessions import count_sessions as count_sessions_query
+from ..utils.model_validation import validate_model
+from .router import router
+
+COMPUTER_USE_BETA_FLAG = "computer-use-2024-10-22"
+
+
+@router.post(
+    "/sessions/{session_id}/render",
+    status_code=HTTP_200_OK,
+    tags=["sessions", "render"],
+)
+async def render(
+    developer: Annotated[Developer, Depends(get_developer_data)],
+    session_id: UUID,
+    chat_input: ChatInput,
+) -> RenderResponse:
+    """
+    Renders a chat input.
+
+    Parameters:
+        developer (Developer): The developer associated with the chat session.
+        session_id (UUID): The unique identifier of the chat session.
+        chat_input (ChatInput): The chat input data.
+
+    Returns:
+        RenderResponse: The rendered chat input.
+    """
+
+    messages, doc_references, tools, *_ = await render_chat_input(
+        developer=developer,
+        session_id=session_id,
+        chat_input=chat_input,
+    )
+
+    return RenderResponse(messages=messages, docs=doc_references, tools=tools)
+
+
+async def render_chat_input(
+    developer: Developer,
+    session_id: UUID,
+    chat_input: ChatInput,
+) -> tuple[list[dict], list[DocReference], list[dict] | None, dict, list[dict], ChatContext]:
+    if chat_input.model:
+        await validate_model(chat_input.model)
+
+    # check if the developer is paid
+    if "paid" not in developer.tags:
+        # get the session length
+        sessions = await count_sessions_query(developer_id=developer.id)
+        session_length = sessions["count"]
+        if session_length > max_free_sessions:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Session length exceeded the free tier limit",
+            )
+
+    # First get the chat context
+    chat_context: ChatContext = await prepare_chat_context(
+        developer_id=developer.id,
+        session_id=session_id,
+    )
+
+    # Merge the settings and prepare environment
+    chat_context.merge_settings(chat_input)
+    settings: dict = chat_context.settings or {}
+
+    # Get the past messages and doc references
+    past_messages, doc_references = await gather_messages(
+        developer=developer,
+        session_id=session_id,
+        chat_context=chat_context,
+        chat_input=chat_input,
+    )
+
+    # Prepare the environment
+    env: dict = chat_context.get_chat_environment()
+    env["docs"] = [
+        {
+            "title": ref.title,
+            "content": [ref.snippet.content],
+            "metadata": ref.metadata or None,
+        }
+        for ref in doc_references
+    ]
+
+    # Render the system message
+    if system_template := chat_context.merge_system_template(
+        chat_context.session.system_template
+    ):
+        system_message = {
+            "role": "system",
+            "content": system_template,
+        }
+
+        system_messages: list[dict] = await render_template[list[dict]](
+            [system_message], variables=env
+        )
+        past_messages = system_messages + past_messages
+
+    # Render the incoming messages
+    new_raw_messages = [msg.model_dump(mode="json") for msg in chat_input.messages]
+
+    if chat_context.session.render_templates:
+        new_messages = await render_template[list[dict]](new_raw_messages, variables=env)
+    else:
+        new_messages = new_raw_messages
+
+    # Combine the past messages with the new messages
+    messages = past_messages + new_messages
+
+    # Get the tools
+    tools = settings.get("tools") or chat_context.get_active_tools()
+
+    # Check if using Claude model and has specific tool types
+    is_claude_model = settings.get("model", "").lower().startswith("claude-3.5")
+
+    # Format tools for litellm
+    # formatted_tools = (
+    #     tools if is_claude_model else [format_tool(tool) for tool in tools]
+    # )
+
+    # FIXME: Truncate chat messages in the chat context
+    # SCRUM-7
+    if chat_context.session.context_overflow == "truncate":
+        # messages = messages[-settings["max_tokens"] :]
+        msg = "Truncation is not yet implemented"
+        raise NotImplementedError(msg)
+
+    # FIXME: Hotfix for datetime not serializable. Needs investigation
+    messages = [
+        {
+            k: v
+            for k, v in m.items()
+            if k in ["role", "content", "tool_calls", "tool_call_id", "user"]
+        }
+        for m in messages
+    ]
+
+    # FIXME: Hack to make the computer use tools compatible with litellm
+    # Issue was: litellm expects type to be `computer_20241022` and spec to be
+    # `function` (see: https://docs.litellm.ai/docs/providers/anthropic#computer-tools)
+    # but we don't allow that (spec should match type).
+    formatted_tools = []
+    for i, tool in enumerate(tools):
+        if tool.type == "computer_20241022" and tool.computer_20241022:
+            function = tool.computer_20241022
+            tool = {
+                "type": tool.type,
+                "function": {
+                    "name": tool.name,
+                    "parameters": {
+                        k: v
+                        for k, v in function.model_dump().items()
+                        if k not in ["name", "type"]
+                    }
+                    if function is not None
+                    else {},
+                },
+            }
+            formatted_tools.append(tool)
+
+    # If not using Claude model
+    # FIXME: Enable formatted_tools once format-tools PR is merged.
+    if not is_claude_model:
+        formatted_tools = None
+
+    # HOTFIX: for groq calls, litellm expects tool_calls_id not to be in the messages
+    # FIXME: This is a temporary fix. We need to update the agent-api to use the new tool calling format
+    is_groq_model = settings.get("model", "").lower().startswith("llama-3.1")
+    if is_groq_model:
+        messages = [
+            {
+                k: v
+                for k, v in message.items()
+                if k not in ["tool_calls", "tool_call_id", "user", "continue_", "name"]
+            }
+            for message in messages
+        ]
+
+    return messages, doc_references, formatted_tools, settings, new_messages, chat_context

--- a/documentation/docs/advanced/render.mdx
+++ b/documentation/docs/advanced/render.mdx
@@ -1,0 +1,204 @@
+---
+title: 'Render Endpoint in Julep'
+description: 'Learn about the render endpoint for previewing chat inputs before sending them to the model'
+icon: 'eye'
+---
+
+## Overview
+
+Julep provides a render endpoint that allows you to preview how chat inputs will be processed before actually sending them to the model. This is useful for debugging, testing templates, and understanding how the system processes your messages.
+
+## Purpose
+
+<Steps>
+  <Step title="Preview Processing">
+    The render endpoint processes chat inputs exactly as the chat endpoint would, but stops short of sending them to the model.
+  </Step>
+  <Step title="Template Rendering">
+    See how templates in your messages and system prompts will be rendered with the current environment variables.
+  </Step>
+  <Step title="Document Retrieval">
+    Preview which documents will be retrieved from your knowledge base for a given input.
+  </Step>
+  <Step title="Tool Configuration">
+    Examine how tools will be formatted and made available to the model.
+  </Step>
+  <Step title="Debugging">
+    Useful for debugging complex prompts and understanding the exact input that would be sent to the model.
+  </Step>
+</Steps>
+
+<Info>  
+  - The render endpoint uses the same input format as the chat endpoint but returns the processed messages without actually calling the model.
+  - To use the render endpoint, you need to create a session first. To learn more about the session object, check out the [Session](/concepts/sessions) page.
+</Info>
+
+## Input Structure
+
+The render endpoint accepts the same input structure as the chat endpoint:
+
+- **Messages**: An array of input messages representing the conversation so far.
+- **Tools**: (Advanced) Additional tools provided for this specific interaction.
+- **Tool Choice**: Specifies which tool the agent should use.
+- **Memory Access**: Controls how the session accesses history and memories (`recall` parameter).
+- **Additional Parameters**: Various parameters to control the behavior of the rendering.
+
+Here's an example of how a typical message object might be structured in a render request:
+
+<Accordion title="Message Object Structure">
+  ```python Python
+    """
+    Attributes for the Message object:
+        role (Literal["user", "assistant", "system", "tool"]): The role of the message sender.
+        tool_call_id (str | None): Optional identifier for a tool call associated with this message.
+        content (Annotated[str | list[str] | list[Content | ContentModel7 | ContentModel] | None, Field(...)]): The main content of the message, which can be a string, a list of strings, or a list of content models.
+        name (str | None): Optional name associated with the message.
+        continue_ (Annotated[StrictBool | None, Field(alias="continue")]): Flag to indicate whether to continue the conversation without interruption.
+        tool_calls (list[ChosenFunctionCall | ChosenComputer20241022 | ChosenTextEditor20241022 | ChosenBash20241022] | None): List of tool calls generated during the message creation, if any.
+    """
+    # Example of a simple message structure
+    messages = [{"role": "user", "content": "Your query here"}]
+  ```
+  <p>This object represents a message in the chat system, detailing the structure and types of data it can hold.</p>
+</Accordion>
+
+## Additional Parameters
+
+The render endpoint accepts the same parameters as the chat endpoint:
+
+| Parameter           | Type    | Description                                      | Default  |
+|---------------------|---------|--------------------------------------------------|----------|
+| `model`             | `str`   | The model to use for validation (though no actual model call is made). | `None` |
+| `agent`             | `UUID`  | Agent ID of the agent to use for this interaction. (Only applicable for multi-agent sessions) | `None` |
+| `recall`            | `bool`  | Whether previous memories and docs should be recalled or not. | `True` |
+| `response_format`   | `str`   | Response format specification (used for validation only). | `None` |
+| `temperature`       | `float` | Not used in rendering but validated for format. | `None` |
+| `top_p`             | `float` | Not used in rendering but validated for format. | `1.0` |
+| `max_tokens`        | `int`   | Not used in rendering but validated for format. | `None` |
+| `stop`              | `list[str]` | Not used in rendering but validated for format. | `[]` |
+
+## Response Structure
+
+The render endpoint returns a `RenderResponse` object with the following structure:
+
+```json
+{
+  "messages": [
+    // Array of processed messages that would be sent to the model
+  ],
+  "docs": [
+    // Array of document references that would be used for this request
+  ],
+  "tools": [
+    // Array of formatted tools that would be available to the model
+  ]
+}
+```
+
+<Info>
+  The render response includes:
+  - `messages`: The fully processed messages, including rendered templates and system messages.
+  - `docs`: List of document references that would be used for this request, intended for citation purposes.
+  - `tools`: The formatted tools that would be available to the model.
+</Info>
+
+## Usage
+
+Here's an example of how to use the render endpoint in Julep using the SDKs:
+
+<Info>
+  To use the render endpoint, you always have to create a session first.
+</Info>
+
+<CodeGroup>
+    ```python Python
+    # Create a session with custom recall options
+    client.sessions.create(
+        agent=agent.id,
+        user=user.id,
+        recall=True,
+        recall_options={
+            "mode": "hybrid", # or "vector", "text"
+            "num_search_messages": 4, # number of messages to search for documents
+            "max_query_length": 1000, # maximum query length
+            "alpha": 0.7, # weight to apply to BM25 vs Vector search results (ranges from 0 to 1)
+            "confidence": 0.6, # confidence cutoff level (ranges from -1 to 1)
+            "limit": 10, # limit of documents to return
+            "lang": "en-US", # language to be used for text-only search
+            "metadata_filter": {}, # metadata filter to apply to the search
+            "mmr_strength": 0, # MMR Strength (ranges from 0 to 1)
+        }
+    )
+
+    # Render the chat input without sending to the model
+    render_response = client.sessions.render(
+        session_id=session.id,
+        messages=[
+            {
+                "role": "user",
+                "content": "Tell me about Julep"
+            }
+        ],
+        recall=True
+    )
+    print("Processed messages:", render_response.messages)
+    print("Retrieved documents:", render_response.docs)
+    print("Available tools:", render_response.tools)
+    ```
+
+    ```javascript Node.js
+    client.sessions.create({
+        agent: agent.id,
+        user: user.id,
+        recall: true,
+        recall_options: {
+            mode: "hybrid", // or "vector", "text"
+            num_search_messages: 4, // number of messages to search for documents
+            max_query_length: 1000, // maximum query length
+            alpha: 0.7, // weight to apply to BM25 vs Vector search results (ranges from 0 to 1)
+            confidence: 0.6, // confidence cutoff level (ranges from -1 to 1)
+            limit: 10, // limit of documents to return
+            lang: "en-US", // language to be used for text-only search
+            metadata_filter: {}, // metadata filter to apply to the search
+            mmr_strength: 0, // MMR Strength (ranges from 0 to 1)
+        }
+    });
+
+    // Render the chat input without sending to the model
+    const renderResponse = await client.sessions.render({
+        session_id: session.id,
+        messages: [
+            {
+                role: "user",
+                content: "Tell me about Julep"
+            }
+        ],
+        recall: true
+    });
+    ```
+</CodeGroup>
+
+## Use Cases
+
+<CardGroup cols={2}>
+  <Card title="Template Debugging" icon="bug">
+    Test how your templates will be rendered with the current environment variables.
+  </Card>
+  <Card title="RAG Preview" icon="magnifying-glass">
+    Preview which documents will be retrieved for a given query.
+  </Card>
+  <Card title="Tool Configuration" icon="wrench">
+    Verify that tools are properly configured before sending to the model.
+  </Card>
+  <Card title="System Prompt Testing" icon="terminal">
+    Test how system prompts will be processed and combined with user messages.
+  </Card>
+</CardGroup>
+
+## Support
+
+If you need help with further questions in Julep:
+
+- Join our [Discord community](https://discord.com/invite/JTSBGRZrzj)
+- Check the [GitHub repository](https://github.com/julep-ai/julep)
+- Contact support at [hey@julep.ai](mailto:hey@julep.ai)

--- a/documentation/mint.json
+++ b/documentation/mint.json
@@ -180,6 +180,7 @@
         "docs/advanced/python-expression",
         "docs/advanced/types-of-task-steps",
         "docs/advanced/chat",
+        "docs/advanced/render",
         "docs/advanced/files",
         "docs/advanced/architecture-deep-dive",
         "docs/advanced/agentic-patterns",

--- a/integrations-service/integrations/autogen/Chat.py
+++ b/integrations-service/integrations/autogen/Chat.py
@@ -90,7 +90,7 @@ class ChatInputData(BaseModel):
     """
     A list of new input messages comprising the conversation so far.
     """
-    tools: list[CreateToolRequest] = []
+    tools: list[CreateToolRequest] | None = None
     """
     (Advanced) List of tools that are provided in addition to agent's default set of tools.
     """
@@ -441,6 +441,16 @@ class MultipleChatOutput(BaseChatOutput):
     messages: Annotated[
         list[MessageModel], Field(json_schema_extra={"readOnly": True}, min_length=1)
     ]
+
+
+class RenderResponse(ChatInputData):
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+    docs: Annotated[list[DocReference], Field(json_schema_extra={"readOnly": True})] = []
+    """
+    Documents referenced for this request (for citation purposes).
+    """
 
 
 class SchemaCompletionResponseFormat(BaseModel):

--- a/integrations-service/integrations/autogen/Sessions.py
+++ b/integrations-service/integrations/autogen/Sessions.py
@@ -89,7 +89,7 @@ class CreateSessionRequest(BaseModel):
     """
     Whether to forward tool calls to the model
     """
-    recall_options: VectorDocSearch | TextOnlyDocSearch | HybridDocSearch | None = None
+    recall_options: HybridDocSearch | None = None
     """
     Recall options for the session
     """
@@ -180,9 +180,7 @@ class PatchSessionRequest(BaseModel):
     """
     Whether to forward tool calls to the model
     """
-    recall_options: (
-        VectorDocSearchUpdate | TextOnlyDocSearchUpdate | HybridDocSearchUpdate | None
-    ) = None
+    recall_options: HybridDocSearchUpdate | None = None
     """
     Recall options for the session
     """
@@ -229,7 +227,7 @@ class Session(BaseModel):
     """
     Whether to forward tool calls to the model
     """
-    recall_options: VectorDocSearch | TextOnlyDocSearch | HybridDocSearch | None = None
+    recall_options: HybridDocSearch | None = None
     """
     Recall options for the session
     """
@@ -332,7 +330,7 @@ class UpdateSessionRequest(BaseModel):
     """
     Whether to forward tool calls to the model
     """
-    recall_options: VectorDocSearch | TextOnlyDocSearch | HybridDocSearch | None = None
+    recall_options: HybridDocSearch | None = None
     """
     Recall options for the session
     """
@@ -422,7 +420,7 @@ class CreateOrUpdateSessionRequest(CreateSessionRequest):
     """
     Whether to forward tool calls to the model
     """
-    recall_options: VectorDocSearch | TextOnlyDocSearch | HybridDocSearch | None = None
+    recall_options: HybridDocSearch | None = None
     """
     Recall options for the session
     """

--- a/schemas/create_agent_request.json
+++ b/schemas/create_agent_request.json
@@ -3729,12 +3729,19 @@
         "recall_options": {
           "anyOf": [
             {
-              "$ref": "#/$defs/RecallOptions"
+              "$ref": "#/$defs/VectorDocSearch"
+            },
+            {
+              "$ref": "#/$defs/TextOnlyDocSearch"
+            },
+            {
+              "$ref": "#/$defs/HybridDocSearch"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "title": "Recall Options"
         },
         "render_templates": {
           "default": true,
@@ -3903,12 +3910,19 @@
         "recall_options": {
           "anyOf": [
             {
-              "$ref": "#/$defs/RecallOptions"
+              "$ref": "#/$defs/VectorDocSearch"
+            },
+            {
+              "$ref": "#/$defs/TextOnlyDocSearch"
+            },
+            {
+              "$ref": "#/$defs/HybridDocSearch"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "title": "Recall Options"
         },
         "render_templates": {
           "default": true,
@@ -4725,6 +4739,184 @@
         }
       },
       "title": "DummyIntegrationDefUpdate",
+      "type": "object"
+    },
+    "Else-Input": {
+      "description": "The steps to run if the condition is false",
+      "properties": {
+        "initial": {
+          "default": [],
+          "title": "Initial"
+        },
+        "kind_": {
+          "const": "map_reduce",
+          "default": "map_reduce",
+          "readOnly": true,
+          "title": "Kind",
+          "type": "string"
+        },
+        "label": {
+          "anyOf": [
+            {
+              "maxLength": 120,
+              "pattern": "^[^0-9]|^[0-9]+[^0-9].*$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Label"
+        },
+        "map": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EvaluateStep"
+            },
+            {
+              "$ref": "#/$defs/ToolCallStep"
+            },
+            {
+              "$ref": "#/$defs/PromptStep-Input"
+            },
+            {
+              "$ref": "#/$defs/GetStep"
+            },
+            {
+              "$ref": "#/$defs/SetStep"
+            },
+            {
+              "$ref": "#/$defs/LogStep"
+            },
+            {
+              "$ref": "#/$defs/YieldStep"
+            }
+          ],
+          "title": "Map"
+        },
+        "over": {
+          "title": "Over",
+          "type": "string"
+        },
+        "parallelism": {
+          "anyOf": [
+            {
+              "maximum": 100.0,
+              "minimum": 1.0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Parallelism"
+        },
+        "reduce": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Reduce"
+        }
+      },
+      "required": [
+        "over",
+        "map"
+      ],
+      "title": "Else",
+      "type": "object"
+    },
+    "Else-Output": {
+      "description": "The steps to run if the condition is false",
+      "properties": {
+        "initial": {
+          "default": [],
+          "title": "Initial"
+        },
+        "kind_": {
+          "const": "map_reduce",
+          "default": "map_reduce",
+          "readOnly": true,
+          "title": "Kind",
+          "type": "string"
+        },
+        "label": {
+          "anyOf": [
+            {
+              "maxLength": 120,
+              "pattern": "^[^0-9]|^[0-9]+[^0-9].*$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Label"
+        },
+        "map": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EvaluateStep"
+            },
+            {
+              "$ref": "#/$defs/ToolCallStep"
+            },
+            {
+              "$ref": "#/$defs/PromptStep-Output"
+            },
+            {
+              "$ref": "#/$defs/GetStep"
+            },
+            {
+              "$ref": "#/$defs/SetStep"
+            },
+            {
+              "$ref": "#/$defs/LogStep"
+            },
+            {
+              "$ref": "#/$defs/YieldStep"
+            }
+          ],
+          "title": "Map"
+        },
+        "over": {
+          "title": "Over",
+          "type": "string"
+        },
+        "parallelism": {
+          "anyOf": [
+            {
+              "maximum": 100.0,
+              "minimum": 1.0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Parallelism"
+        },
+        "reduce": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Reduce"
+        }
+      },
+      "required": [
+        "over",
+        "map"
+      ],
+      "title": "Else",
       "type": "object"
     },
     "EmailArguments": {
@@ -5869,6 +6061,69 @@
       "title": "History",
       "type": "object"
     },
+    "HybridDocSearch": {
+      "properties": {
+        "alpha": {
+          "default": 0.75,
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Alpha",
+          "type": "number"
+        },
+        "confidence": {
+          "default": 0,
+          "maximum": 1.0,
+          "minimum": -1.0,
+          "title": "Confidence",
+          "type": "number"
+        },
+        "lang": {
+          "default": "en-US",
+          "title": "Lang",
+          "type": "string"
+        },
+        "limit": {
+          "default": 10,
+          "maximum": 50.0,
+          "minimum": 1.0,
+          "title": "Limit",
+          "type": "integer"
+        },
+        "max_query_length": {
+          "default": 1000,
+          "maximum": 10000.0,
+          "minimum": 100.0,
+          "title": "Max Query Length",
+          "type": "integer"
+        },
+        "metadata_filter": {
+          "default": {},
+          "title": "Metadata Filter",
+          "type": "object"
+        },
+        "mmr_strength": {
+          "default": 0.5,
+          "exclusiveMaximum": 1.0,
+          "minimum": 0.0,
+          "title": "Mmr Strength",
+          "type": "number"
+        },
+        "mode": {
+          "default": "hybrid",
+          "title": "Mode",
+          "type": "string"
+        },
+        "num_search_messages": {
+          "default": 4,
+          "maximum": 50.0,
+          "minimum": 1.0,
+          "title": "Num Search Messages",
+          "type": "integer"
+        }
+      },
+      "title": "HybridDocSearch",
+      "type": "object"
+    },
     "HybridDocSearchRequest": {
       "properties": {
         "alpha": {
@@ -5886,7 +6141,6 @@
           "type": "number"
         },
         "lang": {
-          "const": "en-US",
           "default": "en-US",
           "title": "Lang",
           "type": "string"
@@ -5904,7 +6158,7 @@
           "type": "object"
         },
         "mmr_strength": {
-          "default": 0,
+          "default": 0.5,
           "exclusiveMaximum": 1.0,
           "minimum": 0.0,
           "title": "Mmr Strength",
@@ -5929,10 +6183,76 @@
       "title": "HybridDocSearchRequest",
       "type": "object"
     },
+    "HybridDocSearchUpdate": {
+      "properties": {
+        "alpha": {
+          "default": 0.75,
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Alpha",
+          "type": "number"
+        },
+        "confidence": {
+          "default": 0,
+          "maximum": 1.0,
+          "minimum": -1.0,
+          "title": "Confidence",
+          "type": "number"
+        },
+        "lang": {
+          "default": "en-US",
+          "title": "Lang",
+          "type": "string"
+        },
+        "limit": {
+          "default": 10,
+          "maximum": 50.0,
+          "minimum": 1.0,
+          "title": "Limit",
+          "type": "integer"
+        },
+        "max_query_length": {
+          "default": 1000,
+          "maximum": 10000.0,
+          "minimum": 100.0,
+          "title": "Max Query Length",
+          "type": "integer"
+        },
+        "metadata_filter": {
+          "default": {},
+          "title": "Metadata Filter",
+          "type": "object"
+        },
+        "mmr_strength": {
+          "default": 0.5,
+          "exclusiveMaximum": 1.0,
+          "minimum": 0.0,
+          "title": "Mmr Strength",
+          "type": "number"
+        },
+        "mode": {
+          "default": "hybrid",
+          "title": "Mode",
+          "type": "string"
+        },
+        "num_search_messages": {
+          "default": 4,
+          "maximum": 50.0,
+          "minimum": 1.0,
+          "title": "Num Search Messages",
+          "type": "integer"
+        }
+      },
+      "title": "HybridDocSearchUpdate",
+      "type": "object"
+    },
     "IfElseWorkflowStep-Input": {
       "properties": {
         "else": {
           "anyOf": [
+            {
+              "$ref": "#/$defs/WaitForInputStep"
+            },
             {
               "$ref": "#/$defs/EvaluateStep"
             },
@@ -5964,7 +6284,19 @@
               "$ref": "#/$defs/ErrorWorkflowStep"
             },
             {
-              "$ref": "#/$defs/WaitForInputStep"
+              "$ref": "#/$defs/IfElseWorkflowStep-Input"
+            },
+            {
+              "$ref": "#/$defs/SwitchStep-Input"
+            },
+            {
+              "$ref": "#/$defs/ForeachStep-Input"
+            },
+            {
+              "$ref": "#/$defs/ParallelStep-Input"
+            },
+            {
+              "$ref": "#/$defs/Else-Input"
             },
             {
               "type": "null"
@@ -5999,6 +6331,9 @@
         "then": {
           "anyOf": [
             {
+              "$ref": "#/$defs/WaitForInputStep"
+            },
+            {
               "$ref": "#/$defs/EvaluateStep"
             },
             {
@@ -6029,7 +6364,19 @@
               "$ref": "#/$defs/ErrorWorkflowStep"
             },
             {
-              "$ref": "#/$defs/WaitForInputStep"
+              "$ref": "#/$defs/IfElseWorkflowStep-Input"
+            },
+            {
+              "$ref": "#/$defs/SwitchStep-Input"
+            },
+            {
+              "$ref": "#/$defs/ForeachStep-Input"
+            },
+            {
+              "$ref": "#/$defs/ParallelStep-Input"
+            },
+            {
+              "$ref": "#/$defs/Then-Input"
             }
           ],
           "title": "Then"
@@ -6047,6 +6394,9 @@
         "else": {
           "anyOf": [
             {
+              "$ref": "#/$defs/WaitForInputStep"
+            },
+            {
               "$ref": "#/$defs/EvaluateStep"
             },
             {
@@ -6077,7 +6427,19 @@
               "$ref": "#/$defs/ErrorWorkflowStep"
             },
             {
-              "$ref": "#/$defs/WaitForInputStep"
+              "$ref": "#/$defs/IfElseWorkflowStep-Output"
+            },
+            {
+              "$ref": "#/$defs/SwitchStep-Output"
+            },
+            {
+              "$ref": "#/$defs/ForeachStep-Output"
+            },
+            {
+              "$ref": "#/$defs/ParallelStep-Output"
+            },
+            {
+              "$ref": "#/$defs/Else-Output"
             },
             {
               "type": "null"
@@ -6112,6 +6474,9 @@
         "then": {
           "anyOf": [
             {
+              "$ref": "#/$defs/WaitForInputStep"
+            },
+            {
               "$ref": "#/$defs/EvaluateStep"
             },
             {
@@ -6142,7 +6507,19 @@
               "$ref": "#/$defs/ErrorWorkflowStep"
             },
             {
-              "$ref": "#/$defs/WaitForInputStep"
+              "$ref": "#/$defs/IfElseWorkflowStep-Output"
+            },
+            {
+              "$ref": "#/$defs/SwitchStep-Output"
+            },
+            {
+              "$ref": "#/$defs/ForeachStep-Output"
+            },
+            {
+              "$ref": "#/$defs/ParallelStep-Output"
+            },
+            {
+              "$ref": "#/$defs/Then-Output"
             }
           ],
           "title": "Then"
@@ -7526,12 +7903,19 @@
         "recall_options": {
           "anyOf": [
             {
-              "$ref": "#/$defs/RecallOptionsUpdate"
+              "$ref": "#/$defs/VectorDocSearchUpdate"
+            },
+            {
+              "$ref": "#/$defs/TextOnlyDocSearchUpdate"
+            },
+            {
+              "$ref": "#/$defs/HybridDocSearchUpdate"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "title": "Recall Options"
         },
         "render_templates": {
           "default": true,
@@ -8229,136 +8613,6 @@
       "title": "PromptStep",
       "type": "object"
     },
-    "RecallOptions": {
-      "properties": {
-        "alpha": {
-          "default": 0.7,
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Alpha",
-          "type": "number"
-        },
-        "confidence": {
-          "default": 0.6,
-          "maximum": 1.0,
-          "minimum": -1.0,
-          "title": "Confidence",
-          "type": "number"
-        },
-        "lang": {
-          "const": "en-US",
-          "default": "en-US",
-          "title": "Lang",
-          "type": "string"
-        },
-        "limit": {
-          "default": 10,
-          "maximum": 50.0,
-          "minimum": 1.0,
-          "title": "Limit",
-          "type": "integer"
-        },
-        "max_query_length": {
-          "default": 1000,
-          "title": "Max Query Length",
-          "type": "integer"
-        },
-        "metadata_filter": {
-          "default": {},
-          "title": "Metadata Filter",
-          "type": "object"
-        },
-        "mmr_strength": {
-          "default": 0,
-          "exclusiveMaximum": 1.0,
-          "minimum": 0.0,
-          "title": "Mmr Strength",
-          "type": "number"
-        },
-        "mode": {
-          "default": "vector",
-          "enum": [
-            "hybrid",
-            "vector",
-            "text"
-          ],
-          "title": "Mode",
-          "type": "string"
-        },
-        "num_search_messages": {
-          "default": 4,
-          "title": "Num Search Messages",
-          "type": "integer"
-        }
-      },
-      "title": "RecallOptions",
-      "type": "object"
-    },
-    "RecallOptionsUpdate": {
-      "properties": {
-        "alpha": {
-          "default": 0.7,
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Alpha",
-          "type": "number"
-        },
-        "confidence": {
-          "default": 0.6,
-          "maximum": 1.0,
-          "minimum": -1.0,
-          "title": "Confidence",
-          "type": "number"
-        },
-        "lang": {
-          "const": "en-US",
-          "default": "en-US",
-          "title": "Lang",
-          "type": "string"
-        },
-        "limit": {
-          "default": 10,
-          "maximum": 50.0,
-          "minimum": 1.0,
-          "title": "Limit",
-          "type": "integer"
-        },
-        "max_query_length": {
-          "default": 1000,
-          "title": "Max Query Length",
-          "type": "integer"
-        },
-        "metadata_filter": {
-          "default": {},
-          "title": "Metadata Filter",
-          "type": "object"
-        },
-        "mmr_strength": {
-          "default": 0,
-          "exclusiveMaximum": 1.0,
-          "minimum": 0.0,
-          "title": "Mmr Strength",
-          "type": "number"
-        },
-        "mode": {
-          "default": "vector",
-          "enum": [
-            "hybrid",
-            "vector",
-            "text"
-          ],
-          "title": "Mode",
-          "type": "string"
-        },
-        "num_search_messages": {
-          "default": 4,
-          "title": "Num Search Messages",
-          "type": "integer"
-        }
-      },
-      "title": "RecallOptionsUpdate",
-      "type": "object"
-    },
     "Relation": {
       "properties": {
         "head": {
@@ -8824,12 +9078,19 @@
         "recall_options": {
           "anyOf": [
             {
-              "$ref": "#/$defs/RecallOptions"
+              "$ref": "#/$defs/VectorDocSearch"
+            },
+            {
+              "$ref": "#/$defs/TextOnlyDocSearch"
+            },
+            {
+              "$ref": "#/$defs/HybridDocSearch"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "title": "Recall Options"
         },
         "render_templates": {
           "default": true,
@@ -10254,10 +10515,51 @@
       "title": "TextEditor20241022DefUpdate",
       "type": "object"
     },
+    "TextOnlyDocSearch": {
+      "properties": {
+        "lang": {
+          "default": "en-US",
+          "title": "Lang",
+          "type": "string"
+        },
+        "limit": {
+          "default": 10,
+          "maximum": 50.0,
+          "minimum": 1.0,
+          "title": "Limit",
+          "type": "integer"
+        },
+        "max_query_length": {
+          "default": 1000,
+          "maximum": 10000.0,
+          "minimum": 100.0,
+          "title": "Max Query Length",
+          "type": "integer"
+        },
+        "metadata_filter": {
+          "default": {},
+          "title": "Metadata Filter",
+          "type": "object"
+        },
+        "mode": {
+          "default": "text",
+          "title": "Mode",
+          "type": "string"
+        },
+        "num_search_messages": {
+          "default": 4,
+          "maximum": 50.0,
+          "minimum": 1.0,
+          "title": "Num Search Messages",
+          "type": "integer"
+        }
+      },
+      "title": "TextOnlyDocSearch",
+      "type": "object"
+    },
     "TextOnlyDocSearchRequest": {
       "properties": {
         "lang": {
-          "const": "en-US",
           "default": "en-US",
           "title": "Lang",
           "type": "string"
@@ -10274,13 +10576,6 @@
           "title": "Metadata Filter",
           "type": "object"
         },
-        "mmr_strength": {
-          "default": 0,
-          "exclusiveMaximum": 1.0,
-          "minimum": 0.0,
-          "title": "Mmr Strength",
-          "type": "number"
-        },
         "text": {
           "title": "Text",
           "type": "string"
@@ -10290,6 +10585,226 @@
         "text"
       ],
       "title": "TextOnlyDocSearchRequest",
+      "type": "object"
+    },
+    "TextOnlyDocSearchUpdate": {
+      "properties": {
+        "lang": {
+          "default": "en-US",
+          "title": "Lang",
+          "type": "string"
+        },
+        "limit": {
+          "default": 10,
+          "maximum": 50.0,
+          "minimum": 1.0,
+          "title": "Limit",
+          "type": "integer"
+        },
+        "max_query_length": {
+          "default": 1000,
+          "maximum": 10000.0,
+          "minimum": 100.0,
+          "title": "Max Query Length",
+          "type": "integer"
+        },
+        "metadata_filter": {
+          "default": {},
+          "title": "Metadata Filter",
+          "type": "object"
+        },
+        "mode": {
+          "default": "text",
+          "title": "Mode",
+          "type": "string"
+        },
+        "num_search_messages": {
+          "default": 4,
+          "maximum": 50.0,
+          "minimum": 1.0,
+          "title": "Num Search Messages",
+          "type": "integer"
+        }
+      },
+      "title": "TextOnlyDocSearchUpdate",
+      "type": "object"
+    },
+    "Then-Input": {
+      "description": "The steps to run if the condition is true",
+      "properties": {
+        "initial": {
+          "default": [],
+          "title": "Initial"
+        },
+        "kind_": {
+          "const": "map_reduce",
+          "default": "map_reduce",
+          "readOnly": true,
+          "title": "Kind",
+          "type": "string"
+        },
+        "label": {
+          "anyOf": [
+            {
+              "maxLength": 120,
+              "pattern": "^[^0-9]|^[0-9]+[^0-9].*$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Label"
+        },
+        "map": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EvaluateStep"
+            },
+            {
+              "$ref": "#/$defs/ToolCallStep"
+            },
+            {
+              "$ref": "#/$defs/PromptStep-Input"
+            },
+            {
+              "$ref": "#/$defs/GetStep"
+            },
+            {
+              "$ref": "#/$defs/SetStep"
+            },
+            {
+              "$ref": "#/$defs/LogStep"
+            },
+            {
+              "$ref": "#/$defs/YieldStep"
+            }
+          ],
+          "title": "Map"
+        },
+        "over": {
+          "title": "Over",
+          "type": "string"
+        },
+        "parallelism": {
+          "anyOf": [
+            {
+              "maximum": 100.0,
+              "minimum": 1.0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Parallelism"
+        },
+        "reduce": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Reduce"
+        }
+      },
+      "required": [
+        "over",
+        "map"
+      ],
+      "title": "Then",
+      "type": "object"
+    },
+    "Then-Output": {
+      "description": "The steps to run if the condition is true",
+      "properties": {
+        "initial": {
+          "default": [],
+          "title": "Initial"
+        },
+        "kind_": {
+          "const": "map_reduce",
+          "default": "map_reduce",
+          "readOnly": true,
+          "title": "Kind",
+          "type": "string"
+        },
+        "label": {
+          "anyOf": [
+            {
+              "maxLength": 120,
+              "pattern": "^[^0-9]|^[0-9]+[^0-9].*$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Label"
+        },
+        "map": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EvaluateStep"
+            },
+            {
+              "$ref": "#/$defs/ToolCallStep"
+            },
+            {
+              "$ref": "#/$defs/PromptStep-Output"
+            },
+            {
+              "$ref": "#/$defs/GetStep"
+            },
+            {
+              "$ref": "#/$defs/SetStep"
+            },
+            {
+              "$ref": "#/$defs/LogStep"
+            },
+            {
+              "$ref": "#/$defs/YieldStep"
+            }
+          ],
+          "title": "Map"
+        },
+        "over": {
+          "title": "Over",
+          "type": "string"
+        },
+        "parallelism": {
+          "anyOf": [
+            {
+              "maximum": 100.0,
+              "minimum": 1.0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Parallelism"
+        },
+        "reduce": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Reduce"
+        }
+      },
+      "required": [
+        "over",
+        "map"
+      ],
+      "title": "Then",
       "type": "object"
     },
     "TokenLogProb": {
@@ -10895,12 +11410,19 @@
         "recall_options": {
           "anyOf": [
             {
-              "$ref": "#/$defs/RecallOptions"
+              "$ref": "#/$defs/VectorDocSearch"
+            },
+            {
+              "$ref": "#/$defs/TextOnlyDocSearch"
+            },
+            {
+              "$ref": "#/$defs/HybridDocSearch"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "title": "Recall Options"
         },
         "render_templates": {
           "default": true,
@@ -11225,6 +11747,62 @@
       "title": "ValidationError",
       "type": "object"
     },
+    "VectorDocSearch": {
+      "properties": {
+        "confidence": {
+          "default": 0,
+          "maximum": 1.0,
+          "minimum": -1.0,
+          "title": "Confidence",
+          "type": "number"
+        },
+        "lang": {
+          "default": "en-US",
+          "title": "Lang",
+          "type": "string"
+        },
+        "limit": {
+          "default": 10,
+          "maximum": 50.0,
+          "minimum": 1.0,
+          "title": "Limit",
+          "type": "integer"
+        },
+        "max_query_length": {
+          "default": 1000,
+          "maximum": 10000.0,
+          "minimum": 100.0,
+          "title": "Max Query Length",
+          "type": "integer"
+        },
+        "metadata_filter": {
+          "default": {},
+          "title": "Metadata Filter",
+          "type": "object"
+        },
+        "mmr_strength": {
+          "default": 0.5,
+          "exclusiveMaximum": 1.0,
+          "minimum": 0.0,
+          "title": "Mmr Strength",
+          "type": "number"
+        },
+        "mode": {
+          "default": "vector",
+          "title": "Mode",
+          "type": "string"
+        },
+        "num_search_messages": {
+          "default": 4,
+          "maximum": 50.0,
+          "minimum": 1.0,
+          "title": "Num Search Messages",
+          "type": "integer"
+        }
+      },
+      "title": "VectorDocSearch",
+      "type": "object"
+    },
     "VectorDocSearchRequest": {
       "properties": {
         "confidence": {
@@ -11235,7 +11813,6 @@
           "type": "number"
         },
         "lang": {
-          "const": "en-US",
           "default": "en-US",
           "title": "Lang",
           "type": "string"
@@ -11253,7 +11830,7 @@
           "type": "object"
         },
         "mmr_strength": {
-          "default": 0,
+          "default": 0.5,
           "exclusiveMaximum": 1.0,
           "minimum": 0.0,
           "title": "Mmr Strength",
@@ -11271,6 +11848,62 @@
         "vector"
       ],
       "title": "VectorDocSearchRequest",
+      "type": "object"
+    },
+    "VectorDocSearchUpdate": {
+      "properties": {
+        "confidence": {
+          "default": 0,
+          "maximum": 1.0,
+          "minimum": -1.0,
+          "title": "Confidence",
+          "type": "number"
+        },
+        "lang": {
+          "default": "en-US",
+          "title": "Lang",
+          "type": "string"
+        },
+        "limit": {
+          "default": 10,
+          "maximum": 50.0,
+          "minimum": 1.0,
+          "title": "Limit",
+          "type": "integer"
+        },
+        "max_query_length": {
+          "default": 1000,
+          "maximum": 10000.0,
+          "minimum": 100.0,
+          "title": "Max Query Length",
+          "type": "integer"
+        },
+        "metadata_filter": {
+          "default": {},
+          "title": "Metadata Filter",
+          "type": "object"
+        },
+        "mmr_strength": {
+          "default": 0.5,
+          "exclusiveMaximum": 1.0,
+          "minimum": 0.0,
+          "title": "Mmr Strength",
+          "type": "number"
+        },
+        "mode": {
+          "default": "vector",
+          "title": "Mode",
+          "type": "string"
+        },
+        "num_search_messages": {
+          "default": 4,
+          "maximum": 50.0,
+          "minimum": 1.0,
+          "title": "Num Search Messages",
+          "type": "integer"
+        }
+      },
+      "title": "VectorDocSearchUpdate",
       "type": "object"
     },
     "WaitForInputInfo": {

--- a/schemas/create_task_request.json
+++ b/schemas/create_task_request.json
@@ -3729,12 +3729,19 @@
         "recall_options": {
           "anyOf": [
             {
-              "$ref": "#/$defs/RecallOptions"
+              "$ref": "#/$defs/VectorDocSearch"
+            },
+            {
+              "$ref": "#/$defs/TextOnlyDocSearch"
+            },
+            {
+              "$ref": "#/$defs/HybridDocSearch"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "title": "Recall Options"
         },
         "render_templates": {
           "default": true,
@@ -3903,12 +3910,19 @@
         "recall_options": {
           "anyOf": [
             {
-              "$ref": "#/$defs/RecallOptions"
+              "$ref": "#/$defs/VectorDocSearch"
+            },
+            {
+              "$ref": "#/$defs/TextOnlyDocSearch"
+            },
+            {
+              "$ref": "#/$defs/HybridDocSearch"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "title": "Recall Options"
         },
         "render_templates": {
           "default": true,
@@ -4725,6 +4739,184 @@
         }
       },
       "title": "DummyIntegrationDefUpdate",
+      "type": "object"
+    },
+    "Else-Input": {
+      "description": "The steps to run if the condition is false",
+      "properties": {
+        "initial": {
+          "default": [],
+          "title": "Initial"
+        },
+        "kind_": {
+          "const": "map_reduce",
+          "default": "map_reduce",
+          "readOnly": true,
+          "title": "Kind",
+          "type": "string"
+        },
+        "label": {
+          "anyOf": [
+            {
+              "maxLength": 120,
+              "pattern": "^[^0-9]|^[0-9]+[^0-9].*$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Label"
+        },
+        "map": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EvaluateStep"
+            },
+            {
+              "$ref": "#/$defs/ToolCallStep"
+            },
+            {
+              "$ref": "#/$defs/PromptStep-Input"
+            },
+            {
+              "$ref": "#/$defs/GetStep"
+            },
+            {
+              "$ref": "#/$defs/SetStep"
+            },
+            {
+              "$ref": "#/$defs/LogStep"
+            },
+            {
+              "$ref": "#/$defs/YieldStep"
+            }
+          ],
+          "title": "Map"
+        },
+        "over": {
+          "title": "Over",
+          "type": "string"
+        },
+        "parallelism": {
+          "anyOf": [
+            {
+              "maximum": 100.0,
+              "minimum": 1.0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Parallelism"
+        },
+        "reduce": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Reduce"
+        }
+      },
+      "required": [
+        "over",
+        "map"
+      ],
+      "title": "Else",
+      "type": "object"
+    },
+    "Else-Output": {
+      "description": "The steps to run if the condition is false",
+      "properties": {
+        "initial": {
+          "default": [],
+          "title": "Initial"
+        },
+        "kind_": {
+          "const": "map_reduce",
+          "default": "map_reduce",
+          "readOnly": true,
+          "title": "Kind",
+          "type": "string"
+        },
+        "label": {
+          "anyOf": [
+            {
+              "maxLength": 120,
+              "pattern": "^[^0-9]|^[0-9]+[^0-9].*$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Label"
+        },
+        "map": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EvaluateStep"
+            },
+            {
+              "$ref": "#/$defs/ToolCallStep"
+            },
+            {
+              "$ref": "#/$defs/PromptStep-Output"
+            },
+            {
+              "$ref": "#/$defs/GetStep"
+            },
+            {
+              "$ref": "#/$defs/SetStep"
+            },
+            {
+              "$ref": "#/$defs/LogStep"
+            },
+            {
+              "$ref": "#/$defs/YieldStep"
+            }
+          ],
+          "title": "Map"
+        },
+        "over": {
+          "title": "Over",
+          "type": "string"
+        },
+        "parallelism": {
+          "anyOf": [
+            {
+              "maximum": 100.0,
+              "minimum": 1.0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Parallelism"
+        },
+        "reduce": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Reduce"
+        }
+      },
+      "required": [
+        "over",
+        "map"
+      ],
+      "title": "Else",
       "type": "object"
     },
     "EmailArguments": {
@@ -5869,6 +6061,69 @@
       "title": "History",
       "type": "object"
     },
+    "HybridDocSearch": {
+      "properties": {
+        "alpha": {
+          "default": 0.75,
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Alpha",
+          "type": "number"
+        },
+        "confidence": {
+          "default": 0,
+          "maximum": 1.0,
+          "minimum": -1.0,
+          "title": "Confidence",
+          "type": "number"
+        },
+        "lang": {
+          "default": "en-US",
+          "title": "Lang",
+          "type": "string"
+        },
+        "limit": {
+          "default": 10,
+          "maximum": 50.0,
+          "minimum": 1.0,
+          "title": "Limit",
+          "type": "integer"
+        },
+        "max_query_length": {
+          "default": 1000,
+          "maximum": 10000.0,
+          "minimum": 100.0,
+          "title": "Max Query Length",
+          "type": "integer"
+        },
+        "metadata_filter": {
+          "default": {},
+          "title": "Metadata Filter",
+          "type": "object"
+        },
+        "mmr_strength": {
+          "default": 0.5,
+          "exclusiveMaximum": 1.0,
+          "minimum": 0.0,
+          "title": "Mmr Strength",
+          "type": "number"
+        },
+        "mode": {
+          "default": "hybrid",
+          "title": "Mode",
+          "type": "string"
+        },
+        "num_search_messages": {
+          "default": 4,
+          "maximum": 50.0,
+          "minimum": 1.0,
+          "title": "Num Search Messages",
+          "type": "integer"
+        }
+      },
+      "title": "HybridDocSearch",
+      "type": "object"
+    },
     "HybridDocSearchRequest": {
       "properties": {
         "alpha": {
@@ -5886,7 +6141,6 @@
           "type": "number"
         },
         "lang": {
-          "const": "en-US",
           "default": "en-US",
           "title": "Lang",
           "type": "string"
@@ -5904,7 +6158,7 @@
           "type": "object"
         },
         "mmr_strength": {
-          "default": 0,
+          "default": 0.5,
           "exclusiveMaximum": 1.0,
           "minimum": 0.0,
           "title": "Mmr Strength",
@@ -5929,10 +6183,76 @@
       "title": "HybridDocSearchRequest",
       "type": "object"
     },
+    "HybridDocSearchUpdate": {
+      "properties": {
+        "alpha": {
+          "default": 0.75,
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Alpha",
+          "type": "number"
+        },
+        "confidence": {
+          "default": 0,
+          "maximum": 1.0,
+          "minimum": -1.0,
+          "title": "Confidence",
+          "type": "number"
+        },
+        "lang": {
+          "default": "en-US",
+          "title": "Lang",
+          "type": "string"
+        },
+        "limit": {
+          "default": 10,
+          "maximum": 50.0,
+          "minimum": 1.0,
+          "title": "Limit",
+          "type": "integer"
+        },
+        "max_query_length": {
+          "default": 1000,
+          "maximum": 10000.0,
+          "minimum": 100.0,
+          "title": "Max Query Length",
+          "type": "integer"
+        },
+        "metadata_filter": {
+          "default": {},
+          "title": "Metadata Filter",
+          "type": "object"
+        },
+        "mmr_strength": {
+          "default": 0.5,
+          "exclusiveMaximum": 1.0,
+          "minimum": 0.0,
+          "title": "Mmr Strength",
+          "type": "number"
+        },
+        "mode": {
+          "default": "hybrid",
+          "title": "Mode",
+          "type": "string"
+        },
+        "num_search_messages": {
+          "default": 4,
+          "maximum": 50.0,
+          "minimum": 1.0,
+          "title": "Num Search Messages",
+          "type": "integer"
+        }
+      },
+      "title": "HybridDocSearchUpdate",
+      "type": "object"
+    },
     "IfElseWorkflowStep-Input": {
       "properties": {
         "else": {
           "anyOf": [
+            {
+              "$ref": "#/$defs/WaitForInputStep"
+            },
             {
               "$ref": "#/$defs/EvaluateStep"
             },
@@ -5964,7 +6284,19 @@
               "$ref": "#/$defs/ErrorWorkflowStep"
             },
             {
-              "$ref": "#/$defs/WaitForInputStep"
+              "$ref": "#/$defs/IfElseWorkflowStep-Input"
+            },
+            {
+              "$ref": "#/$defs/SwitchStep-Input"
+            },
+            {
+              "$ref": "#/$defs/ForeachStep-Input"
+            },
+            {
+              "$ref": "#/$defs/ParallelStep-Input"
+            },
+            {
+              "$ref": "#/$defs/Else-Input"
             },
             {
               "type": "null"
@@ -5999,6 +6331,9 @@
         "then": {
           "anyOf": [
             {
+              "$ref": "#/$defs/WaitForInputStep"
+            },
+            {
               "$ref": "#/$defs/EvaluateStep"
             },
             {
@@ -6029,7 +6364,19 @@
               "$ref": "#/$defs/ErrorWorkflowStep"
             },
             {
-              "$ref": "#/$defs/WaitForInputStep"
+              "$ref": "#/$defs/IfElseWorkflowStep-Input"
+            },
+            {
+              "$ref": "#/$defs/SwitchStep-Input"
+            },
+            {
+              "$ref": "#/$defs/ForeachStep-Input"
+            },
+            {
+              "$ref": "#/$defs/ParallelStep-Input"
+            },
+            {
+              "$ref": "#/$defs/Then-Input"
             }
           ],
           "title": "Then"
@@ -6047,6 +6394,9 @@
         "else": {
           "anyOf": [
             {
+              "$ref": "#/$defs/WaitForInputStep"
+            },
+            {
               "$ref": "#/$defs/EvaluateStep"
             },
             {
@@ -6077,7 +6427,19 @@
               "$ref": "#/$defs/ErrorWorkflowStep"
             },
             {
-              "$ref": "#/$defs/WaitForInputStep"
+              "$ref": "#/$defs/IfElseWorkflowStep-Output"
+            },
+            {
+              "$ref": "#/$defs/SwitchStep-Output"
+            },
+            {
+              "$ref": "#/$defs/ForeachStep-Output"
+            },
+            {
+              "$ref": "#/$defs/ParallelStep-Output"
+            },
+            {
+              "$ref": "#/$defs/Else-Output"
             },
             {
               "type": "null"
@@ -6112,6 +6474,9 @@
         "then": {
           "anyOf": [
             {
+              "$ref": "#/$defs/WaitForInputStep"
+            },
+            {
               "$ref": "#/$defs/EvaluateStep"
             },
             {
@@ -6142,7 +6507,19 @@
               "$ref": "#/$defs/ErrorWorkflowStep"
             },
             {
-              "$ref": "#/$defs/WaitForInputStep"
+              "$ref": "#/$defs/IfElseWorkflowStep-Output"
+            },
+            {
+              "$ref": "#/$defs/SwitchStep-Output"
+            },
+            {
+              "$ref": "#/$defs/ForeachStep-Output"
+            },
+            {
+              "$ref": "#/$defs/ParallelStep-Output"
+            },
+            {
+              "$ref": "#/$defs/Then-Output"
             }
           ],
           "title": "Then"
@@ -7526,12 +7903,19 @@
         "recall_options": {
           "anyOf": [
             {
-              "$ref": "#/$defs/RecallOptionsUpdate"
+              "$ref": "#/$defs/VectorDocSearchUpdate"
+            },
+            {
+              "$ref": "#/$defs/TextOnlyDocSearchUpdate"
+            },
+            {
+              "$ref": "#/$defs/HybridDocSearchUpdate"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "title": "Recall Options"
         },
         "render_templates": {
           "default": true,
@@ -8229,136 +8613,6 @@
       "title": "PromptStep",
       "type": "object"
     },
-    "RecallOptions": {
-      "properties": {
-        "alpha": {
-          "default": 0.7,
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Alpha",
-          "type": "number"
-        },
-        "confidence": {
-          "default": 0.6,
-          "maximum": 1.0,
-          "minimum": -1.0,
-          "title": "Confidence",
-          "type": "number"
-        },
-        "lang": {
-          "const": "en-US",
-          "default": "en-US",
-          "title": "Lang",
-          "type": "string"
-        },
-        "limit": {
-          "default": 10,
-          "maximum": 50.0,
-          "minimum": 1.0,
-          "title": "Limit",
-          "type": "integer"
-        },
-        "max_query_length": {
-          "default": 1000,
-          "title": "Max Query Length",
-          "type": "integer"
-        },
-        "metadata_filter": {
-          "default": {},
-          "title": "Metadata Filter",
-          "type": "object"
-        },
-        "mmr_strength": {
-          "default": 0,
-          "exclusiveMaximum": 1.0,
-          "minimum": 0.0,
-          "title": "Mmr Strength",
-          "type": "number"
-        },
-        "mode": {
-          "default": "vector",
-          "enum": [
-            "hybrid",
-            "vector",
-            "text"
-          ],
-          "title": "Mode",
-          "type": "string"
-        },
-        "num_search_messages": {
-          "default": 4,
-          "title": "Num Search Messages",
-          "type": "integer"
-        }
-      },
-      "title": "RecallOptions",
-      "type": "object"
-    },
-    "RecallOptionsUpdate": {
-      "properties": {
-        "alpha": {
-          "default": 0.7,
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Alpha",
-          "type": "number"
-        },
-        "confidence": {
-          "default": 0.6,
-          "maximum": 1.0,
-          "minimum": -1.0,
-          "title": "Confidence",
-          "type": "number"
-        },
-        "lang": {
-          "const": "en-US",
-          "default": "en-US",
-          "title": "Lang",
-          "type": "string"
-        },
-        "limit": {
-          "default": 10,
-          "maximum": 50.0,
-          "minimum": 1.0,
-          "title": "Limit",
-          "type": "integer"
-        },
-        "max_query_length": {
-          "default": 1000,
-          "title": "Max Query Length",
-          "type": "integer"
-        },
-        "metadata_filter": {
-          "default": {},
-          "title": "Metadata Filter",
-          "type": "object"
-        },
-        "mmr_strength": {
-          "default": 0,
-          "exclusiveMaximum": 1.0,
-          "minimum": 0.0,
-          "title": "Mmr Strength",
-          "type": "number"
-        },
-        "mode": {
-          "default": "vector",
-          "enum": [
-            "hybrid",
-            "vector",
-            "text"
-          ],
-          "title": "Mode",
-          "type": "string"
-        },
-        "num_search_messages": {
-          "default": 4,
-          "title": "Num Search Messages",
-          "type": "integer"
-        }
-      },
-      "title": "RecallOptionsUpdate",
-      "type": "object"
-    },
     "Relation": {
       "properties": {
         "head": {
@@ -8824,12 +9078,19 @@
         "recall_options": {
           "anyOf": [
             {
-              "$ref": "#/$defs/RecallOptions"
+              "$ref": "#/$defs/VectorDocSearch"
+            },
+            {
+              "$ref": "#/$defs/TextOnlyDocSearch"
+            },
+            {
+              "$ref": "#/$defs/HybridDocSearch"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "title": "Recall Options"
         },
         "render_templates": {
           "default": true,
@@ -10254,10 +10515,51 @@
       "title": "TextEditor20241022DefUpdate",
       "type": "object"
     },
+    "TextOnlyDocSearch": {
+      "properties": {
+        "lang": {
+          "default": "en-US",
+          "title": "Lang",
+          "type": "string"
+        },
+        "limit": {
+          "default": 10,
+          "maximum": 50.0,
+          "minimum": 1.0,
+          "title": "Limit",
+          "type": "integer"
+        },
+        "max_query_length": {
+          "default": 1000,
+          "maximum": 10000.0,
+          "minimum": 100.0,
+          "title": "Max Query Length",
+          "type": "integer"
+        },
+        "metadata_filter": {
+          "default": {},
+          "title": "Metadata Filter",
+          "type": "object"
+        },
+        "mode": {
+          "default": "text",
+          "title": "Mode",
+          "type": "string"
+        },
+        "num_search_messages": {
+          "default": 4,
+          "maximum": 50.0,
+          "minimum": 1.0,
+          "title": "Num Search Messages",
+          "type": "integer"
+        }
+      },
+      "title": "TextOnlyDocSearch",
+      "type": "object"
+    },
     "TextOnlyDocSearchRequest": {
       "properties": {
         "lang": {
-          "const": "en-US",
           "default": "en-US",
           "title": "Lang",
           "type": "string"
@@ -10274,13 +10576,6 @@
           "title": "Metadata Filter",
           "type": "object"
         },
-        "mmr_strength": {
-          "default": 0,
-          "exclusiveMaximum": 1.0,
-          "minimum": 0.0,
-          "title": "Mmr Strength",
-          "type": "number"
-        },
         "text": {
           "title": "Text",
           "type": "string"
@@ -10290,6 +10585,226 @@
         "text"
       ],
       "title": "TextOnlyDocSearchRequest",
+      "type": "object"
+    },
+    "TextOnlyDocSearchUpdate": {
+      "properties": {
+        "lang": {
+          "default": "en-US",
+          "title": "Lang",
+          "type": "string"
+        },
+        "limit": {
+          "default": 10,
+          "maximum": 50.0,
+          "minimum": 1.0,
+          "title": "Limit",
+          "type": "integer"
+        },
+        "max_query_length": {
+          "default": 1000,
+          "maximum": 10000.0,
+          "minimum": 100.0,
+          "title": "Max Query Length",
+          "type": "integer"
+        },
+        "metadata_filter": {
+          "default": {},
+          "title": "Metadata Filter",
+          "type": "object"
+        },
+        "mode": {
+          "default": "text",
+          "title": "Mode",
+          "type": "string"
+        },
+        "num_search_messages": {
+          "default": 4,
+          "maximum": 50.0,
+          "minimum": 1.0,
+          "title": "Num Search Messages",
+          "type": "integer"
+        }
+      },
+      "title": "TextOnlyDocSearchUpdate",
+      "type": "object"
+    },
+    "Then-Input": {
+      "description": "The steps to run if the condition is true",
+      "properties": {
+        "initial": {
+          "default": [],
+          "title": "Initial"
+        },
+        "kind_": {
+          "const": "map_reduce",
+          "default": "map_reduce",
+          "readOnly": true,
+          "title": "Kind",
+          "type": "string"
+        },
+        "label": {
+          "anyOf": [
+            {
+              "maxLength": 120,
+              "pattern": "^[^0-9]|^[0-9]+[^0-9].*$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Label"
+        },
+        "map": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EvaluateStep"
+            },
+            {
+              "$ref": "#/$defs/ToolCallStep"
+            },
+            {
+              "$ref": "#/$defs/PromptStep-Input"
+            },
+            {
+              "$ref": "#/$defs/GetStep"
+            },
+            {
+              "$ref": "#/$defs/SetStep"
+            },
+            {
+              "$ref": "#/$defs/LogStep"
+            },
+            {
+              "$ref": "#/$defs/YieldStep"
+            }
+          ],
+          "title": "Map"
+        },
+        "over": {
+          "title": "Over",
+          "type": "string"
+        },
+        "parallelism": {
+          "anyOf": [
+            {
+              "maximum": 100.0,
+              "minimum": 1.0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Parallelism"
+        },
+        "reduce": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Reduce"
+        }
+      },
+      "required": [
+        "over",
+        "map"
+      ],
+      "title": "Then",
+      "type": "object"
+    },
+    "Then-Output": {
+      "description": "The steps to run if the condition is true",
+      "properties": {
+        "initial": {
+          "default": [],
+          "title": "Initial"
+        },
+        "kind_": {
+          "const": "map_reduce",
+          "default": "map_reduce",
+          "readOnly": true,
+          "title": "Kind",
+          "type": "string"
+        },
+        "label": {
+          "anyOf": [
+            {
+              "maxLength": 120,
+              "pattern": "^[^0-9]|^[0-9]+[^0-9].*$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Label"
+        },
+        "map": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EvaluateStep"
+            },
+            {
+              "$ref": "#/$defs/ToolCallStep"
+            },
+            {
+              "$ref": "#/$defs/PromptStep-Output"
+            },
+            {
+              "$ref": "#/$defs/GetStep"
+            },
+            {
+              "$ref": "#/$defs/SetStep"
+            },
+            {
+              "$ref": "#/$defs/LogStep"
+            },
+            {
+              "$ref": "#/$defs/YieldStep"
+            }
+          ],
+          "title": "Map"
+        },
+        "over": {
+          "title": "Over",
+          "type": "string"
+        },
+        "parallelism": {
+          "anyOf": [
+            {
+              "maximum": 100.0,
+              "minimum": 1.0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Parallelism"
+        },
+        "reduce": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Reduce"
+        }
+      },
+      "required": [
+        "over",
+        "map"
+      ],
+      "title": "Then",
       "type": "object"
     },
     "TokenLogProb": {
@@ -10895,12 +11410,19 @@
         "recall_options": {
           "anyOf": [
             {
-              "$ref": "#/$defs/RecallOptions"
+              "$ref": "#/$defs/VectorDocSearch"
+            },
+            {
+              "$ref": "#/$defs/TextOnlyDocSearch"
+            },
+            {
+              "$ref": "#/$defs/HybridDocSearch"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "title": "Recall Options"
         },
         "render_templates": {
           "default": true,
@@ -11225,6 +11747,62 @@
       "title": "ValidationError",
       "type": "object"
     },
+    "VectorDocSearch": {
+      "properties": {
+        "confidence": {
+          "default": 0,
+          "maximum": 1.0,
+          "minimum": -1.0,
+          "title": "Confidence",
+          "type": "number"
+        },
+        "lang": {
+          "default": "en-US",
+          "title": "Lang",
+          "type": "string"
+        },
+        "limit": {
+          "default": 10,
+          "maximum": 50.0,
+          "minimum": 1.0,
+          "title": "Limit",
+          "type": "integer"
+        },
+        "max_query_length": {
+          "default": 1000,
+          "maximum": 10000.0,
+          "minimum": 100.0,
+          "title": "Max Query Length",
+          "type": "integer"
+        },
+        "metadata_filter": {
+          "default": {},
+          "title": "Metadata Filter",
+          "type": "object"
+        },
+        "mmr_strength": {
+          "default": 0.5,
+          "exclusiveMaximum": 1.0,
+          "minimum": 0.0,
+          "title": "Mmr Strength",
+          "type": "number"
+        },
+        "mode": {
+          "default": "vector",
+          "title": "Mode",
+          "type": "string"
+        },
+        "num_search_messages": {
+          "default": 4,
+          "maximum": 50.0,
+          "minimum": 1.0,
+          "title": "Num Search Messages",
+          "type": "integer"
+        }
+      },
+      "title": "VectorDocSearch",
+      "type": "object"
+    },
     "VectorDocSearchRequest": {
       "properties": {
         "confidence": {
@@ -11235,7 +11813,6 @@
           "type": "number"
         },
         "lang": {
-          "const": "en-US",
           "default": "en-US",
           "title": "Lang",
           "type": "string"
@@ -11253,7 +11830,7 @@
           "type": "object"
         },
         "mmr_strength": {
-          "default": 0,
+          "default": 0.5,
           "exclusiveMaximum": 1.0,
           "minimum": 0.0,
           "title": "Mmr Strength",
@@ -11271,6 +11848,62 @@
         "vector"
       ],
       "title": "VectorDocSearchRequest",
+      "type": "object"
+    },
+    "VectorDocSearchUpdate": {
+      "properties": {
+        "confidence": {
+          "default": 0,
+          "maximum": 1.0,
+          "minimum": -1.0,
+          "title": "Confidence",
+          "type": "number"
+        },
+        "lang": {
+          "default": "en-US",
+          "title": "Lang",
+          "type": "string"
+        },
+        "limit": {
+          "default": 10,
+          "maximum": 50.0,
+          "minimum": 1.0,
+          "title": "Limit",
+          "type": "integer"
+        },
+        "max_query_length": {
+          "default": 1000,
+          "maximum": 10000.0,
+          "minimum": 100.0,
+          "title": "Max Query Length",
+          "type": "integer"
+        },
+        "metadata_filter": {
+          "default": {},
+          "title": "Metadata Filter",
+          "type": "object"
+        },
+        "mmr_strength": {
+          "default": 0.5,
+          "exclusiveMaximum": 1.0,
+          "minimum": 0.0,
+          "title": "Mmr Strength",
+          "type": "number"
+        },
+        "mode": {
+          "default": "vector",
+          "title": "Mode",
+          "type": "string"
+        },
+        "num_search_messages": {
+          "default": 4,
+          "maximum": 50.0,
+          "minimum": 1.0,
+          "title": "Num Search Messages",
+          "type": "integer"
+        }
+      },
+      "title": "VectorDocSearchUpdate",
       "type": "object"
     },
     "WaitForInputInfo": {

--- a/scripts/generate_openapi_code.sh
+++ b/scripts/generate_openapi_code.sh
@@ -16,7 +16,7 @@ uv_run () {
 codegen_then_format () {
   uv_run 'poe codegen' && \
   uv_run 'poe format'  && \
-  uv_run 'ruff check --fix --unsafe-fixes .' 'ruff' || exit 0
+  uv_run 'poe lint' || exit 0
 }
 
 generate_json_schema_local () {

--- a/typespec/chat/endpoints.tsp
+++ b/typespec/chat/endpoints.tsp
@@ -38,3 +38,23 @@ interface Endpoints {
         body: ChatResponse;
     };
 }
+
+interface RenderEndpoints {
+    @post
+    @doc("Render system prompt for the session")
+    render(
+        @path
+        @doc("The session ID")
+        id: uuid;
+
+        @bodyRoot
+        @doc("Request to generate a response from the model")
+        body: ChatInput;
+    ): {
+        @statusCode _: "200";
+
+        @bodyRoot
+        @doc("Response from the model")
+        body: RenderResponse;
+    };
+}

--- a/typespec/chat/endpoints.tsp
+++ b/typespec/chat/endpoints.tsp
@@ -48,7 +48,7 @@ interface RenderEndpoints {
         id: uuid;
 
         @bodyRoot
-        @doc("Request to generate a response from the model")
+        @doc("Request to render the system prompt for the session")
         body: ChatInput;
     ): {
         @statusCode _: "200";

--- a/typespec/chat/models.tsp
+++ b/typespec/chat/models.tsp
@@ -162,7 +162,7 @@ model ChatInputData {
     messages: InputChatMLMessage[];
 
     /** (Advanced) List of tools that are provided in addition to agent's default set of tools. */
-    tools: CreateToolRequest[] = #[];
+    tools: CreateToolRequest[] | null = null;
 
     /** Can be one of existing tools given to the agent earlier or the ones provided in this request. */
     tool_choice?: ToolChoiceOption;
@@ -259,3 +259,9 @@ model MessageChatResponse extends BaseChatResponse {
 }
 
 alias ChatResponse = ChunkChatResponse | MessageChatResponse;
+
+model RenderResponse extends ChatInputData {
+    /** Documents referenced for this request (for citation purposes). */
+    @visibility("read")
+    docs: DocReference[] = #[];
+}

--- a/typespec/main.tsp
+++ b/typespec/main.tsp
@@ -89,6 +89,9 @@ namespace Api {
     @route("/sessions/{id}/chat")
     interface ChatRoute extends Chat.Endpoints {}
 
+    @route("/sessions/{id}/render")
+    interface RenderRoute extends Chat.RenderEndpoints {}
+
     @route("/embed")
     interface EmbedRoute extends Docs.EmbedEndpoints {}
 

--- a/typespec/sessions/models.tsp
+++ b/typespec/sessions/models.tsp
@@ -144,7 +144,7 @@ model Session {
     forward_tool_calls: boolean = false;
 
     /** Recall options for the session */
-    recall_options?: DocSearch | null = null;
+    recall_options?: HybridDocSearch | null = null;
 
     ...HasId;
     ...HasMetadata;

--- a/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
+++ b/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
@@ -1022,6 +1022,31 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Entries.History'
+  /sessions/{id}/render:
+    post:
+      operationId: RenderRoute_render
+      description: Render system prompt for the session
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The session ID
+          schema:
+            $ref: '#/components/schemas/Common.uuid'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Chat.RenderResponse'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Chat.ChatInput'
+        description: Request to generate a response from the model
   /tasks/{id}:
     get:
       operationId: TasksGetRoute_get
@@ -2245,8 +2270,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Tools.CreateToolRequest'
+          nullable: true
           description: (Advanced) List of tools that are provided in addition to agent's default set of tools.
-          default: []
+          default: null
         tool_choice:
           anyOf:
             - type: string
@@ -2627,6 +2653,20 @@ components:
       allOf:
         - $ref: '#/components/schemas/Chat.BaseChatOutput'
       description: The output returned by the model. Note that, depending on the model provider, they might return more than one message.
+    Chat.RenderResponse:
+      type: object
+      required:
+        - docs
+      properties:
+        docs:
+          type: array
+          items:
+            $ref: '#/components/schemas/Docs.DocReference'
+          description: Documents referenced for this request (for citation purposes).
+          default: []
+          readOnly: true
+      allOf:
+        - $ref: '#/components/schemas/Chat.ChatInputData'
     Chat.SchemaCompletionResponseFormat:
       type: object
       required:
@@ -4063,9 +4103,8 @@ components:
           description: Whether to forward tool calls to the model
           default: false
         recall_options:
-          anyOf:
-            - $ref: '#/components/schemas/Sessions.VectorDocSearch'
-            - $ref: '#/components/schemas/Sessions.TextOnlyDocSearch'
+          type: object
+          allOf:
             - $ref: '#/components/schemas/Sessions.HybridDocSearch'
           nullable: true
           description: Recall options for the session
@@ -4139,9 +4178,8 @@ components:
           description: Whether to forward tool calls to the model
           default: false
         recall_options:
-          anyOf:
-            - $ref: '#/components/schemas/Sessions.VectorDocSearch'
-            - $ref: '#/components/schemas/Sessions.TextOnlyDocSearch'
+          type: object
+          allOf:
             - $ref: '#/components/schemas/Sessions.HybridDocSearch'
           nullable: true
           description: Recall options for the session
@@ -4296,9 +4334,8 @@ components:
           description: Whether to forward tool calls to the model
           default: false
         recall_options:
-          anyOf:
-            - $ref: '#/components/schemas/Sessions.VectorDocSearchUpdate'
-            - $ref: '#/components/schemas/Sessions.TextOnlyDocSearchUpdate'
+          type: object
+          allOf:
             - $ref: '#/components/schemas/Sessions.HybridDocSearchUpdate'
           nullable: true
           description: Recall options for the session
@@ -4365,9 +4402,8 @@ components:
           description: Whether to forward tool calls to the model
           default: false
         recall_options:
-          anyOf:
-            - $ref: '#/components/schemas/Sessions.VectorDocSearch'
-            - $ref: '#/components/schemas/Sessions.TextOnlyDocSearch'
+          type: object
+          allOf:
             - $ref: '#/components/schemas/Sessions.HybridDocSearch'
           nullable: true
           description: Recall options for the session
@@ -4505,9 +4541,8 @@ components:
           description: Whether to forward tool calls to the model
           default: false
         recall_options:
-          anyOf:
-            - $ref: '#/components/schemas/Sessions.VectorDocSearch'
-            - $ref: '#/components/schemas/Sessions.TextOnlyDocSearch'
+          type: object
+          allOf:
             - $ref: '#/components/schemas/Sessions.HybridDocSearch'
           nullable: true
           description: Recall options for the session
@@ -5054,7 +5089,6 @@ components:
             - $ref: '#/components/schemas/Tasks.ReturnStep'
             - $ref: '#/components/schemas/Tasks.SleepStep'
             - $ref: '#/components/schemas/Tasks.ErrorWorkflowStep'
-            - $ref: '#/components/schemas/Tasks.WaitForInputStep'
             - $ref: '#/components/schemas/Tasks.IfElseWorkflowStep'
             - $ref: '#/components/schemas/Tasks.SwitchStep'
             - $ref: '#/components/schemas/Tasks.ForeachStep'
@@ -5132,7 +5166,6 @@ components:
             - $ref: '#/components/schemas/Tasks.ReturnStep'
             - $ref: '#/components/schemas/Tasks.SleepStep'
             - $ref: '#/components/schemas/Tasks.ErrorWorkflowStep'
-            - $ref: '#/components/schemas/Tasks.WaitForInputStep'
             - $ref: '#/components/schemas/Tasks.IfElseWorkflowStep'
             - $ref: '#/components/schemas/Tasks.SwitchStep'
             - $ref: '#/components/schemas/Tasks.ForeachStep'
@@ -5241,7 +5274,6 @@ components:
             - $ref: '#/components/schemas/Tasks.ReturnStep'
             - $ref: '#/components/schemas/Tasks.SleepStep'
             - $ref: '#/components/schemas/Tasks.ErrorWorkflowStep'
-            - $ref: '#/components/schemas/Tasks.WaitForInputStep'
             - $ref: '#/components/schemas/Tasks.IfElseWorkflowStepUpdateItem'
             - $ref: '#/components/schemas/Tasks.SwitchStepUpdateItem'
             - $ref: '#/components/schemas/Tasks.ForeachStepUpdateItem'
@@ -5307,7 +5339,6 @@ components:
             - $ref: '#/components/schemas/Tasks.ReturnStep'
             - $ref: '#/components/schemas/Tasks.SleepStep'
             - $ref: '#/components/schemas/Tasks.ErrorWorkflowStep'
-            - $ref: '#/components/schemas/Tasks.WaitForInputStep'
             - $ref: '#/components/schemas/Tasks.IfElseWorkflowStepUpdateItem'
             - $ref: '#/components/schemas/Tasks.SwitchStepUpdateItem'
             - $ref: '#/components/schemas/Tasks.ForeachStepUpdateItem'

--- a/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
+++ b/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
@@ -1046,7 +1046,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Chat.ChatInput'
-        description: Request to generate a response from the model
+        description: Request to render the system prompt for the session
   /tasks/{id}:
     get:
       operationId: TasksGetRoute_get


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation, Tests


___

### **Description**
- Introduced a new `render` endpoint for debugging chat inputs.

- Refactored and modularized chat input rendering logic.

- Updated schemas to support `HybridDocSearch` exclusively for recall options.

- Added comprehensive documentation for the `render` endpoint.

- Enhanced test coverage for the `render` endpoint and related functionality.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td><strong>chat.py</strong><dd><code>Refactored chat route to use modular rendering logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1201/files#diff-37385dc5ce1960a145f02585085ed045b6e53758271e5107a16a09b6e2653b7c">+15/-143</a></td>

</tr>

<tr>
  <td><strong>render.py</strong><dd><code>Added new `render` endpoint for chat input debugging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1201/files#diff-4172deb9528561fe2b68e2974b9f3abdfa1bdafc7802c607b64e5305b6377399">+199/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Sessions.py</strong><dd><code>Updated schemas to use `HybridDocSearch` exclusively</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1201/files#diff-f291b9370866972bda1967cbb40936e1b5f9d050ea676704ed562f508296c8d3">+5/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Sessions.py</strong><dd><code>Updated schemas to use `HybridDocSearch` exclusively</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1201/files#diff-4eda72ea5108b028e5127d401c3732c016e2f308eaddc6e8e16065be69941211">+5/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Chat.py</strong><dd><code>Added `RenderResponse` schema for `render` endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1201/files#diff-16c26ae8be6a865aa9578ea7a042fedb911f545bcd444c71951683f88a84d557">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Chat.py</strong><dd><code>Added `RenderResponse` schema for `render` endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1201/files#diff-dfec4dddf1793d44e620395aafe41a1c43aa3d1b04cbd366c1c07dfdc8a39c86">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>template.py</strong><dd><code>Updated `render_template` to support generic type inference</code></dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1201/files#diff-e81ee1470535f8482d878a8523401dc115e14734172b582777188f788c35040f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong><dd><code>Registered `render` endpoint in session routes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1201/files#diff-1c77304a552ccd6eb2b7e2fe85e9898788a2059fa666e7e46f290505375be0df">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>create_agent_request.json</strong><dd><code>Updated JSON schema to reflect `HybridDocSearch` changes</code>&nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1201/files#diff-86039a5a019746105dee3ad84a06f87ce9ec899d7bd10e4b8259a7059f6e6936">+803/-170</a></td>

</tr>

<tr>
  <td><strong>openapi-1.0.0.yaml</strong><dd><code>Updated OpenAPI spec to include `render` endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1201/files#diff-cc33ca315e1bd4501d3b3bcf1ca4af5628c16524390d8a8031b09a17f065d285">+51/-20</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>models.tsp</strong><dd><code>Added `RenderResponse` model for `render` endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1201/files#diff-6c988aef4dc3bb8c8043eed3364c8e73da06341b051385301f00217304cbf272">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>endpoints.tsp</strong><dd><code>Defined `render` endpoint in TypeSpec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1201/files#diff-abb7d342c816562e0192d564e9950013fc7c2979acc0cd643c311a0fa9e8411d">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.tsp</strong><dd><code>Registered `render` endpoint in API routes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1201/files#diff-8b3f1637736ef0f6e288646b45395cd7821e8cecb41648be667519b0a927704e">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>models.tsp</strong><dd><code>Updated session model to use `HybridDocSearch` exclusively</code></dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1201/files#diff-d85f1e28cfbe7eb036f34240a688aa6217c0e21705e76a651ac148ba1281fe0d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>test_chat_routes.py</strong><dd><code>Added tests for `render` endpoint and updated mocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1201/files#diff-25451f47641b57f6d97aa8002424d9e954c728375f90f2771bf0475a5eaaedbb">+57/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>render.mdx</strong><dd><code>Added documentation for the `render` endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1201/files#diff-c79f45f3b178b30573295d9cfa29d41aacb47e57f9fe021904cbe40f588a802f">+204/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mint.json</strong><dd><code>Added `render` endpoint documentation to navigation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1201/files#diff-8a8fc0c19a54c14b4725c7f6d23f3fb36b11d83ff48b61a58b196935a310148f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>create_task_request.json</strong></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1201/files#diff-c26f37355270b2dbc8ae81c953bbdb8396817c4c5792efa5428de07aa72758d1">+803/-170</a></td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

---
# EntelligenceAI PR Summary 
 **Purpose**:
- Enhance chat input rendering, simplify document search, and improve user experience.

**Changes**:
- **New Feature**: Added `RenderResponse` class and `render` endpoint for chat input preview.
- **Enhancement**: Unified document search with `HybridDocSearch` in `recall_options`.
- **Test**: Updated tests for the new `render` endpoint.
- **Documentation**: Included documentation for the `render` endpoint.

**Impact**:
- Improved chat visualization, streamlined document retrieval, and enhanced system performance. 


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces a `render` endpoint for debugging chat inputs, refactors rendering logic, updates schemas for `HybridDocSearch`, and adds documentation and tests.
> 
>   - **New Feature**:
>     - Added `render` endpoint in `render.py` for debugging chat inputs.
>     - Introduced `RenderResponse` class in `Chat.py` for the `render` endpoint.
>   - **Refactoring**:
>     - Modularized chat input rendering logic in `chat.py`.
>   - **Schema Updates**:
>     - Updated schemas in `Sessions.py` to use `HybridDocSearch` exclusively.
>   - **Documentation**:
>     - Added `render` endpoint documentation in `render.mdx`.
>   - **Tests**:
>     - Added tests for `render` endpoint in `test_chat_routes.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 0c283867297e6240b93a21c3070fbb5f301de274. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->