### PR TITLE
fix: Properly handle Jinja2 template errors

### DIFF
--- a/agents-api/agents_api/common/utils/template.py
+++ b/agents-api/agents_api/common/utils/template.py
@@ -59,7 +59,7 @@ async def render_template_string(
         )
     except Exception as e:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Template rendering error: {e!s}",
         )
 


### PR DESCRIPTION
### **User description**
## Summary
- Catch TemplateSyntaxError and UndefinedError from Jinja2 and convert them to user-friendly HTTP 400 errors
- Changes 500 Internal Server Errors to 400 Bad Request when users have syntax errors in their templates
- Provides specific error messages for different types of template errors
## Test plan
- Verify that template syntax errors in Jinja2 templates now return a 400 error instead of 500
- Test with a template containing undefined variables (e.g., try to use `now()` function which was the original issue)
- Test with a template containing a syntax error (e.g., missing closing brace)
Fixes #1216
🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added error handling for Jinja2 template rendering.

- Catch `TemplateSyntaxError` and `UndefinedError` and return HTTP 400 errors.

- Converted generic template errors to user-friendly messages.

- Prevented 500 Internal Server Errors caused by template issues.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>template.py</strong><dd><code>Add error handling for Jinja2 template rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/common/utils/template.py

<li>Added error handling for Jinja2 template rendering.<br> <li> Catch <code>TemplateSyntaxError</code> and <code>UndefinedError</code> and raise HTTP 400 <br>errors.<br> <li> Introduced a generic exception handler for template rendering errors.<br> <li> Updated the <code>render_template_string</code> function to include error handling.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1275/files#diff-e81ee1470535f8482d878a8523401dc115e14734172b582777188f788c35040f">+28/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>