### PR TITLE
fix: repair latest_transitions continuous aggregate view

### DIFF
--- a/agents-api/agents_api/autogen/Executions.py
+++ b/agents-api/agents_api/autogen/Executions.py
@@ -29,6 +29,10 @@ class CreateExecutionRequest(BaseModel):
     """
     The error of the execution if it failed
     """
+    transition_count: int | None = None
+    """
+    The number of transitions in this execution
+    """
     metadata: dict[str, Any] | None = None
 
 
@@ -66,6 +70,10 @@ class Execution(BaseModel):
     error: str | None = None
     """
     The error of the execution if it failed
+    """
+    transition_count: int | None = None
+    """
+    The number of transitions in this execution
     """
     created_at: Annotated[AwareDatetime, Field(json_schema_extra={"readOnly": True})]
     """

--- a/agents-api/agents_api/queries/executions/get_execution.py
+++ b/agents-api/agents_api/queries/executions/get_execution.py
@@ -8,46 +8,30 @@ from ...common.utils.db_exceptions import common_db_exceptions
 from ..utils import pg_query, rewrap_exceptions, wrap_in_class
 from .constants import OUTPUT_UNNEST_KEY
 
-# Query to get an execution
+# Query to get an execution using the latest_executions view
 get_execution_query = """
 SELECT
-    e.developer_id,
-    e.task_id,
-    e.task_version,
-    e.execution_id,
-    e.input,
-    e.metadata,
-    e.created_at,
-    coalesce(lt.created_at, e.created_at) AS updated_at,
-    CASE
-        WHEN lt.type::text IS NULL THEN 'queued'
-        WHEN lt.type::text = 'init' THEN 'starting'
-        WHEN lt.type::text = 'init_branch' THEN 'running'
-        WHEN lt.type::text = 'wait' THEN 'awaiting_input'
-        WHEN lt.type::text = 'resume' THEN 'running'
-        WHEN lt.type::text = 'step' THEN 'running'
-        WHEN lt.type::text = 'finish' THEN 'succeeded'
-        WHEN lt.type::text = 'finish_branch' THEN 'running'
-        WHEN lt.type::text = 'error' THEN 'failed'
-        WHEN lt.type::text = 'cancelled' THEN 'cancelled'
-        ELSE 'queued'
-    END AS status,
-    CASE
-        WHEN lt.type::text = 'error' THEN lt.output ->> 'error'
-        ELSE NULL
-    END AS error,
-    coalesce(lt.output, '{}'::jsonb) AS output,
-    lt.current_step,
-    lt.next_step,
-    lt.step_label,
-    lt.task_token,
-    lt.metadata AS transition_metadata
+    developer_id,
+    task_id,
+    task_version,
+    execution_id,
+    input,
+    metadata,
+    created_at,
+    updated_at,
+    status,
+    error,
+    transition_count,
+    output,
+    current_step,
+    next_step,
+    step_label,
+    task_token,
+    transition_metadata
 FROM
-    executions e
-    LEFT JOIN transitions lt ON e.execution_id = lt.execution_id
-    WHERE e.execution_id = $1
-ORDER BY lt.created_at DESC
-LIMIT 1;
+    latest_executions
+WHERE
+    execution_id = $1;
 """
 
 

--- a/agents-api/agents_api/queries/executions/get_paused_execution_token.py
+++ b/agents-api/agents_api/queries/executions/get_paused_execution_token.py
@@ -6,15 +6,23 @@ from beartype import beartype
 from ...common.utils.db_exceptions import common_db_exceptions
 from ..utils import pg_query, rewrap_exceptions, wrap_in_class
 
-# FIXME: We should use latest_transitions instead of transitions
-# Query to get a paused execution token
+# Query to get a paused execution token using latest_transitions
 get_paused_execution_token_query = """
-SELECT * FROM transitions
+SELECT
+    execution_id,
+    transition_id,
+    type,
+    created_at,
+    step_label,
+    current_step,
+    next_step,
+    output,
+    task_token,
+    metadata
+FROM latest_transitions
 WHERE
     execution_id = $1
