### PR TITLE
fix: remove idx_docs_search_covering index from search_by_text

### DIFF
--- a/memory-store/migrations/000032_enhance_trigram_search.down.sql
+++ b/memory-store/migrations/000032_enhance_trigram_search.down.sql
@@ -9,7 +9,6 @@ DROP FUNCTION IF EXISTS enhanced_similarity;
 
 -- Drop the additional indexes we created
 DROP INDEX IF EXISTS idx_docs_lookup;
-DROP INDEX IF EXISTS idx_docs_search_covering;
 DROP INDEX IF EXISTS idx_doc_owners_search;
 
 -- Restore the original search_by_text function from 000031

--- a/memory-store/migrations/000032_enhance_trigram_search.up.sql
+++ b/memory-store/migrations/000032_enhance_trigram_search.up.sql
@@ -105,10 +105,6 @@ $$ LANGUAGE plpgsql;
 -- Create additional indexes for improved search performance
 CREATE INDEX IF NOT EXISTS idx_docs_lookup ON docs (developer_id, doc_id, index);
 
-CREATE INDEX IF NOT EXISTS idx_docs_search_covering ON docs (developer_id)
-INCLUDE (doc_id, index, title, content)
-WHERE search_tsv IS NOT NULL;
-
 CREATE INDEX IF NOT EXISTS idx_doc_owners_search ON doc_owners (doc_id, developer_id, owner_type, owner_id);
 
 -- Update search_by_text function to use comprehensive similarity


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed the `idx_docs_search_covering` index from the database migration scripts.

- Updated the `up.sql` and `down.sql` scripts to reflect the removal.

- Ensured consistency in database schema and search functionality.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>000032_enhance_trigram_search.down.sql</strong><dd><code>Remove `idx_docs_search_covering` from down migration script</code></dd></summary>
<hr>

memory-store/migrations/000032_enhance_trigram_search.down.sql

<li>Removed the <code>DROP INDEX IF EXISTS idx_docs_search_covering</code> statement.<br> <li> Adjusted the down migration script to align with the updated schema.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1237/files#diff-aa6c6f35af85c24d8bf22c687ed42d6d027c59005f26500bb264e8cddf9a57d8">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>000032_enhance_trigram_search.up.sql</strong><dd><code>Remove `idx_docs_search_covering` from up migration script</code></dd></summary>
<hr>

memory-store/migrations/000032_enhance_trigram_search.up.sql

<li>Removed the creation of <code>idx_docs_search_covering</code> index.<br> <li> Adjusted the up migration script to align with the updated schema.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1237/files#diff-2f1637feee8f0ce962a3ce36d55431f546ca22ff321a3b41b7b14c4128e27004">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>