### PR TITLE
fix(documentation): Add missing $ to expression

### DIFF
--- a/documentation/advanced/python-expression.mdx
+++ b/documentation/advanced/python-expression.mdx
@@ -49,7 +49,7 @@ The `$` variable is used to differentiate between a Python expression and a stri
 - prompt:
     - role: user
       content: |-
-        f'''
+        $ f'''
         Please answer the following question:
         {_.question} 
         '''


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Fixes documentation by adding a missing `$` symbol to a Python expression example in the Python Expression guide.

- Added the missing `$` prefix to the f-string example in `documentation/advanced/python-expression.mdx` to correctly demonstrate how to use Python expressions in prompt content.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->