-        AND type = 'wait'
-    ORDER BY created_at DESC
-    LIMIT 1;
+    AND type = 'wait';
 """
 
 

--- a/agents-api/agents_api/queries/executions/list_executions.py
+++ b/agents-api/agents_api/queries/executions/list_executions.py
@@ -10,59 +10,36 @@ from ...common.utils.db_exceptions import common_db_exceptions, partialclass
 from ..utils import pg_query, rewrap_exceptions, wrap_in_class
 from .constants import OUTPUT_UNNEST_KEY
 
-# Query to list executions
-# FIXME: order by updated_at as well
-# FIXME: return to latest_executions view once latest_transitions is fixed
+# Query to list executions using the latest_executions view
 list_executions_query = """
 SELECT
-    e.developer_id,
-    e.task_id,
-    e.task_version,
-    e.execution_id,
-    e.input,
-    e.metadata,
-    e.created_at,
-    coalesce(lt.created_at, e.created_at) AS updated_at,
-    CASE
-        WHEN lt.type::text IS NULL THEN 'queued'
-        WHEN lt.type::text = 'init' THEN 'starting'
-        WHEN lt.type::text = 'init_branch' THEN 'running'
-        WHEN lt.type::text = 'wait' THEN 'awaiting_input'
-        WHEN lt.type::text = 'resume' THEN 'running'
-        WHEN lt.type::text = 'step' THEN 'running'
-        WHEN lt.type::text = 'finish' THEN 'succeeded'
-        WHEN lt.type::text = 'finish_branch' THEN 'running'
-        WHEN lt.type::text = 'error' THEN 'failed'
-        WHEN lt.type::text = 'cancelled' THEN 'cancelled'
-        ELSE 'queued'
-    END AS status,
-    CASE
-        WHEN lt.type::text = 'error' THEN lt.output ->> 'error'
-        ELSE NULL
-    END AS error,
-    coalesce(lt.output, '{}'::jsonb) AS output,
-    lt.current_step,
-    lt.next_step,
-    lt.step_label,
-    lt.task_token,
-    lt.metadata AS transition_metadata
+    developer_id,
+    task_id,
+    task_version,
+    execution_id,
+    input,
+    metadata,
+    created_at,
+    updated_at,
+    status,
+    error,
+    output,
+    current_step,
+    next_step,
+    step_label,
+    task_token,
+    transition_metadata
 FROM
-    executions e
-    LEFT JOIN LATERAL (
-        SELECT *
-        FROM transitions t
-        WHERE t.execution_id = e.execution_id
-        ORDER BY t.created_at DESC
-        LIMIT 1
-    ) lt ON true
+    latest_executions
 WHERE
-    e.developer_id = $1 AND
-    e.task_id = $2
+    developer_id = $1 AND
+    task_id = $2
 ORDER BY
-    CASE WHEN $3 = 'asc' THEN e.created_at END ASC NULLS LAST,
-    CASE WHEN $3 = 'desc' THEN e.created_at END DESC NULLS LAST
-    -- CASE WHEN $3 = 'updated_at' AND $4 = 'asc' THEN e.updated_at END ASC NULLS LAST,
-    -- CASE WHEN $3 = 'updated_at' AND $4 = 'desc' THEN e.updated_at END DESC NULLS LAST
+    CASE WHEN $3 = 'asc' THEN created_at END ASC NULLS LAST,
+    CASE WHEN $3 = 'desc' THEN created_at END DESC NULLS LAST
+    -- Add this back once we update the view to support sorting by updated_at
+    -- CASE WHEN $3 = 'updated_at' AND $4 = 'asc' THEN updated_at END ASC NULLS LAST,
+    -- CASE WHEN $3 = 'updated_at' AND $4 = 'desc' THEN updated_at END DESC NULLS LAST
 LIMIT $4 OFFSET $5;
 """
 

--- a/integrations-service/integrations/autogen/Executions.py
+++ b/integrations-service/integrations/autogen/Executions.py
@@ -29,6 +29,10 @@ class CreateExecutionRequest(BaseModel):
     """
     The error of the execution if it failed
     """
+    transition_count: int | None = None
+    """
+    The number of transitions in this execution
+    """
     metadata: dict[str, Any] | None = None
 
 
@@ -66,6 +70,10 @@ class Execution(BaseModel):
     error: str | None = None
     """
     The error of the execution if it failed
