### PR TITLE
feat(memory-store): Switch cont agg/hypertables to hypercore

### DIFF
--- a/agents-api/tests/utils.py
+++ b/agents-api/tests/utils.py
@@ -196,7 +196,7 @@ def patch_integration_service(output: dict = {"result": "ok"}):
 
 @contextmanager
 def get_pg_dsn(start_vectorizer: bool = False):
-    with PostgresContainer("timescale/timescaledb-ha:pg17") as postgres:
+    with PostgresContainer("timescale/timescaledb-ha:pg17-ts2.18-all") as postgres:
         test_psql_url = postgres.get_connection_url()
         pg_dsn = f"postgres://{test_psql_url[22:]}?sslmode=disable"
         command = f"migrate -database '{pg_dsn}' -path ../memory-store/migrations/ up"

--- a/memory-store/migrations/000034_switch_to_hypercore.down.sql
+++ b/memory-store/migrations/000034_switch_to_hypercore.down.sql
@@ -1,0 +1,85 @@
+BEGIN;
+
+ALTER MATERIALIZED VIEW latest_transitions
+    SET (
+        timescaledb.enable_columnstore = false
+    );
+
+-- Drop the index on execution_id
+DROP INDEX IF EXISTS idx_transitions_execution_id_hash;
+
+-- Entries: Revert hypercore changes
+CALL remove_columnstore_policy('entries', if_exists => true);
+
+ALTER TABLE
+    entries
+SET ACCESS METHOD heap;
+DO $$
+BEGIN
+    BEGIN
+        ALTER TABLE
+            entries
+        SET
+            (
+                timescaledb.enable_columnstore = false
+            );
+    EXCEPTION
+        WHEN others THEN
+            RAISE NOTICE 'An error occurred disabling columnstore for entries: %, %', SQLSTATE, SQLERRM;
+    END;
+END $$;
+
+DO $$
+BEGIN
+    BEGIN
+        ALTER TABLE
+            entries 
+        SET
+            (
+                timescaledb.compress
+            );
+    EXCEPTION
+        WHEN others THEN
+            RAISE NOTICE 'An error occurred setting compression for entries: %, %', SQLSTATE, SQLERRM;
+    END;
+END $$;
+
+-- Transitions: Revert hypercore changes
+CALL remove_columnstore_policy('transitions', if_exists => true);
+
+ALTER TABLE
+    transitions
+SET
+    ACCESS METHOD heap;
+
+DO $$
+BEGIN
+    BEGIN
+        ALTER TABLE
+            transitions
+        SET
+            (
+                timescaledb.enable_columnstore = false
+            );
+    EXCEPTION
+        WHEN others THEN
+            RAISE NOTICE 'An error occurred disabling columnstore for transitions: %, %', SQLSTATE, SQLERRM;
+    END;
+END $$;
+
+DO $$
+BEGIN
+    BEGIN
+        ALTER TABLE
+            transitions 
+        SET
+            (
+                timescaledb.compress
+            );
+    EXCEPTION
+        WHEN others THEN
+            RAISE NOTICE 'An error occurred setting compression for transitions: %, %', SQLSTATE, SQLERRM;
+    END;
+END $$;
+
+COMMIT;

--- a/memory-store/migrations/000034_switch_to_hypercore.up.sql
+++ b/memory-store/migrations/000034_switch_to_hypercore.up.sql
@@ -1,0 +1,62 @@
+BEGIN;
+
+-- -- Make sure all extensions are up to date
+-- ALTER EXTENSION timescaledb UPDATE;
+-- ALTER EXTENSION vectorscale UPDATE;
+-- ALTER EXTENSION ai UPDATE;
+
+-- Entries: Switch to hypercore
+SELECT remove_compression_policy ('entries', if_exists => true);
+
+ALTER TABLE
+    entries
+SET
+    (
+        timescaledb.enable_columnstore,
+        timescaledb.segmentby = 'session_id',
+        timescaledb.compress_chunk_time_interval = '14 days'
+    ),
+SET
+    ACCESS METHOD hypercore;
+
+CALL add_columnstore_policy(
+    'entries',
+    after => interval '7 days',
+    if_not_exists => true,
+    hypercore_use_access_method => true
+);
+
+
+-- Transitions: Switch to hypercore
+SELECT remove_compression_policy ('transitions', if_exists => true);
+
+ALTER TABLE
+    transitions
+SET
+    (
+        timescaledb.enable_columnstore = true,
+        timescaledb.segmentby = 'execution_id',
+        timescaledb.orderby = 'created_at DESC',
+        timescaledb.compress_chunk_time_interval = '14 days'
+    ),
+SET
+    ACCESS METHOD hypercore;
+
+CALL add_columnstore_policy(
+    'transitions',
+    after => interval '7 days',
+    if_not_exists => true,
+    hypercore_use_access_method => true
+);
+
+CREATE INDEX IF NOT EXISTS idx_transitions_execution_id_hash ON transitions USING hash (execution_id);
+
+ALTER MATERIALIZED VIEW latest_transitions
+    SET (
+        timescaledb.enable_columnstore = true,
+        timescaledb.orderby = 'bucket DESC',
+        timescaledb.segmentby = 'execution_id',
+        timescaledb.compress_chunk_time_interval = '14 days'
+    );
+
+COMMIT;

--- a/memory-store/migrations/000034_switch_to_hypercore.up.sql
+++ b/memory-store/migrations/000034_switch_to_hypercore.up.sql
@@ -12,7 +12,7 @@ ALTER TABLE
     entries
 SET
     (
-        timescaledb.enable_columnstore,
+        timescaledb.enable_columnstore = true,
         timescaledb.segmentby = 'session_id',
         timescaledb.compress_chunk_time_interval = '14 days'
     ),


### PR DESCRIPTION
### **User description**
Signed-off-by: Diwank Singh Tomer <diwank.singh@gmail.com>


___

### **PR Type**
Enhancement


___

### **Description**
- Migrated `entries` and `transitions` tables to use the `hypercore` access method.

- Added and removed columnstore and compression policies for `entries` and `transitions`.

- Updated test utility to use a specific TimescaleDB image version.

- Created SQL migration scripts for switching to and reverting from `hypercore`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Update TimescaleDB image version in test utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/tests/utils.py

<li>Updated the TimescaleDB Docker image version in test utilities.<br> <li> Ensured compatibility with the new database schema changes.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1271/files#diff-f57e08363e297b9a26b89a750f00ff1dbcbfdba9189591c528f35691d58a7432">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>000034_switch_to_hypercore.down.sql</strong><dd><code>Add migration script to revert from `hypercore`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

memory-store/migrations/000034_switch_to_hypercore.down.sql

<li>Added SQL script to revert <code>entries</code> and <code>transitions</code> from <code>hypercore</code>.<br> <li> Removed columnstore and compression policies.<br> <li> Handled errors during table alterations with exception handling.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1271/files#diff-cb13261a8f96a779626f4b8ee47cbd49656e05f18d8994b3d541804377be8864">+85/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>000034_switch_to_hypercore.up.sql</strong><dd><code>Add migration script to switch to `hypercore`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

memory-store/migrations/000034_switch_to_hypercore.up.sql

<li>Added SQL script to migrate <code>entries</code> and <code>transitions</code> to <code>hypercore</code>.<br> <li> Set columnstore, segmentby, and compression policies.<br> <li> Created index for <code>transitions</code> table and updated materialized view.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1271/files#diff-a1848a00c83e27afde0003015ba4c26429a1a360bfaf0d8f3bbbcba87448893e">+62/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>