### PR TITLE
dev->main

### DIFF
--- a/agents-api/agents_api/queries/developers/get_developer.py
+++ b/agents-api/agents_api/queries/developers/get_developer.py
@@ -11,7 +11,7 @@ from ...common.utils.db_exceptions import common_db_exceptions
 from ..utils import pg_query, rewrap_exceptions, wrap_in_class
 
 developer_query = """
-SELECT * FROM developers WHERE developer_id = $1 -- developer_id
+SELECT * FROM developers WHERE developer_id = $1 and active = true
 """
 
 

--- a/agents-api/agents_api/queries/docs/delete_doc.py
+++ b/agents-api/agents_api/queries/docs/delete_doc.py
@@ -10,17 +10,18 @@ from ..utils import pg_query, rewrap_exceptions, wrap_in_class
 
 # Delete doc query
 delete_doc_query = """
-DELETE FROM docs
-WHERE developer_id = $1
-  AND doc_id = $2
+DELETE FROM docs d
+WHERE d.developer_id = $1
+  AND d.doc_id = $2
   AND EXISTS (
-    SELECT 1 FROM doc_owners
-    WHERE developer_id = $1
-      AND doc_id = $2
-      AND owner_type = $3
-      AND owner_id = $4
+    SELECT 1
+    FROM doc_owners o
+    WHERE o.developer_id = d.developer_id
+      AND o.doc_id = d.doc_id
+      AND o.owner_type = $3
+      AND o.owner_id = $4
   )
-RETURNING doc_id;
+RETURNING d.doc_id;
 """
 
 delete_doc_owners_query = """


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Restricts developer retrieval to only active developers

- Updates SQL query to include `active = true` condition


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>get_developer.py</strong><dd><code>Restrict developer query to active developers only</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/queries/developers/get_developer.py

<li>Adds <code>active = true</code> condition to SQL query<br> <li> Ensures only active developers are returned from database


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1346/files#diff-c9425aed2b6db3867a3b82ba0534930f8fd5a758a4213253d7c63dd2948915a4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify SQL query in `get_developer.py` to filter for active developers only.
> 
>   - **Behavior**:
>     - Modify SQL query in `get_developer.py` to include `active = true` condition, filtering for active developers only.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 0ea30548256009310028c41499ef2ce9c638979f. You can [customize](https://app.ellipsis.dev/julep-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->