### PR TITLE
fix(agents-api): add pydantic model calulation to total_size function

### DIFF
--- a/agents-api/agents_api/common/utils/memory.py
+++ b/agents-api/agents_api/common/utils/memory.py
@@ -10,6 +10,8 @@ from collections.abc import Callable
 from itertools import chain
 from typing import Any
 
+from pydantic import BaseModel
+
 
 def total_size(
     o: Any, handlers: dict[type, Callable] | None = None, verbose: bool = False
@@ -19,6 +21,7 @@ def total_size(
 
     Automatically finds the contents of the following builtin containers and
     their subclasses: tuple, list, deque, dict, set and frozenset.
+    Also handles Pydantic models by recursively measuring their fields.
 
     To search other containers, add handlers to iterate over their contents:
         handlers = {SomeContainerClass: iter,
@@ -38,6 +41,9 @@ def total_size(
     def dict_handler(d):
         return chain.from_iterable(d.items())
 
+    def pydantic_handler(model: BaseModel):
+        return chain.from_iterable(model.model_dump().items())
+
     all_handlers = {
         tuple: iter,
         list: iter,
@@ -45,6 +51,7 @@ def total_size(
         dict: dict_handler,
         set: iter,
         frozenset: iter,
+        BaseModel: pydantic_handler,
     }
     all_handlers.update(handlers)  # user handlers take precedence
     seen: set[int] = set()  # track which object id's have already been seen


### PR DESCRIPTION
### **PR Type**
bug_fix, enhancement


___

### **Description**
- Added support for calculating memory size of Pydantic models in `total_size`.

- Introduced a handler for recursively measuring Pydantic model fields.

- Updated documentation to reflect Pydantic model support.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>memory.py</strong><dd><code>Add handler for Pydantic models in memory size calculation</code></dd></summary>
<hr>

agents-api/agents_api/common/utils/memory.py

<li>Imported <code>BaseModel</code> from Pydantic.<br> <li> Documented support for Pydantic models in <code>total_size</code> docstring.<br> <li> Added <code>pydantic_handler</code> to recursively measure Pydantic model fields.<br> <li> Registered <code>BaseModel</code> handler in the <code>all_handlers</code> dictionary.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1340/files#diff-38677c2236f9d946b6634b41d270da4dd598d39a0bd48d1b8bfd510af89e6e75">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance `total_size()` in `memory.py` to support Pydantic models by adding a handler for recursive field measurement.
> 
>   - **Behavior**:
>     - `total_size()` in `memory.py` now supports Pydantic models by adding a `pydantic_handler` that uses `model_dump()` to measure fields.
>     - Updates `all_handlers` to include `BaseModel` with `pydantic_handler` for recursive field measurement.
>   - **Misc**:
>     - Imports `BaseModel` from `pydantic` in `memory.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 95ea0fa67ad5e5af7515abed5bf3b07df752190f. You can [customize](https://app.ellipsis.dev/julep-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->