+    """
+    transition_count: int | None = None
+    """
+    The number of transitions in this execution
     """
     created_at: Annotated[AwareDatetime, Field(json_schema_extra={"readOnly": True})]
     """

--- a/memory-store/migrations/000033_fix_latest_transitions.down.sql
+++ b/memory-store/migrations/000033_fix_latest_transitions.down.sql
@@ -1,0 +1,110 @@
+BEGIN;
+
+/*
+ * REVERT FIX FOR LATEST_TRANSITIONS CONTINUOUS AGGREGATE
+ * 
+ * This migration reverts the fix for the latest_transitions continuous aggregate view.
+ * We restore the original view definition from migration 000013.
+ */
+
+-- Drop existing continuous aggregate policy
+DO $$
+BEGIN
+    BEGIN
+        SELECT remove_continuous_aggregate_policy('latest_transitions');
+    EXCEPTION
+        WHEN others THEN
+            RAISE NOTICE 'An error occurred during remove_continuous_aggregate_policy(latest_transitions): %, %', SQLSTATE, SQLERRM;
+    END;
+END $$;
+
+-- Drop the existing views
+DROP VIEW IF EXISTS latest_executions;
+DROP MATERIALIZED VIEW IF EXISTS latest_transitions;
+
+-- Create a continuous view that aggregates the transitions table with the original workflows join
+CREATE MATERIALIZED VIEW IF NOT EXISTS latest_transitions
+WITH
+    (
+        timescaledb.continuous,
+        timescaledb.materialized_only = FALSE
+    ) AS
+SELECT
+    time_bucket ('1 day', t.created_at) AS bucket,
+    t.execution_id,
+    last (t.transition_id, t.created_at) AS transition_id,
+    count(*) AS transition_count,
+    max(t.created_at) AS created_at,
+    last (t.type, t.created_at) AS type,
+    last (t.step_label, t.created_at) AS step_label,
+    last (t.current_step, t.created_at) AS current_step,
+    last (t.next_step, t.created_at) AS next_step,
+    last (t.output, t.created_at) AS output,
+    last (t.task_token, t.created_at) AS task_token,
+    last (t.metadata, t.created_at) AS metadata,
+    last (e.task_id, e.created_at) AS task_id,
+    last (e.task_version, e.created_at) AS task_version,
+    last (w.step_definition, e.created_at) AS step_definition
+FROM
+    transitions t
+    JOIN executions e ON t.execution_id = e.execution_id
+    JOIN workflows w ON e.task_id = w.task_id
+    AND e.task_version = w.version
+    AND w.step_idx = (t.current_step).step_index
+    AND w.name = (t.current_step).workflow_name
+GROUP BY
+    bucket,
+    t.execution_id
+WITH
+    no data;
+
+-- Add the continuous aggregate policy
+SELECT
+    add_continuous_aggregate_policy (
+        'latest_transitions',
+        start_offset => NULL,
+        end_offset => INTERVAL '10 minutes',
+        schedule_interval => INTERVAL '10 minutes'
+    );
+
+-- Recreate the latest_executions view with step_definition
+CREATE OR REPLACE VIEW latest_executions AS
+SELECT
+    e.developer_id,
+    e.task_id,
+    e.task_version,
+    e.execution_id,
+    e.input,
+    e.metadata,
+    e.created_at,
+    coalesce(lt.created_at, e.created_at) AS updated_at,
+    CASE
+        WHEN lt.type::text IS NULL THEN 'queued'
+        WHEN lt.type::text = 'init' THEN 'starting'
+        WHEN lt.type::text = 'init_branch' THEN 'running'
+        WHEN lt.type::text = 'wait' THEN 'awaiting_input'
+        WHEN lt.type::text = 'resume' THEN 'running'
+        WHEN lt.type::text = 'step' THEN 'running'
+        WHEN lt.type::text = 'finish' THEN 'succeeded'
+        WHEN lt.type::text = 'finish_branch' THEN 'running'
+        WHEN lt.type::text = 'error' THEN 'failed'
+        WHEN lt.type::text = 'cancelled' THEN 'cancelled'
+        ELSE 'queued'
+    END AS status,
+    CASE
+        WHEN lt.type::text = 'error' THEN lt.output ->> 'error'
+        ELSE NULL
+    END AS error,
+    coalesce(lt.transition_count, 0) AS transition_count,
+    coalesce(lt.output, '{}'::jsonb) AS output,
+    lt.current_step,
+    lt.next_step,
+    lt.step_definition,
+    lt.step_label,
+    lt.task_token,
+    lt.metadata AS transition_metadata
+FROM
+    executions e
+    LEFT JOIN latest_transitions lt ON e.execution_id = lt.execution_id;
+
+COMMIT;

