### PR TITLE
fix(agents-api): add developer id to litellm requests

### DIFF
--- a/agents-api/agents_api/activities/task_steps/prompt_step.py
+++ b/agents-api/agents_api/activities/task_steps/prompt_step.py
@@ -97,6 +97,7 @@ async def prompt_step(context: StepContext) -> StepOutcome:
         exclude_unset=True,
     )
     passed_settings.update(passed_settings.pop("settings", {}) or {})
+    passed_settings["user"] = str(context.execution_input.developer_id)
 
     if not passed_settings.get("tools"):
         passed_settings.pop("tool_choice", None)

--- a/agents-api/agents_api/clients/litellm.py
+++ b/agents-api/agents_api/clients/litellm.py
@@ -53,7 +53,7 @@ async def acompletion(
         model = f"openai/{model}"  # This is needed for litellm
 
     supported_params = get_supported_openai_params(model)
-    settings = {k: v for k, v in kwargs.items() if k in supported_params}
+    settings = {k: v for k, v in kwargs.items() if k in supported_params or k == "user"}
 
     # NOTE: This is a fix for Mistral API, which expects a different message format
     if model[7:].startswith("mistral"):

--- a/agents-api/agents_api/queries/chat/gather_messages.py
+++ b/agents-api/agents_api/queries/chat/gather_messages.py
@@ -101,6 +101,7 @@ async def gather_messages(
         [query_embedding, *_] = await litellm.aembedding(
             inputs=embed_text[-(recall_options.max_query_length) :],
             embed_instruction="Represent the query for retrieving supporting documents: ",
+            user=str(developer.id),
         )
 
     # Get query text from last message

--- a/agents-api/agents_api/routers/docs/embed.py
+++ b/agents-api/agents_api/routers/docs/embed.py
@@ -22,6 +22,7 @@ async def embed(
     vectors = await litellm.aembedding(
         inputs=text_to_embed,
         embed_instruction=data.embed_instruction,
+        user=str(x_developer_id),
     )
 
     return EmbedQueryResponse(vectors=vectors)


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added `developer_id` as `user` in multiple API calls.

- Updated `prompt_step` to include `user` in passed settings.

- Enhanced `acompletion` to support `user` parameter in settings.

- Improved embedding-related functions to include `user` for tracking.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prompt_step.py</strong><dd><code>Include developer ID in prompt step settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/activities/task_steps/prompt_step.py

<li>Added <code>user</code> key with <code>developer_id</code> to <code>passed_settings</code>.<br> <li> Ensures <code>developer_id</code> is passed during prompt step execution.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1292/files#diff-568607bf9eff0a7b0bac363c2f9c64de9aec36b6e67497724377962151efb6f1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>litellm.py</strong><dd><code>Add `user` parameter support in LiteLLM settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/clients/litellm.py

<li>Modified <code>settings</code> to include <code>user</code> parameter.<br> <li> Ensures <code>user</code> is passed for LiteLLM API compatibility.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1292/files#diff-09573e4e5766575081152c80e3a78b28ca3a0cee3f07a448abcb4db7566edaab">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gather_messages.py</strong><dd><code>Pass developer ID to embedding in message gathering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/queries/chat/gather_messages.py

<li>Added <code>user</code> parameter with <code>developer_id</code> to embedding function.<br> <li> Ensures <code>developer_id</code> is passed during message gathering.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1292/files#diff-1b7f13a02e66bbfa4c5963a5d6339d096f0cfcf5cdaeb414fac26c1e6189f4a0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>embed.py</strong><dd><code>Include developer ID in embedding API requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/routers/docs/embed.py

<li>Added <code>user</code> parameter with <code>developer_id</code> to embedding API.<br> <li> Ensures <code>developer_id</code> is included in embedding requests.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1292/files#diff-c530cd75f1e52a72083c32a175783a4bc0a167c38e7a0b685bed953b6a923f62">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add developer ID to LiteLLM requests in `prompt_step.py`, `gather_messages.py`, and `embed.py` for tracking or authorization.
> 
>   - **Behavior**:
>     - Add `developer_id` to `passed_settings` in `prompt_step()` in `prompt_step.py`.
>     - Include `user` parameter with `developer.id` in `aembedding()` call in `gather_messages()` in `gather_messages.py`.
>     - Add `user` parameter with `x_developer_id` in `aembedding()` call in `embed()` in `embed.py`.
>   - **Clients**:
>     - Update `acompletion()` in `litellm.py` to include `user` in `settings` if present in `kwargs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for fbe4da3dc8922a960da33779965f2b9fcaa8a561. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->