### PR TITLE
hotfix(agents-api): Fix subquery cardinality issue

### DIFF
--- a/agents-api/agents_api/queries/entries/get_history.py
+++ b/agents-api/agents_api/queries/entries/get_history.py
@@ -42,7 +42,7 @@ collected_relations AS (
 SELECT
     (SELECT json_agg(e) FROM collected_entries e) AS entries,
     (SELECT json_agg(r) FROM collected_relations r) AS relations,
-    (SELECT session_created_at FROM collected_entries) AS created_at,
+    (SELECT session_created_at FROM collected_entries LIMIT 1) AS created_at,
     $1::uuid AS session_id
 """
 

--- a/agents-api/agents_api/queries/entries/list_entries.py
+++ b/agents-api/agents_api/queries/entries/list_entries.py
@@ -42,7 +42,7 @@ WHERE e.session_id = $1
     AND e.source = ANY($2)
     AND (er.relation IS NULL OR er.relation != ALL($6))
     AND e.created_at >= $7
-    AND e.created_at >= (select created_at from sessions where session_id = $1)
+    AND e.created_at >= (select created_at from sessions where session_id = $1 LIMIT 1)
 ORDER BY e.{sort_by} {direction} -- safe to interpolate
 LIMIT $3
 OFFSET $4;

--- a/agents-api/agents_api/queries/executions/count_executions.py
+++ b/agents-api/agents_api/queries/executions/count_executions.py
@@ -11,7 +11,7 @@ execution_count_query = """
 SELECT COUNT(*) FROM latest_executions
 WHERE
     developer_id = $1
-    AND created_at >= (select created_at from developers where developer_id = $1)
+    AND created_at >= (select created_at from developers where developer_id = $1 LIMIT 1)
     AND task_id = $2;
 """
 

--- a/agents-api/agents_api/queries/executions/get_paused_execution_token.py
+++ b/agents-api/agents_api/queries/executions/get_paused_execution_token.py
@@ -25,7 +25,7 @@ FROM latest_transitions
 WHERE
     execution_id = $1
     AND created_at >= $2
-    AND created_at >= (select created_at from executions where execution_id = $1)
+    AND created_at >= (select created_at from executions where execution_id = $1 LIMIT 1)
     AND type = 'wait';
 """
 

--- a/agents-api/agents_api/queries/executions/list_execution_transitions.py
+++ b/agents-api/agents_api/queries/executions/list_execution_transitions.py
@@ -18,7 +18,7 @@ WHERE
     execution_id = $1
     AND (current_step).scope_id = $7
     AND created_at >= $6
-    AND created_at >= (select created_at from executions where execution_id = $1)
+    AND created_at >= (select created_at from executions where execution_id = $1 LIMIT 1)
 ORDER BY
     CASE WHEN $4 = 'created_at' AND $5 = 'asc' THEN created_at END ASC NULLS LAST,
     CASE WHEN $4 = 'created_at' AND $5 = 'desc' THEN created_at END DESC NULLS LAST

--- a/agents-api/agents_api/queries/executions/prepare_execution_input.py
+++ b/agents-api/agents_api/queries/executions/prepare_execution_input.py
@@ -17,6 +17,7 @@ SELECT * FROM
             AND agent_id = (
                 SELECT agent_id FROM tasks
                 WHERE developer_id = $1 AND task_id = $2
+                ORDER BY created_at DESC
                 LIMIT 1
             )
         LIMIT 1


### PR DESCRIPTION
### **User description**

Fix for this error on get_history when trying to talk to tira bot:

```
agents-api-multi-tenant-1  | asyncpg.exceptions.CardinalityViolationError: more than one row returned by a subquery used as an expression
```

Signed-off-by: Diwank Singh Tomer <diwank.singh@gmail.com>


___

### **PR Type**
Bug fix


___

### **Description**
- Added `LIMIT 1` to subqueries to ensure single-row results.

- Fixed potential cardinality issues in multiple SQL queries.

- Improved query reliability and consistency across the API.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>get_history.py</strong><dd><code>Fix cardinality issue in `get_history` query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/queries/entries/get_history.py

<li>Added <code>LIMIT 1</code> to subquery for <code>session_created_at</code>.<br> <li> Ensured single-row result for <code>created_at</code> field.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1298/files#diff-d02b03b5ed3d24a267020baefdcdd44b65eedcaeb31f598445c653ae0e29fe2c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>list_entries.py</strong><dd><code>Fix cardinality issue in `list_entries` query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/queries/entries/list_entries.py

<li>Added <code>LIMIT 1</code> to subquery for session <code>created_at</code>.<br> <li> Ensured single-row result for session creation time.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1298/files#diff-9df391cfc2fe63c71db76d8aa66b98622beec4ef31984f42d12062a7131e90bf">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>count_executions.py</strong><dd><code>Fix cardinality issue in `count_executions` query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/queries/executions/count_executions.py

<li>Added <code>LIMIT 1</code> to subquery for developer <code>created_at</code>.<br> <li> Ensured single-row result for developer creation time.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1298/files#diff-ea0d2ed5f91d90d7b7bfddac58cd1e62ce3e1805d41e65a063d94a78450d6c63">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>get_paused_execution_token.py</strong><dd><code>Fix cardinality issue in `get_paused_execution_token` query</code></dd></summary>
<hr>

agents-api/agents_api/queries/executions/get_paused_execution_token.py

<li>Added <code>LIMIT 1</code> to subquery for execution <code>created_at</code>.<br> <li> Ensured single-row result for paused execution token query.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1298/files#diff-4eea35b55589364151f8e94587ed07ab70493127fb6c5690d46a6fdddd46030a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>list_execution_transitions.py</strong><dd><code>Fix cardinality issue in `list_execution_transitions` query</code></dd></summary>
<hr>

agents-api/agents_api/queries/executions/list_execution_transitions.py

<li>Added <code>LIMIT 1</code> to subquery for execution <code>created_at</code>.<br> <li> Ensured single-row result for execution transitions query.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1298/files#diff-6826ed6d78428fbc5979f602cd07c92a42e0397cac86e6b5948eabe8be6fe9c9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>prepare_execution_input.py</strong><dd><code>Fix cardinality issue in `prepare_execution_input` query</code>&nbsp; </dd></summary>
<hr>

agents-api/agents_api/queries/executions/prepare_execution_input.py

<li>Added <code>ORDER BY created_at DESC</code> and <code>LIMIT 1</code> to subquery for agent <br>selection.<br> <li> Ensured latest agent is selected for execution input.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1298/files#diff-68fde313e0100e3c50d3e026a331797470704844117b6f24b3ef95fc5ec10753">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix subquery cardinality issues by adding `LIMIT 1` to ensure single-row results in various SQL queries.
> 
>   - **SQL Query Fixes**:
>     - Add `LIMIT 1` to subqueries in `get_history.py`, `list_entries.py`, `count_executions.py`, `get_paused_execution_token.py`, and `list_execution_transitions.py` to ensure single-row results.
>     - In `prepare_execution_input.py`, add `ORDER BY created_at DESC` and `LIMIT 1` to subquery for selecting `agent_id` to ensure the most recent agent is selected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for af0a8603aaf17b87bfdf0beb792f3b65def4f28d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->