--- a/memory-store/migrations/000033_fix_latest_transitions.up.sql
+++ b/memory-store/migrations/000033_fix_latest_transitions.up.sql
@@ -1,0 +1,107 @@
+BEGIN;
+
+/*
+ * FIX FOR LATEST_TRANSITIONS CONTINUOUS AGGREGATE
+ * 
+ * This migration fixes an issue with the latest_transitions continuous aggregate view
+ * where the join on the workflows table was causing empty rows when transitions were of
+ * type 'finish' or 'error' since there's no step definition available for these states.
+ * 
+ * We remove the join on the workflows table and the step_definition column from the view.
+ */
+
+-- Drop existing continuous aggregate policy
+DO $$
+BEGIN
+    BEGIN
+        SELECT remove_continuous_aggregate_policy('latest_transitions');
+    EXCEPTION
+        WHEN others THEN
+            RAISE NOTICE 'An error occurred during remove_continuous_aggregate_policy(latest_transitions): %, %', SQLSTATE, SQLERRM;
+    END;
+END $$;
+
+-- Drop the existing views
+DROP VIEW IF EXISTS latest_executions;
+DROP MATERIALIZED VIEW IF EXISTS latest_transitions;
+
+-- Create a continuous view that aggregates the transitions table without the workflows join
+CREATE MATERIALIZED VIEW IF NOT EXISTS latest_transitions
+WITH
+    (
+        timescaledb.continuous,
+        timescaledb.materialized_only = FALSE
+    ) AS
+SELECT
+    time_bucket ('1 day', t.created_at) AS bucket,
+    t.execution_id,
+    last (t.transition_id, t.created_at) AS transition_id,
+    count(*) AS transition_count,
+    max(t.created_at) AS created_at,
+    last (t.type, t.created_at) AS type,
+    last (t.step_label, t.created_at) AS step_label,
+    last (t.current_step, t.created_at) AS current_step,
+    last (t.next_step, t.created_at) AS next_step,
+    last (t.output, t.created_at) AS output,
+    last (t.task_token, t.created_at) AS task_token,
+    last (t.metadata, t.created_at) AS metadata,
+    last (e.task_id, e.created_at) AS task_id,
+    last (e.task_version, e.created_at) AS task_version
+FROM
+    transitions t
+    JOIN executions e ON t.execution_id = e.execution_id
+GROUP BY
+    bucket,
+    t.execution_id
+WITH
+    no data;
+
+-- Add the continuous aggregate policy
+SELECT
+    add_continuous_aggregate_policy (
+        'latest_transitions',
+        start_offset => NULL,
+        end_offset => INTERVAL '10 minutes',
+        schedule_interval => INTERVAL '10 minutes'
+    );
+
+-- Recreate the latest_executions view without step_definition
+CREATE OR REPLACE VIEW latest_executions AS
+SELECT
+    e.developer_id,
+    e.task_id,
+    e.task_version,
+    e.execution_id,
+    e.input,
+    e.metadata,
+    e.created_at,
+    coalesce(lt.created_at, e.created_at) AS updated_at,
+    CASE
+        WHEN lt.type::text IS NULL THEN 'queued'
+        WHEN lt.type::text = 'init' THEN 'starting'
+        WHEN lt.type::text = 'init_branch' THEN 'running'
+        WHEN lt.type::text = 'wait' THEN 'awaiting_input'
+        WHEN lt.type::text = 'resume' THEN 'running'
+        WHEN lt.type::text = 'step' THEN 'running'
+        WHEN lt.type::text = 'finish' THEN 'succeeded'
+        WHEN lt.type::text = 'finish_branch' THEN 'running'
+        WHEN lt.type::text = 'error' THEN 'failed'
+        WHEN lt.type::text = 'cancelled' THEN 'cancelled'
+        ELSE 'queued'
+    END AS status,
+    CASE
+        WHEN lt.type::text = 'error' THEN lt.output ->> 'error'
+        ELSE NULL
+    END AS error,
+    coalesce(lt.transition_count, 0) AS transition_count,
+    coalesce(lt.output, '{}'::jsonb) AS output,
+    lt.current_step,
+    lt.next_step,
+    lt.step_label,
+    lt.task_token,
+    lt.metadata AS transition_metadata
+FROM
+    executions e
+    LEFT JOIN latest_transitions lt ON e.execution_id = lt.execution_id;
+
+COMMIT;

