### PR TITLE
refactor: Move query parameters validation to beartype

### DIFF
--- a/agents-api/agents_api/common/exceptions/validation.py
+++ b/agents-api/agents_api/common/exceptions/validation.py
@@ -1,0 +1,8 @@
+from . import BaseCommonException
+
+
+class QueryParamsValidationError(BaseCommonException):
+    """Exception raised for validation errors in query parameters."""
+
+    def __init__(self, message: str):
+        super().__init__(message, http_code=400)

--- a/agents-api/agents_api/common/utils/db_exceptions.py
+++ b/agents-api/agents_api/common/utils/db_exceptions.py
@@ -12,8 +12,8 @@ import asyncpg
 import pydantic
 from beartype.roar import BeartypeCallHintParamViolation
 from fastapi import HTTPException
-from agents_api.common.exceptions.validation import QueryParamsValidationError
 
+from agents_api.common.exceptions.validation import QueryParamsValidationError
 
 invalid_ref_re = re.compile(r"invalid (\w+) reference", re.IGNORECASE)
 

--- a/agents-api/agents_api/common/utils/db_exceptions.py
+++ b/agents-api/agents_api/common/utils/db_exceptions.py
@@ -10,7 +10,10 @@ from functools import partialmethod, wraps
 
 import asyncpg
 import pydantic
+from beartype.roar import BeartypeCallHintParamViolation
 from fastapi import HTTPException
+from agents_api.common.exceptions.validation import QueryParamsValidationError
+
 
 invalid_ref_re = re.compile(r"invalid (\w+) reference", re.IGNORECASE)
 
@@ -180,6 +183,26 @@ def common_db_exceptions(
                 "details": e.errors(),
             },
         )(e),
+        QueryParamsValidationError: lambda e: partialclass(
+            HTTPException,
+            status_code=400,
+            detail=str(e),
+        ),
+        lambda e: isinstance(e, BeartypeCallHintParamViolation)
+        and "typing.Literal['asc', 'desc']" in str(e): partialclass(
+            HTTPException,
+            status_code=400,
+            detail="Invalid sort direction",
+        ),
+        lambda e: isinstance(e, BeartypeCallHintParamViolation)
+        and (
+            "typing.Literal['created_at', 'updated_at']" in str(e)
+            or "typing.Literal['created_at', 'timestamp']" in str(e)
+        ): partialclass(
+            HTTPException,
+            status_code=400,
+            detail="Invalid sort field",
+        ),
     }
 
     # Add operation-specific exceptions

