### PR TITLE
Fix: Enable compression for transitions and entries tables

### DIFF
--- a/memory-store/migrations/000034_switch_to_hypercore.down.sql
+++ b/memory-store/migrations/000034_switch_to_hypercore.down.sql
@@ -1,84 +1,48 @@
 BEGIN;
 
-ALTER MATERIALIZED VIEW latest_transitions
-    SET (
-        timescaledb.enable_columnstore = false
-    );
-
--- Drop the index on execution_id
-DROP INDEX IF EXISTS idx_transitions_execution_id_hash;
-
--- Entries: Revert hypercore changes
-CALL remove_columnstore_policy('entries', if_exists => true);
-
-ALTER TABLE
-    entries
-SET ACCESS METHOD heap;
 DO $$
 BEGIN
     BEGIN
-        ALTER TABLE
-            entries
-        SET
-            (
-                timescaledb.enable_columnstore = false
-            );
+        SELECT
+            remove_compression_policy ('entries');
     EXCEPTION
         WHEN others THEN
-            RAISE NOTICE 'An error occurred disabling columnstore for entries: %, %', SQLSTATE, SQLERRM;
+            RAISE NOTICE 'An error occurred during remove_compression_policy(entries): %, %', SQLSTATE, SQLERRM;
     END;
 END $$;
 
 DO $$
 BEGIN
     BEGIN
-        ALTER TABLE
-            entries 
-        SET
-            (
-                timescaledb.compress
-            );
+        SELECT
+            remove_compression_policy ('transitions');
     EXCEPTION
         WHEN others THEN
-            RAISE NOTICE 'An error occurred setting compression for entries: %, %', SQLSTATE, SQLERRM;
-    END;
-END $$;
-
--- Transitions: Revert hypercore changes
-CALL remove_columnstore_policy('transitions', if_exists => true);
-
-ALTER TABLE
-    transitions
-SET
-    ACCESS METHOD heap;
-
-DO $$
-BEGIN
-    BEGIN
-        ALTER TABLE
-            transitions
-        SET
-            (
-                timescaledb.enable_columnstore = false
-            );
-    EXCEPTION
-        WHEN others THEN
-            RAISE NOTICE 'An error occurred disabling columnstore for transitions: %, %', SQLSTATE, SQLERRM;
+            RAISE NOTICE 'An error occurred during remove_compression_policy(transitions): %, %', SQLSTATE, SQLERRM;
     END;
 END $$;
 
 DO $$
 BEGIN
     BEGIN
-        ALTER TABLE
-            transitions 
+        ALTER TABLE entries
         SET
-            (
-                timescaledb.compress
-            );
+            (timescaledb.compress = FALSE);
     EXCEPTION
         WHEN others THEN
-            RAISE NOTICE 'An error occurred setting compression for transitions: %, %', SQLSTATE, SQLERRM;
+            RAISE NOTICE 'An error occurred during unsetting entries.compress: %, %', SQLSTATE, SQLERRM;
+    END;
+END $$;
+
+DO $$
+BEGIN
+    BEGIN
+        ALTER TABLE transitions
+        SET
+            (timescaledb.compress = FALSE);
+    EXCEPTION
+        WHEN others THEN
+            RAISE NOTICE 'An error occurred during unsetting transitions.compress: %, %', SQLSTATE, SQLERRM;
     END;
 END $$;
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactored SQL migrations to enable compression for `entries` and `transitions` tables.

- Removed deprecated hypercore-specific configurations and policies.

- Added error handling for compression-related operations.

- Updated compression settings to improve data management and performance.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>000034_switch_to_hypercore.down.sql</strong><dd><code>Refactor to remove hypercore configurations and disable compression</code></dd></summary>
<hr>

memory-store/migrations/000034_switch_to_hypercore.down.sql

<li>Removed hypercore-specific configurations and policies.<br> <li> Added error handling for removing compression policies.<br> <li> Updated table settings to disable compression.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1282/files#diff-cb13261a8f96a779626f4b8ee47cbd49656e05f18d8994b3d541804377be8864">+12/-48</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>000034_switch_to_hypercore.up.sql</strong><dd><code>Enable compression and remove hypercore configurations</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

memory-store/migrations/000034_switch_to_hypercore.up.sql

<li>Added compression settings for <code>entries</code> and <code>transitions</code> tables.<br> <li> Introduced error handling for adding compression policies.<br> <li> Removed hypercore-specific configurations and policies.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1282/files#diff-a1848a00c83e27afde0003015ba4c26429a1a360bfaf0d8f3bbbcba87448893e">+54/-58</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable compression for `entries` and `transitions` tables in TimescaleDB, adding compression policies and error handling in migration scripts.
> 
>   - **Compression Enablement**:
>     - In `000034_switch_to_hypercore.up.sql`, enable compression for `entries` and `transitions` tables with `timescaledb.compress = TRUE`.
>     - Set `compress_segmentby` and `compress_orderby` for both tables.
>     - Add compression policies with a 7-day interval.
>   - **Compression Disablement**:
>     - In `000034_switch_to_hypercore.down.sql`, disable compression for `entries` and `transitions` tables with `timescaledb.compress = FALSE`.
>     - Remove compression policies for both tables.
>   - **Error Handling**:
>     - Add exception handling in both up and down migrations to log errors during compression policy changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 8dafedb39a66e405233005a096e93cd074c7dfe8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->