--- a/schemas/create_agent_request.json
+++ b/schemas/create_agent_request.json
@@ -102,6 +102,226 @@
       "title": "Agent",
       "type": "object"
     },
+    "AlgoliaIntegrationDef": {
+      "description": "Algolia integration definition",
+      "properties": {
+        "arguments": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AlgoliaSearchArguments"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "method": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Method"
+        },
+        "provider": {
+          "const": "algolia",
+          "default": "algolia",
+          "title": "Provider",
+          "type": "string"
+        },
+        "setup": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AlgoliaSetup"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "title": "AlgoliaIntegrationDef",
+      "type": "object"
+    },
+    "AlgoliaIntegrationDefUpdate": {
+      "description": "Algolia integration definition",
+      "properties": {
+        "arguments": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AlgoliaSearchArgumentsUpdate"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "method": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Method"
+        },
+        "provider": {
+          "const": "algolia",
+          "default": "algolia",
+          "title": "Provider",
+          "type": "string"
+        },
+        "setup": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AlgoliaSetupUpdate"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "title": "AlgoliaIntegrationDefUpdate",
+      "type": "object"
+    },
+    "AlgoliaSearchArguments": {
+      "description": "Arguments for Algolia Search",
+      "properties": {
+        "attributes_to_retrieve": {
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Attributes To Retrieve"
+        },
+        "hits_per_page": {
+          "default": 10,
+          "maximum": 1000.0,
+          "minimum": 1.0,
+          "title": "Hits Per Page",
+          "type": "integer"
+        },
+        "index_name": {
+          "title": "Index Name",
+          "type": "string"
+        },
+        "query": {
+          "title": "Query",
+          "type": "string"
+        }
+      },
+      "required": [
+        "index_name",
+        "query"
+      ],
+      "title": "AlgoliaSearchArguments",
+      "type": "object"
+    },
+    "AlgoliaSearchArgumentsUpdate": {
+      "description": "Arguments for Algolia Search",
+      "properties": {
+        "attributes_to_retrieve": {
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Attributes To Retrieve"
+        },
+        "hits_per_page": {
+          "default": 10,
+          "maximum": 1000.0,
+          "minimum": 1.0,
+          "title": "Hits Per Page",
+          "type": "integer"
+        },
+        "index_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Index Name"
+        },
+        "query": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Query"
+        }
+      },
+      "title": "AlgoliaSearchArgumentsUpdate",
+      "type": "object"
+    },
+    "AlgoliaSetup": {
+      "description": "Integration definition for Algolia",
+      "properties": {
+        "algolia_api_key": {
+          "title": "Algolia Api Key",
+          "type": "string"
+        },
+        "algolia_application_id": {
+          "title": "Algolia Application Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "algolia_application_id",
+        "algolia_api_key"
+      ],
+      "title": "AlgoliaSetup",
+      "type": "object"
+    },
+    "AlgoliaSetupUpdate": {
+      "description": "Integration definition for Algolia",
+      "properties": {
+        "algolia_api_key": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Algolia Api Key"
+        },
+        "algolia_application_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Algolia Application Id"
+        }
+      },
+      "title": "AlgoliaSetupUpdate",
+      "type": "object"
+    },
     "ApiCallDef": {
       "description": "API call definition",
       "properties": {
@@ -4096,6 +4316,9 @@
               "$ref": "#/$defs/UnstructuredIntegrationDef"
             },
             {
+              "$ref": "#/$defs/AlgoliaIntegrationDef"
+            },
+            {
               "type": "null"
             }
           ],