--- a/agents-api/agents_api/common/utils/task_validation.py
+++ b/agents-api/agents_api/common/utils/task_validation.py
@@ -501,7 +501,6 @@ def validate_task(
         TaskValidationResult with validation issues
     """
     validation_result = TaskValidationResult(is_valid=True)
-
     # Convert to task spec (this will exclude version, developer_id etc.)
     try:
         task_spec = task_to_spec(task)

--- a/agents-api/agents_api/queries/agents/list_agents.py
+++ b/agents-api/agents_api/queries/agents/list_agents.py
@@ -7,7 +7,6 @@ from typing import Any, Literal
 from uuid import UUID
 
 from beartype import beartype
-from fastapi import HTTPException
 
 from ...autogen.openapi_model import Agent
 from ...common.utils.db_exceptions import common_db_exceptions
@@ -73,9 +72,6 @@ async def list_agents(
     Returns:
         Tuple of (query, params)
     """
-    # Validate sort direction
-    if direction.lower() not in ["asc", "desc"]:
-        raise HTTPException(status_code=400, detail="Invalid sort direction")
 
     # Initialize parameters
     params = [

--- a/agents-api/agents_api/queries/files/list_files.py
+++ b/agents-api/agents_api/queries/files/list_files.py
@@ -3,15 +3,15 @@ This module contains the functionality for listing files from the PostgreSQL dat
 It constructs and executes SQL queries to fetch a list of files based on developer ID with pagination.
 """
 
-from typing import Literal
+from typing import Annotated, Literal
 from uuid import UUID
 
 from beartype import beartype
-from fastapi import HTTPException
+from beartype.vale import Is
 
 from ...autogen.openapi_model import File
 from ...common.utils.db_exceptions import common_db_exceptions
-from ..utils import pg_query, rewrap_exceptions, wrap_in_class
+from ..utils import make_num_validator, pg_query, rewrap_exceptions, wrap_in_class
 
 # Base query for listing files
 base_files_query = """
@@ -40,8 +40,17 @@ async def list_files(
     developer_id: UUID,
     owner_id: UUID | None = None,
     owner_type: Literal["user", "agent"] | None = None,
-    limit: int = 100,
-    offset: int = 0,
+    limit: Annotated[
+        int,
+        Is[
+            make_num_validator(
+                min_value=1, max_value=100, err_msg="Limit must be between 1 and 100"
+            )
+        ],
+    ] = 100,
+    offset: Annotated[
+        int, Is[make_num_validator(min_value=0, err_msg="Offset must be >= 0")]
+    ] = 0,
     sort_by: Literal["created_at", "updated_at"] = "created_at",
     direction: Literal["asc", "desc"] = "desc",
 ) -> tuple[str, list]:
@@ -49,17 +58,11 @@ async def list_files(
     Lists files with optional owner filtering, pagination, and sorting.
     """
     # Validate parameters
-    if direction.lower() not in ["asc", "desc"]:
-        raise HTTPException(status_code=400, detail="Invalid sort direction")
+    # if direction.lower() not in ["asc", "desc"]:
+    #     raise HTTPException(status_code=400, detail="Invalid sort direction")
 
-    if sort_by not in ["created_at", "updated_at"]:
-        raise HTTPException(status_code=400, detail="Invalid sort field")
-
-    if limit > 100 or limit < 1:
-        raise HTTPException(status_code=400, detail="Limit must be between 1 and 100")
-
-    if offset < 0:
-        raise HTTPException(status_code=400, detail="Offset must be non-negative")
+    # if sort_by not in ["created_at", "updated_at"]:
+    #     raise HTTPException(status_code=400, detail="Invalid sort field")
 
     # Start with the base query
     query = base_files_query

--- a/agents-api/agents_api/queries/tasks/list_tasks.py
+++ b/agents-api/agents_api/queries/tasks/list_tasks.py
@@ -1,12 +1,12 @@
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 from uuid import UUID
 
 from beartype import beartype
-from fastapi import HTTPException
+from beartype.vale import Is
 
 from ...common.protocol.models import spec_to_task
 from ...common.utils.db_exceptions import common_db_exceptions
-from ..utils import pg_query, rewrap_exceptions, wrap_in_class
+from ..utils import make_num_validator, pg_query, rewrap_exceptions, wrap_in_class
 
 # Define the raw SQL query for listing tasks
 list_tasks_query = """
@@ -49,8 +49,17 @@ async def list_tasks(
     *,
     developer_id: UUID,
     agent_id: UUID,
-    limit: int = 100,
-    offset: int = 0,
+    limit: Annotated[
+        int,
+        Is[
+            make_num_validator(
+                min_value=1, max_value=100, err_msg="Limit must be between 1 and 100"
+            )
+        ],
+    ] = 100,
+    offset: Annotated[
+        int, Is[make_num_validator(min_value=0, err_msg="Offset must be >= 0")]
+    ] = 0,
     sort_by: Literal["created_at", "updated_at"] = "created_at",
     direction: Literal["asc", "desc"] = "desc",
     metadata_filter: dict[str, Any] = {},
@@ -73,14 +82,8 @@ async def list_tasks(
     Raises:
         HTTPException: If parameters are invalid or developer/agent doesn't exist
     """
-    if direction.lower() not in ["asc", "desc"]:
-        raise HTTPException(status_code=400, detail="Invalid sort direction")
-
-    if limit > 100 or limit < 1:
-        raise HTTPException(status_code=400, detail="Limit must be between 1 and 100")
-
-    if offset < 0:
-        raise HTTPException(status_code=400, detail="Offset must be non-negative")
+    # if direction.lower() not in ["asc", "desc"]:
+    #     raise HTTPException(status_code=400, detail="Invalid sort direction")
 
     # Format query with metadata filter if needed
     query = list_tasks_query.format(

--- a/agents-api/agents_api/queries/utils.py
+++ b/agents-api/agents_api/queries/utils.py
@@ -21,6 +21,8 @@ from fastapi import HTTPException
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
+from agents_api.common.exceptions.validation import QueryParamsValidationError
+
 from ..app import app
 from ..env import query_timeout
 
@@ -376,3 +378,24 @@ def build_metadata_filter_conditions(
         sql_conditions = " AND " + sql_conditions
 
     return sql_conditions, params
+
+
+def make_num_validator(
+    min_value: int | float | None = None,
+    max_value: int | float | None = None,
+    err_msg: str | None = None,
+):
+    def validator(v: int | float):
+        nonlocal err_msg
+
+        if min_value is not None and v < min_value:
+            err_msg = err_msg or f"Number must be greater than or equal to {min_value}"
+            raise QueryParamsValidationError(err_msg)
+
+        if max_value is not None and v > max_value:
+            err_msg = err_msg or f"Number must be less than or equal to {max_value}"
+            raise QueryParamsValidationError(err_msg)
+
+        return True
+
+    return validator

--- a/agents-api/tests/test_agent_queries.py
+++ b/agents-api/tests/test_agent_queries.py
@@ -18,6 +18,7 @@ from agents_api.queries.agents import (
     patch_agent,
     update_agent,
 )
+from fastapi import HTTPException
 from uuid_extensions import uuid7
 from ward import raises, test
 
@@ -127,6 +128,22 @@ async def _(dsn=pg_dsn, developer_id=test_developer_id):
 
     assert isinstance(result, list)
     assert all(isinstance(agent, Agent) for agent in result)
+
+
+@test("query: list agents sql, invalid sort direction")
+async def _(dsn=pg_dsn, developer_id=test_developer_id):
+    """Test that listing agents with an invalid sort direction raises an exception."""
+
+    pool = await create_db_pool(dsn=dsn)
+    with raises(HTTPException) as exc:
+        await list_agents(
+            developer_id=developer_id,
+            connection_pool=pool,
+            direction="invalid",
+        )  # type: ignore[not-callable]
+
+    assert exc.raised.status_code == 400
+    assert exc.raised.detail == "Invalid sort direction"
 
 
 @test("query: patch agent sql")

--- a/agents-api/tests/test_docs_queries.py
+++ b/agents-api/tests/test_docs_queries.py
@@ -192,6 +192,126 @@ async def _(dsn=pg_dsn, developer=test_developer, user=test_user):
     assert any(d.metadata == {"test": "test2"} for d in docs_list_metadata)
 
 
+@test("query: list user docs, invalid limit")
+async def _(dsn=pg_dsn, developer=test_developer, user=test_user):
+    pool = await create_db_pool(dsn=dsn)
+
+    await create_doc(
+        developer_id=developer.id,
+        data=CreateDocRequest(
+            title="User List Test",
+            content="Some user doc content",
+            metadata={"test": "test"},
+            embed_instruction="Embed the document",
+        ),
+        owner_type="user",
+        owner_id=user.id,
+        connection_pool=pool,
+    )
+
+    with raises(HTTPException) as exc:
+        await list_docs(
+            developer_id=developer.id,
+            owner_type="user",
+            owner_id=user.id,
+            connection_pool=pool,
+            limit=101,
+        )
+
+    assert exc.raised.status_code == 400
+    assert exc.raised.detail == "Limit must be between 1 and 100"
+
+
+@test("query: list user docs, invalid offset")
+async def _(dsn=pg_dsn, developer=test_developer, user=test_user):
+    pool = await create_db_pool(dsn=dsn)
+
+    await create_doc(
+        developer_id=developer.id,
+        data=CreateDocRequest(
+            title="User List Test",
+            content="Some user doc content",
+            metadata={"test": "test"},
+            embed_instruction="Embed the document",
+        ),
+        owner_type="user",
+        owner_id=user.id,
+        connection_pool=pool,
+    )
+
+    with raises(HTTPException) as exc:
+        await list_docs(
+            developer_id=developer.id,
+            owner_type="user",
+            owner_id=user.id,
+            connection_pool=pool,
+            offset=-1,
+        )
+
+    assert exc.raised.status_code == 400
+    assert exc.raised.detail == "Offset must be >= 0"
+
+
+@test("query: list user docs, invalid sort by")
+async def _(dsn=pg_dsn, developer=test_developer, user=test_user):
+    pool = await create_db_pool(dsn=dsn)
+
+    await create_doc(
+        developer_id=developer.id,
+        data=CreateDocRequest(
+            title="User List Test",
+            content="Some user doc content",
+            metadata={"test": "test"},
+            embed_instruction="Embed the document",
+        ),
+        owner_type="user",
+        owner_id=user.id,
+        connection_pool=pool,
+    )
+
+    with raises(HTTPException) as exc:
+        await list_docs(
+            developer_id=developer.id,
+            owner_type="user",
+            owner_id=user.id,
+            connection_pool=pool,
+            sort_by="invalid",
+        )
+
+    assert exc.raised.status_code == 400
+    assert exc.raised.detail == "Invalid sort field"
+
+
+@test("query: list user docs, invalid sort direction")
+async def _(dsn=pg_dsn, developer=test_developer, user=test_user):
+    pool = await create_db_pool(dsn=dsn)
+
+    await create_doc(
+        developer_id=developer.id,
+        data=CreateDocRequest(
+            title="User List Test",
+            content="Some user doc content",
+            metadata={"test": "test"},
+            embed_instruction="Embed the document",
+        ),
+        owner_type="user",
+        owner_id=user.id,
+        connection_pool=pool,
+    )
+
+    with raises(HTTPException) as exc:
+        await list_docs(
+            developer_id=developer.id,
+            owner_type="user",
+            owner_id=user.id,
+            connection_pool=pool,
+            direction="invalid",
+        )
+
+    assert exc.raised.status_code == 400
+    assert exc.raised.detail == "Invalid sort direction"
+
+
 @test("query: list agent docs")
 async def _(dsn=pg_dsn, developer=test_developer, agent=test_agent):
     pool = await create_db_pool(dsn=dsn)
@@ -246,6 +366,80 @@ async def _(dsn=pg_dsn, developer=test_developer, agent=test_agent):
     assert len(docs_list_metadata) >= 1
     assert any(d.id == doc_agent_different_metadata.id for d in docs_list_metadata)
     assert any(d.metadata == {"test": "test2"} for d in docs_list_metadata)
+
+
+@test("query: list agent docs, invalid limit")
+async def _(dsn=pg_dsn):
+    """Test that listing agent docs with an invalid limit raises an exception."""
+
+    pool = await create_db_pool(dsn=dsn)
+
+    with raises(HTTPException) as exc:
+        await list_docs(
+            developer_id=uuid4(),
+            owner_type="agent",
+            owner_id=uuid4(),
+            connection_pool=pool,
+            limit=101,
+        )
+
+    assert exc.raised.status_code == 400
+    assert exc.raised.detail == "Limit must be between 1 and 100"
+
+
+@test("query: list agent docs, invalid offset")
+async def _(dsn=pg_dsn):
+    """Test that listing agent docs with an invalid offset raises an exception."""
+
+    pool = await create_db_pool(dsn=dsn)
+
+    with raises(HTTPException) as exc:
+        await list_docs(
+            developer_id=uuid4(),
+            owner_type="agent",
+            owner_id=uuid4(),
+            connection_pool=pool,
+            offset=-1,
+        )
+
+    assert exc.raised.status_code == 400
+    assert exc.raised.detail == "Offset must be >= 0"
+
+
+@test("query: list agent docs, invalid sort by")
+async def _(dsn=pg_dsn):
+    """Test that listing agent docs with an invalid sort by raises an exception."""
+    pool = await create_db_pool(dsn=dsn)
+
+    with raises(HTTPException) as exc:
+        await list_docs(
+            developer_id=uuid4(),
+            owner_type="agent",
+            owner_id=uuid4(),
+            connection_pool=pool,
+            sort_by="invalid",
+        )
+
+    assert exc.raised.status_code == 400
+    assert exc.raised.detail == "Invalid sort field"
+
+
+@test("query: list agent docs, invalid sort direction")
+async def _(dsn=pg_dsn):
+    """Test that listing agent docs with an invalid sort direction raises an exception."""
+    pool = await create_db_pool(dsn=dsn)
+
+    with raises(HTTPException) as exc:
+        await list_docs(
+            developer_id=uuid4(),
+            owner_type="agent",
+            owner_id=uuid4(),
+            connection_pool=pool,
+            direction="invalid",
+        )
+
+    assert exc.raised.status_code == 400
+    assert exc.raised.detail == "Invalid sort direction"
 
 
 @test("query: delete user doc")

--- a/agents-api/tests/test_entry_queries.py
+++ b/agents-api/tests/test_entry_queries.py
@@ -61,6 +61,84 @@ async def _(dsn=pg_dsn, developer=test_developer):
     assert exc_info.raised.status_code == 404
 
 
+@test("query: list entries sql, invalid limit")
+async def _(dsn=pg_dsn, developer_id=test_developer_id):
+    """Test that listing entries with an invalid limit raises an exception."""
+
+    pool = await create_db_pool(dsn=dsn)
+
+    with raises(HTTPException) as exc_info:
+        await list_entries(
+            developer_id=developer_id,
+            session_id=uuid7(),
+            limit=1001,
+            connection_pool=pool,
+        )  # type: ignore[not-callable]
+    assert exc_info.raised.status_code == 400
+    assert exc_info.raised.detail == "Limit must be between 1 and 1000"
+
+    with raises(HTTPException) as exc_info:
+        await list_entries(
+            developer_id=developer_id,
+            session_id=uuid7(),
+            limit=0,
+            connection_pool=pool,
+        )  # type: ignore[not-callable]
+    assert exc_info.raised.status_code == 400
+    assert exc_info.raised.detail == "Limit must be between 1 and 1000"
+
+
+@test("query: list entries sql, invalid offset")
+async def _(dsn=pg_dsn, developer_id=test_developer_id):
+    """Test that listing entries with an invalid offset raises an exception."""
+
+    pool = await create_db_pool(dsn=dsn)
+
+    with raises(HTTPException) as exc_info:
+        await list_entries(
+            developer_id=developer_id,
+            session_id=uuid7(),
+            offset=-1,
+            connection_pool=pool,
+        )  # type: ignore[not-callable]
+    assert exc_info.raised.status_code == 400
+    assert exc_info.raised.detail == "Offset must be >= 0"
+
+
+@test("query: list entries sql, invalid sort by")
+async def _(dsn=pg_dsn, developer_id=test_developer_id):
+    """Test that listing entries with an invalid sort by raises an exception."""
+
+    pool = await create_db_pool(dsn=dsn)
+
+    with raises(HTTPException) as exc_info:
+        await list_entries(
+            developer_id=developer_id,
+            session_id=uuid7(),
+            sort_by="invalid",
+            connection_pool=pool,
+        )  # type: ignore[not-callable]
+    assert exc_info.raised.status_code == 400
+    assert exc_info.raised.detail == "Invalid sort field"
+
+
+@test("query: list entries sql, invalid sort direction")
+async def _(dsn=pg_dsn, developer_id=test_developer_id):
+    """Test that listing entries with an invalid sort direction raises an exception."""
+
+    pool = await create_db_pool(dsn=dsn)
+
+    with raises(HTTPException) as exc_info:
+        await list_entries(
+            developer_id=developer_id,
+            session_id=uuid7(),
+            direction="invalid",
+            connection_pool=pool,
+        )  # type: ignore[not-callable]
+    assert exc_info.raised.status_code == 400
+    assert exc_info.raised.detail == "Invalid sort direction"
+
+
 @test("query: list entries sql - session exists")
 async def _(dsn=pg_dsn, developer_id=test_developer_id, session=test_session):
     """Test the retrieval of entries from the database."""

--- a/agents-api/tests/test_task_queries.py
+++ b/agents-api/tests/test_task_queries.py
@@ -198,6 +198,80 @@ async def _(dsn=pg_dsn, developer_id=test_developer_id, agent=test_agent, task=t
     )
 
 
+@test("query: list tasks sql, invalid limit")
+async def _(dsn=pg_dsn, developer_id=test_developer_id, agent=test_agent, task=test_task):
+    """Test that listing tasks with an invalid limit raises an exception."""
+
+    pool = await create_db_pool(dsn=dsn)
+    with raises(HTTPException) as exc:
+        await list_tasks(
+            developer_id=developer_id,
+            agent_id=agent.id,
+            connection_pool=pool,
+            limit=101,
+        )
+    assert exc.raised.status_code == 400
+    assert exc.raised.detail == "Limit must be between 1 and 100"
+
+    with raises(HTTPException) as exc:
+        await list_tasks(
+            developer_id=developer_id,
+            agent_id=agent.id,
+            connection_pool=pool,
+            limit=0,
+        )
+    assert exc.raised.status_code == 400
+    assert exc.raised.detail == "Limit must be between 1 and 100"
+
+
+@test("query: list tasks sql, invalid offset")
+async def _(dsn=pg_dsn, developer_id=test_developer_id, agent=test_agent, task=test_task):
+    """Test that listing tasks with an invalid offset raises an exception."""
+
+    pool = await create_db_pool(dsn=dsn)
+    with raises(HTTPException) as exc:
+        await list_tasks(
+            developer_id=developer_id,
+            agent_id=agent.id,
+            connection_pool=pool,
+            offset=-1,
+        )
+    assert exc.raised.status_code == 400
+    assert exc.raised.detail == "Offset must be >= 0"
+
+
+@test("query: list tasks sql, invalid sort by")
+async def _(dsn=pg_dsn, developer_id=test_developer_id, agent=test_agent, task=test_task):
+    """Test that listing tasks with an invalid sort by raises an exception."""
+
+    pool = await create_db_pool(dsn=dsn)
+    with raises(HTTPException) as exc:
+        await list_tasks(
+            developer_id=developer_id,
+            agent_id=agent.id,
+            connection_pool=pool,
+            sort_by="invalid",
+        )
+    assert exc.raised.status_code == 400
+    assert exc.raised.detail == "Invalid sort field"
+
+
+@test("query: list tasks sql, invalid sort direction")
+async def _(dsn=pg_dsn, developer_id=test_developer_id, agent=test_agent, task=test_task):
+    """Test that listing tasks with an invalid sort direction raises an exception."""
+
+    pool = await create_db_pool(dsn=dsn)
+    with raises(HTTPException) as exc:
+        await list_tasks(
+            developer_id=developer_id,
+            agent_id=agent.id,
+            connection_pool=pool,
+            direction="invalid",
+        )
+    assert exc.raised.status_code == 400
+    assert exc.raised.detail == "Invalid sort direction"
+
+
 @test("query: update task sql - exists")
 async def _(dsn=pg_dsn, developer_id=test_developer_id, agent=test_agent, task=test_task):
     """Test that a task can be successfully updated."""


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Refactored query parameter validation to use `beartype` and centralized validation logic.
  - Introduced `make_num_validator` utility for numeric validation with custom error messages.
  - Added `QueryParamsValidationError` for consistent exception handling.

- Replaced inline validation logic in query functions with `Annotated` and `beartype.vale`.

- Enhanced error handling for invalid query parameters across multiple query modules.

- Added comprehensive test cases for invalid query parameter scenarios.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>validation.py</strong><dd><code>Added <code>QueryParamsValidationError</code> for query parameter validation errors</code></dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1303/files#diff-b4326afd15eeb7248833f8e3df8c8a4ebf27d507c64e06d3bea4d45c31d56413">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>db_exceptions.py</strong><dd><code>Enhanced exception handling for query parameter validation</code></dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1303/files#diff-15e4c843422b852e647db8608631728d83cad8f06f579774dc3c7b5213fbee8f">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>task_validation.py</strong><dd><code>Removed redundant validation logic for task validation</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1303/files#diff-536283ced20f35bc610e4d49258098f86053911c0e53af09a035b6dffe9fcadc">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>list_agents.py</strong><dd><code>Refactored query parameter validation for listing agents</code>&nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1303/files#diff-abed8cc457fda7326510eb858c68e739849c4d0b05428f87b865baf01fed1fa9">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>list_docs.py</strong><dd><code>Refactored query parameter validation for listing documents</code></dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1303/files#diff-8abede8e9aab32f6622b45ba6e76f699b4b3baa69c70ba8ad89ab689db9ea468">+18/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>list_entries.py</strong><dd><code>Refactored query parameter validation for listing entries</code></dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1303/files#diff-9df391cfc2fe63c71db76d8aa66b98622beec4ef31984f42d12062a7131e90bf">+14/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>list_executions.py</strong><dd><code>Refactored query parameter validation for listing executions</code></dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1303/files#diff-7ea19dff595b2ae1dfccc45c298ed94e18841bd79ecd56bbb820d0651f99a07a">+16/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>list_files.py</strong><dd><code>Refactored query parameter validation for listing files</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1303/files#diff-b9ab2d662e5278cff6c0a4dad0163135041a22c1bf43d92a54f7b40d85821f0d">+18/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>list_tasks.py</strong><dd><code>Refactored query parameter validation for listing tasks</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1303/files#diff-c0a3c98605d0e3a887497d95ccfa483c70f5e0456432c5fa167401fd078cae47">+16/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>list_users.py</strong><dd><code>Refactored query parameter validation for listing users</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1303/files#diff-4f612c9658fbe077d96cfb1d0af5a50421c2c8f4cf06ed300613e93a1bac4f5c">+14/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>utils.py</strong><dd><code>Added `make_num_validator` utility for numeric validation</code></dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1303/files#diff-192f7f1d70156bc031f76c9c7b53f6dceec68037dc01767439a7f866ea1c9d1e">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>test_agent_queries.py</strong><dd><code>Added tests for invalid query parameters in agent queries</code></dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1303/files#diff-c4eba55a4f98c1a817734187edb2dc42317456f34c36786b7679acd469cd69e0">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_docs_queries.py</strong><dd><code>Added tests for invalid query parameters in document queries</code></dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1303/files#diff-36539fadcf9fdd23428ea921b45082c021d6816dddf931a806b9828fa43d1fb1">+194/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_entry_queries.py</strong><dd><code>Added tests for invalid query parameters in entry queries</code></dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1303/files#diff-346a3a000d1891f0d62ace9ee59c43cee7392bb49c32309ddfb530522acd7fb2">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_execution_queries.py</strong><dd><code>Added tests for invalid query parameters in execution queries</code></dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1303/files#diff-51519c833a02178e0e9fb808b57af5c0607450bb228800f9be7d8d984c33af83">+97/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_files_queries.py</strong><dd><code>Added tests for invalid query parameters in file queries</code>&nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1303/files#diff-3fd9a0154441c44e3e437b82acb56b822e6cc493e958d11a6b01d90155c69120">+71/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_task_queries.py</strong><dd><code>Added tests for invalid query parameters in task queries</code>&nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1303/files#diff-55be243be83743c620e4bf1aa699becda6f72add060ee9ac3118682e89705cda">+74/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_user_queries.py</strong><dd><code>Added tests for invalid query parameters in user queries</code>&nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1303/files#diff-d09ddb8a02bec1198ff885e5e2f00d627130eae46f1f6ad83ec8e7f589f41f63">+76/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor query parameter validation using `beartype` across multiple query functions, adding new tests for validation errors.
> 
>   - **Validation Refactor**:
>     - Introduced `beartype` for query parameter validation in functions like `list_agents`, `list_docs`, `list_entries`, `list_executions`, `list_files`, `list_tasks`, and `list_users`.
>     - Removed manual validation checks for `limit`, `offset`, `sort_by`, and `direction` in these functions.
>   - **Exceptions**:
>     - Added `QueryParamsValidationError` in `validation.py` for handling query parameter validation errors.
>     - Updated `common_db_exceptions` in `db_exceptions.py` to map `QueryParamsValidationError` to HTTP 400 errors.
>   - **Tests**:
>     - Added tests for invalid `limit`, `offset`, `sort_by`, and `direction` parameters in `test_agent_queries.py`, `test_docs_queries.py`, `test_entry_queries.py`, `test_execution_queries.py`, `test_files_queries.py`, `test_task_queries.py`, and `test_user_queries.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 757a1daa23e17125777dc0ed2bb8cd4fdfa5bd7f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->