### PR TITLE
fix(agents-api): fix fallback pricing

### DIFF
--- a/agents-api/agents_api/queries/usage/create_usage_record.py
+++ b/agents-api/agents_api/queries/usage/create_usage_record.py
@@ -27,11 +27,13 @@ FALLBACK_PRICING = {
         "api_request": 0.0 / 1000000,
         "api_response": 0.0 / 1000000,
     },
+
     # Qwen model
     "qwen/qwen-2.5-72b-instruct": {
         "api_request": 0.7 / 1000000,
         "api_response": 0.7 / 1000000,
     },
+
     # Sao10k model
     "sao10k/l3.3-euryale-70b": {
         "api_request": 0.7 / 1000000,
@@ -40,6 +42,22 @@ FALLBACK_PRICING = {
     "sao10k/l3.1-euryale-70b": {
         "api_request": 0.7 / 1000000,
         "api_response": 0.8 / 1000000,
+    },
+
+    # eva-unit-01 model
+    'openrouter/eva-unit-01/eva-llama-3.33-70b': {
+        'api_request': 4/1000000,
+         'api_response': 6/1000000
+    },
+    'openrouter/eva-unit-01/eva-qwen-2.5-72b': {
+        'api_request': 0.9/1000000,
+        'api_response': 1.2/1000000
+    },
+
+    # mistral-large-2411 model
+    'openrouter/mistralai/mistral-large-2411': {
+        'api_request': 2/1000000,
+        'api_response': 6/1000000
     },
 }
 

--- a/agents-api/agents_api/queries/usage/create_usage_record.py
+++ b/agents-api/agents_api/queries/usage/create_usage_record.py
@@ -27,13 +27,11 @@ FALLBACK_PRICING = {
         "api_request": 0.0 / 1000000,
         "api_response": 0.0 / 1000000,
     },
-
     # Qwen model
     "qwen/qwen-2.5-72b-instruct": {
         "api_request": 0.7 / 1000000,
         "api_response": 0.7 / 1000000,
     },
-
     # Sao10k model
     "sao10k/l3.3-euryale-70b": {
         "api_request": 0.7 / 1000000,
@@ -43,21 +41,19 @@ FALLBACK_PRICING = {
         "api_request": 0.7 / 1000000,
         "api_response": 0.8 / 1000000,
     },
-
     # eva-unit-01 model
-    'openrouter/eva-unit-01/eva-llama-3.33-70b': {
-        'api_request': 4/1000000,
-         'api_response': 6/1000000
+    "openrouter/eva-unit-01/eva-llama-3.33-70b": {
+        "api_request": 4 / 1000000,
+        "api_response": 6 / 1000000,
     },
-    'openrouter/eva-unit-01/eva-qwen-2.5-72b': {
-        'api_request': 0.9/1000000,
-        'api_response': 1.2/1000000
+    "openrouter/eva-unit-01/eva-qwen-2.5-72b": {
+        "api_request": 0.9 / 1000000,
+        "api_response": 1.2 / 1000000,
     },
-
     # mistral-large-2411 model
-    'openrouter/mistralai/mistral-large-2411': {
-        'api_request': 2/1000000,
-        'api_response': 6/1000000
+    "openrouter/mistralai/mistral-large-2411": {
+        "api_request": 2 / 1000000,
+        "api_response": 6 / 1000000,
     },
 }
 

--- a/agents-api/agents_api/queries/usage/create_usage_record.py
+++ b/agents-api/agents_api/queries/usage/create_usage_record.py
@@ -16,30 +16,30 @@ from ..utils import pg_query, rewrap_exceptions
 FALLBACK_PRICING = {
     # Meta Llama models
     "meta-llama/llama-4-scout": {
-        "api_request": 0.08 / 1000,
-        "api_response": 0.45 / 1000,
+        "api_request": 0.08 / 1000000,
+        "api_response": 0.45 / 1000000,
     },
     "meta-llama/llama-4-maverick": {
-        "api_request": 0.19 / 1000,
-        "api_response": 0.85 / 1000,
+        "api_request": 0.19 / 1000000,
+        "api_response": 0.85 / 1000000,
     },
     "meta-llama/llama-4-maverick:free": {
-        "api_request": 0.0 / 1000,
-        "api_response": 0.0 / 1000,
+        "api_request": 0.0 / 1000000,
+        "api_response": 0.0 / 1000000,
     },
     # Qwen model
     "qwen/qwen-2.5-72b-instruct": {
-        "api_request": 0.7 / 1000,
-        "api_response": 0.7 / 1000,
+        "api_request": 0.7 / 1000000,
+        "api_response": 0.7 / 1000000,
     },
     # Sao10k model
     "sao10k/l3.3-euryale-70b": {
-        "api_request": 0.7 / 1000,
-        "api_response": 0.8 / 1000,
+        "api_request": 0.7 / 1000000,
+        "api_response": 0.8 / 1000000,
     },
     "sao10k/l3.1-euryale-70b": {
-        "api_request": 0.7 / 1000,
-        "api_response": 0.8 / 1000,
+        "api_request": 0.7 / 1000000,
+        "api_response": 0.8 / 1000000,
     },
 }
 


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Fixes the fallback pricing calculation for LLM models by correcting the divisor from 1000 to 1000000 to properly calculate per-token costs.

- Updated the FALLBACK_PRICING dictionary in `agents-api/agents_api/queries/usage/create_usage_record.py` to use the correct divisor (1000000 instead of 1000) for calculating per-token costs.
- This correction ensures accurate cost calculation when the standard litellm cost_per_token function fails and the system falls back to manual pricing.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes fallback pricing calculation in `create_usage_record.py` by correcting divisor for accurate per-token costs.
> 
>   - **Behavior**:
>     - Corrects divisor in `FALLBACK_PRICING` in `create_usage_record.py` from 1000 to 1000000 for accurate per-token cost calculation.
>     - Ensures accurate fallback pricing when `cost_per_token` function fails.
>   - **Models**:
>     - Updates pricing for models like `meta-llama/llama-4-scout`, `qwen/qwen-2.5-72b-instruct`, and others.
>   - **Misc**:
>     - Adds new models `openrouter/eva-unit-01/eva-llama-3.33-70b`, `openrouter/mistralai/mistral-large-2411` to `FALLBACK_PRICING`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 55f04304d95b9e3ed539543464a91f96960db59e. You can [customize](https://app.ellipsis.dev/julep-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->