@@ -8051,6 +8274,9 @@
               "$ref": "#/$defs/UnstructuredIntegrationDefUpdate"
             },
             {
+              "$ref": "#/$defs/AlgoliaIntegrationDefUpdate"
+            },
+            {
               "type": "null"
             }
           ],
@@ -10211,6 +10437,9 @@
               "$ref": "#/$defs/UnstructuredIntegrationDef"
             },
             {
+              "$ref": "#/$defs/AlgoliaIntegrationDef"
+            },
+            {
               "type": "null"
             }
           ],
@@ -10383,6 +10612,9 @@
             },
             {
               "$ref": "#/$defs/UnstructuredIntegrationDef"
+            },
+            {
+              "$ref": "#/$defs/AlgoliaIntegrationDef"
             },
             {
               "type": "null"
@@ -10933,6 +11165,9 @@
             },
             {
               "$ref": "#/$defs/UnstructuredIntegrationDef"
+            },
+            {
+              "$ref": "#/$defs/AlgoliaIntegrationDef"
             },
             {
               "type": "null"
@@ -11848,6 +12083,9 @@
             },
             {
               "$ref": "#/$defs/UnstructuredIntegrationDef"
+            },
+            {
+              "$ref": "#/$defs/AlgoliaIntegrationDef"
             },
             {
               "type": "null"
@@ -13047,6 +13285,9 @@
               "$ref": "#/$defs/UnstructuredIntegrationDef"
             },
             {
+              "$ref": "#/$defs/AlgoliaIntegrationDef"
+            },
+            {
               "type": "null"
             }
           ],
@@ -13213,6 +13454,9 @@
             },
             {
               "$ref": "#/$defs/UnstructuredIntegrationDef"
+            },
+            {
+              "$ref": "#/$defs/AlgoliaIntegrationDef"
             },
             {
               "type": "null"

--- a/schemas/create_task_request.json
+++ b/schemas/create_task_request.json
@@ -102,6 +102,226 @@
       "title": "Agent",
       "type": "object"
     },
+    "AlgoliaIntegrationDef": {
+      "description": "Algolia integration definition",
+      "properties": {
+        "arguments": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AlgoliaSearchArguments"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "method": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Method"
+        },
+        "provider": {
+          "const": "algolia",
+          "default": "algolia",
+          "title": "Provider",
+          "type": "string"
+        },
+        "setup": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AlgoliaSetup"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "title": "AlgoliaIntegrationDef",
+      "type": "object"
+    },
+    "AlgoliaIntegrationDefUpdate": {
+      "description": "Algolia integration definition",
+      "properties": {
+        "arguments": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AlgoliaSearchArgumentsUpdate"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "method": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Method"
+        },
+        "provider": {
+          "const": "algolia",
+          "default": "algolia",
+          "title": "Provider",
+          "type": "string"
+        },
+        "setup": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AlgoliaSetupUpdate"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "title": "AlgoliaIntegrationDefUpdate",
+      "type": "object"
+    },
+    "AlgoliaSearchArguments": {
+      "description": "Arguments for Algolia Search",
+      "properties": {
+        "attributes_to_retrieve": {
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Attributes To Retrieve"
+        },
+        "hits_per_page": {
+          "default": 10,
+          "maximum": 1000.0,
+          "minimum": 1.0,
+          "title": "Hits Per Page",
+          "type": "integer"
+        },
+        "index_name": {
+          "title": "Index Name",
+          "type": "string"
+        },
+        "query": {
+          "title": "Query",
+          "type": "string"
+        }
+      },
+      "required": [
+        "index_name",
+        "query"
+      ],
+      "title": "AlgoliaSearchArguments",
+      "type": "object"
+    },
+    "AlgoliaSearchArgumentsUpdate": {
+      "description": "Arguments for Algolia Search",
+      "properties": {
+        "attributes_to_retrieve": {
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Attributes To Retrieve"
+        },
+        "hits_per_page": {
+          "default": 10,
+          "maximum": 1000.0,
+          "minimum": 1.0,
+          "title": "Hits Per Page",
+          "type": "integer"
+        },
+        "index_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Index Name"
+        },
+        "query": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Query"
+        }
+      },
+      "title": "AlgoliaSearchArgumentsUpdate",
+      "type": "object"
+    },
+    "AlgoliaSetup": {
+      "description": "Integration definition for Algolia",
+      "properties": {
+        "algolia_api_key": {
+          "title": "Algolia Api Key",
+          "type": "string"
+        },
+        "algolia_application_id": {
+          "title": "Algolia Application Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "algolia_application_id",
+        "algolia_api_key"
+      ],
+      "title": "AlgoliaSetup",
+      "type": "object"
+    },
+    "AlgoliaSetupUpdate": {
+      "description": "Integration definition for Algolia",
+      "properties": {
+        "algolia_api_key": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Algolia Api Key"
+        },
+        "algolia_application_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Algolia Application Id"
+        }
+      },
+      "title": "AlgoliaSetupUpdate",
+      "type": "object"
+    },
     "ApiCallDef": {
       "description": "API call definition",
       "properties": {
@@ -4096,6 +4316,9 @@
               "$ref": "#/$defs/UnstructuredIntegrationDef"
             },
             {
+              "$ref": "#/$defs/AlgoliaIntegrationDef"
+            },
+            {
               "type": "null"
             }
           ],
@@ -8051,6 +8274,9 @@
               "$ref": "#/$defs/UnstructuredIntegrationDefUpdate"
             },
             {
+              "$ref": "#/$defs/AlgoliaIntegrationDefUpdate"
+            },
+            {
               "type": "null"
             }
           ],
@@ -10211,6 +10437,9 @@
               "$ref": "#/$defs/UnstructuredIntegrationDef"
             },
             {
+              "$ref": "#/$defs/AlgoliaIntegrationDef"
+            },
+            {
               "type": "null"
             }
           ],
@@ -10383,6 +10612,9 @@
             },
             {
               "$ref": "#/$defs/UnstructuredIntegrationDef"
+            },
+            {
+              "$ref": "#/$defs/AlgoliaIntegrationDef"
             },
             {
               "type": "null"
@@ -10933,6 +11165,9 @@
             },
             {
               "$ref": "#/$defs/UnstructuredIntegrationDef"
+            },
+            {
+              "$ref": "#/$defs/AlgoliaIntegrationDef"
             },
             {
               "type": "null"
@@ -11848,6 +12083,9 @@
             },
             {
               "$ref": "#/$defs/UnstructuredIntegrationDef"
+            },
+            {
+              "$ref": "#/$defs/AlgoliaIntegrationDef"
             },
             {
               "type": "null"
@@ -13047,6 +13285,9 @@
               "$ref": "#/$defs/UnstructuredIntegrationDef"
             },
             {
+              "$ref": "#/$defs/AlgoliaIntegrationDef"
+            },
+            {
               "type": "null"
             }
           ],
@@ -13213,6 +13454,9 @@
             },
             {
               "$ref": "#/$defs/UnstructuredIntegrationDef"
+            },
+            {
+              "$ref": "#/$defs/AlgoliaIntegrationDef"
             },
             {
               "type": "null"

--- a/typespec/executions/models.tsp
+++ b/typespec/executions/models.tsp
@@ -56,6 +56,9 @@ model Execution {
     /** The error of the execution if it failed */
     error?: string;
 
+    /** The number of transitions in this execution */
+    transition_count?: uint8;
+
     ...HasTimestamps;
     ...HasMetadata;
     ...HasId;

--- a/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
+++ b/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
@@ -3616,6 +3616,10 @@ components:
         error:
           type: string
           description: The error of the execution if it failed
+        transition_count:
+          type: integer
+          format: uint8
+          description: The number of transitions in this execution
         metadata:
           type: object
           additionalProperties: {}
@@ -3656,6 +3660,10 @@ components:
         error:
           type: string
           description: The error of the execution if it failed
+        transition_count:
+          type: integer
+          format: uint8
+          description: The number of transitions in this execution
         created_at:
           type: string
           format: date-time


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Fixed the `latest_transitions` continuous aggregate view to handle `finish` and `error` transitions.
  - Removed the join on the workflows table and step definitions.
  - Updated the `latest_executions` view to reflect these changes.

- Added a `transition_count` field to execution models and queries.
  - Updated schemas, models, and queries to include `transition_count`.

- Enhanced test coverage for execution queries.
  - Added tests for `finish` and `error` transitions.
  - Verified the correctness of `transition_count` in various scenarios.

- Introduced Algolia integration definitions in schemas.
  - Added support for Algolia setup, arguments, and updates.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>Executions.py</strong><dd><code>Added `transition_count` field to execution models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1258/files#diff-2724b6372f2f5d65274d7d01fe5f0405e99f651f7353152b3f854ee17ba352c6">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>get_execution.py</strong><dd><code>Updated query to use `latest_executions` view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1258/files#diff-31a860df28c986bb4c57529e0f979ec4317502988a9da224c723b65f633e93cd">+21/-37</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>get_paused_execution_token.py</strong><dd><code>Updated query to use `latest_transitions` view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1258/files#diff-4eea35b55589364151f8e94587ed07ab70493127fb6c5690d46a6fdddd46030a">+14/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>list_executions.py</strong><dd><code>Updated query to use `latest_executions` view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1258/files#diff-7ea19dff595b2ae1dfccc45c298ed94e18841bd79ecd56bbb820d0651f99a07a">+25/-48</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Executions.py</strong><dd><code>Added `transition_count` field to execution models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1258/files#diff-f708b7f25a2c54a68758cd1e67ad33fbbcaa0565282ddc49fa8c50c057cef836">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>create_agent_request.json</strong><dd><code>Added Algolia integration definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1258/files#diff-86039a5a019746105dee3ad84a06f87ce9ec899d7bd10e4b8259a7059f6e6936">+244/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>create_task_request.json</strong><dd><code>Added Algolia integration definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1258/files#diff-c26f37355270b2dbc8ae81c953bbdb8396817c4c5792efa5428de07aa72758d1">+244/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>models.tsp</strong><dd><code>Added `transition_count` to execution model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1258/files#diff-f6a9eb49d6c2cd31674bdfbc5810462de1920d8a4cf8e4f5d0f4081e0f7f8698">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>openapi-1.0.0.yaml</strong><dd><code>Updated OpenAPI spec with `transition_count`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1258/files#diff-cc33ca315e1bd4501d3b3bcf1ca4af5628c16524390d8a8031b09a17f065d285">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>test_execution_queries.py</strong><dd><code>Added tests for execution queries and transitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1258/files#diff-51519c833a02178e0e9fb808b57af5c0607450bb228800f9be7d8d984c33af83">+136/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>000033_fix_latest_transitions.down.sql</strong><dd><code>Reverted changes to `latest_transitions` view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1258/files#diff-c066e72b38703857b35249c5affff6e37df71ed87f07859298722061c0024cff">+111/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>000033_fix_latest_transitions.up.sql</strong><dd><code>Fixed `latest_transitions` view to handle all transitions</code></dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1258/files#diff-ecba23cdc31e0d8260cfcfd220098cc8365682304422cf9636c017f88bcdabd0">+108/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `latest_transitions` view, adds `transition_count`, enhances tests, and introduces Algolia integration.
> 
>   - **Bug Fix**:
>     - Fixed `latest_transitions` view in `000033_fix_latest_transitions.up.sql` to handle `finish` and `error` transitions by removing the join on workflows.
>     - Reverted changes in `000033_fix_latest_transitions.down.sql`.
>   - **Enhancements**:
>     - Added `transition_count` field to execution models in `Executions.py` and `models.tsp`.
>     - Updated queries in `get_execution.py`, `get_paused_execution_token.py`, and `list_executions.py` to use `latest_executions` view.
>     - Introduced Algolia integration definitions in `create_agent_request.json` and `create_task_request.json`.
>   - **Tests**:
>     - Added tests in `test_execution_queries.py` for `finish` and `error` transitions and `transition_count`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for b5d35ba31948f67a1c96adb6995b66513c2ad003. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->