### PR TITLE
Developers and costs check

### DIFF
--- a/agents-api/agents_api/dependencies/developer_id.py
+++ b/agents-api/agents_api/dependencies/developer_id.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import Header, HTTPException, status
+from fastapi import Header
 
 from ..common.protocol.developers import Developer
 from ..env import multi_tenant_mode
@@ -25,17 +25,6 @@ async def get_developer_id(
         except ValueError as e:
             msg = "X-Developer-Id must be a valid UUID"
             raise InvalidHeaderFormat(msg) from e
-
-    try:
-        await get_developer(developer_id=x_developer_id)
-    except HTTPException as e:
-        if e.status_code == status.HTTP_404_NOT_FOUND:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Invalid developer account",
-            )
-
-        raise e
 
     return x_developer_id
 

--- a/agents-api/agents_api/env.py
+++ b/agents-api/agents_api/env.py
@@ -91,6 +91,10 @@ api_key_header_name: str = env.str("AGENTS_API_KEY_HEADER_NAME", default="X-Auth
 max_free_sessions: int = env.int("MAX_FREE_SESSIONS", default=50)
 max_free_executions: int = env.int("MAX_FREE_EXECUTIONS", default=50)
 
+# Usage limits
+# -----------
+free_tier_cost_limit: float = env.float("FREE_TIER_COST_LIMIT", default=2.0)
+
 # Litellm API
 # -----------
 litellm_url: str | None = env.str("LITELLM_URL", default=None)
@@ -194,6 +198,7 @@ environment: dict[str, Any] = {
     "s3_secret_key": s3_secret_key,
     "testing": testing,
     "enable_responses": enable_responses,
+    "free_tier_cost_limit": free_tier_cost_limit,
 }
 
 if debug or testing:

--- a/agents-api/agents_api/queries/developers/get_developer.py
+++ b/agents-api/agents_api/queries/developers/get_developer.py
@@ -11,7 +11,7 @@ from ...common.utils.db_exceptions import common_db_exceptions
 from ..utils import pg_query, rewrap_exceptions, wrap_in_class
 
 developer_query = """
-SELECT * FROM developers WHERE developer_id = $1 and active = true
+SELECT * FROM developers WHERE developer_id = $1 AND active = true
 """
 
 

--- a/agents-api/agents_api/queries/usage/__init__.py
+++ b/agents-api/agents_api/queries/usage/__init__.py
@@ -14,7 +14,9 @@ related to usage tracking and reporting.
 # ruff: noqa: F401, F403, F405
 
 from .create_usage_record import create_usage_record
+from .get_user_cost import get_user_cost
 
 __all__ = [
     "create_usage_record",
+    "get_user_cost",
 ]

--- a/agents-api/agents_api/queries/usage/__init__.py
+++ b/agents-api/agents_api/queries/usage/__init__.py
@@ -14,9 +14,9 @@ related to usage tracking and reporting.
 # ruff: noqa: F401, F403, F405
 
 from .create_usage_record import create_usage_record
-from .get_user_cost import get_user_cost
+from .get_user_cost import get_usage_cost
 
 __all__ = [
     "create_usage_record",
-    "get_user_cost",
+    "get_usage_cost",
 ]

--- a/agents-api/agents_api/queries/usage/create_usage_record.py
+++ b/agents-api/agents_api/queries/usage/create_usage_record.py
@@ -59,11 +59,11 @@ FALLBACK_PRICING = {
 
 MAX_INPUT_COST_PER_TOKEN = max(
     max((model_cost[model].get("input_cost_per_token", 0) for model in model_cost), default=0),
-    max((pricing["api_request"] for pricing in FALLBACK_PRICING.values()), default=0)
+    max((pricing["api_request"] for pricing in FALLBACK_PRICING.values()), default=0),
 )
 MAX_OUTPUT_COST_PER_TOKEN = max(
     max((model_cost[model].get("output_cost_per_token", 0) for model in model_cost), default=0),
-    max((pricing["api_response"] for pricing in FALLBACK_PRICING.values()), default=0)
+    max((pricing["api_response"] for pricing in FALLBACK_PRICING.values()), default=0),
 )
 
 # Define the raw SQL query
@@ -145,7 +145,9 @@ async def create_usage_record(
                     MAX_INPUT_COST_PER_TOKEN * prompt_tokens
                     + MAX_OUTPUT_COST_PER_TOKEN * completion_tokens
                 )
-                print(f"No fallback pricing found for model {model}, using max costs: {total_cost}")
+                print(
+                    f"No fallback pricing found for model {model}, using max costs: {total_cost}"
+                )
 
     params = [
         developer_id,

--- a/agents-api/agents_api/queries/usage/create_usage_record.py
+++ b/agents-api/agents_api/queries/usage/create_usage_record.py
@@ -6,6 +6,7 @@ It tracks token usage and costs for LLM API calls.
 from typing import Any
 from uuid import UUID
 
+import numpy as np
 from beartype import beartype
 from litellm import cost_per_token, model_cost
 
@@ -57,14 +58,23 @@ FALLBACK_PRICING = {
     },
 }
 
-MAX_INPUT_COST_PER_TOKEN = max(
-    max((model_cost[model].get("input_cost_per_token", 0) for model in model_cost), default=0),
-    max((pricing["api_request"] for pricing in FALLBACK_PRICING.values()), default=0),
-)
-MAX_OUTPUT_COST_PER_TOKEN = max(
-    max((model_cost[model].get("output_cost_per_token", 0) for model in model_cost), default=0),
-    max((pricing["api_response"] for pricing in FALLBACK_PRICING.values()), default=0),
-)
+# Calculate average of non-zero input costs
+input_costs_litellm = [model_cost[model].get("input_cost_per_token", 0) 
+                      for model in model_cost 
+                      if model_cost[model].get("input_cost_per_token", 0) > 0]
+input_costs_fallback = [pricing["api_request"] 
+                       for pricing in FALLBACK_PRICING.values() 
+                       if pricing["api_request"] > 0]
+AVG_INPUT_COST_PER_TOKEN = np.mean(input_costs_litellm + input_costs_fallback) if input_costs_litellm + input_costs_fallback else 0
+
+# Calculate average of non-zero output costs
+output_costs_litellm = [model_cost[model].get("output_cost_per_token", 0) 
+                       for model in model_cost 
+                       if model_cost[model].get("output_cost_per_token", 0) > 0]
+output_costs_fallback = [pricing["api_response"] 
+                        for pricing in FALLBACK_PRICING.values() 
+                        if pricing["api_response"] > 0]
+AVG_OUTPUT_COST_PER_TOKEN = np.mean(output_costs_litellm + output_costs_fallback) if output_costs_litellm + output_costs_fallback else 0
 
 # Define the raw SQL query
 usage_query = """
@@ -142,12 +152,10 @@ async def create_usage_record(
                 )
             else:
                 total_cost = (
-                    MAX_INPUT_COST_PER_TOKEN * prompt_tokens
-                    + MAX_OUTPUT_COST_PER_TOKEN * completion_tokens
+                    AVG_INPUT_COST_PER_TOKEN * prompt_tokens
+                    + AVG_OUTPUT_COST_PER_TOKEN * completion_tokens
                 )
-                print(
-                    f"No fallback pricing found for model {model}, using max costs: {total_cost}"
-                )
+                print(f"No fallback pricing found for model {model}, using avg costs: {total_cost}")
 
     params = [
         developer_id,

--- a/agents-api/agents_api/queries/usage/create_usage_record.py
+++ b/agents-api/agents_api/queries/usage/create_usage_record.py
@@ -6,7 +6,6 @@ It tracks token usage and costs for LLM API calls.
 from typing import Any
 from uuid import UUID
 
-import numpy as np
 from beartype import beartype
 from litellm import cost_per_token, model_cost
 
@@ -69,10 +68,9 @@ input_costs_fallback = [
     for pricing in FALLBACK_PRICING.values()
     if pricing["api_request"] > 0
 ]
+combined_input_costs = input_costs_litellm + input_costs_fallback
 AVG_INPUT_COST_PER_TOKEN = (
-    np.mean(input_costs_litellm + input_costs_fallback)
-    if input_costs_litellm + input_costs_fallback
-    else 0
+    sum(combined_input_costs) / len(combined_input_costs) if combined_input_costs else 0
 )
 
 # Calculate average of non-zero output costs
@@ -86,10 +84,9 @@ output_costs_fallback = [
     for pricing in FALLBACK_PRICING.values()
     if pricing["api_response"] > 0
 ]
+combined_output_costs = output_costs_litellm + output_costs_fallback
 AVG_OUTPUT_COST_PER_TOKEN = (
-    np.mean(output_costs_litellm + output_costs_fallback)
-    if output_costs_litellm + output_costs_fallback
-    else 0
+    sum(combined_output_costs) / len(combined_output_costs) if combined_output_costs else 0
 )
 
 # Define the raw SQL query

--- a/agents-api/agents_api/queries/usage/create_usage_record.py
+++ b/agents-api/agents_api/queries/usage/create_usage_record.py
@@ -59,22 +59,38 @@ FALLBACK_PRICING = {
 }
 
 # Calculate average of non-zero input costs
-input_costs_litellm = [model_cost[model].get("input_cost_per_token", 0) 
-                      for model in model_cost 
-                      if model_cost[model].get("input_cost_per_token", 0) > 0]
-input_costs_fallback = [pricing["api_request"] 
-                       for pricing in FALLBACK_PRICING.values() 
-                       if pricing["api_request"] > 0]
-AVG_INPUT_COST_PER_TOKEN = np.mean(input_costs_litellm + input_costs_fallback) if input_costs_litellm + input_costs_fallback else 0
+input_costs_litellm = [
+    model_cost[model].get("input_cost_per_token", 0)
+    for model in model_cost
+    if model_cost[model].get("input_cost_per_token", 0) > 0
+]
+input_costs_fallback = [
+    pricing["api_request"]
+    for pricing in FALLBACK_PRICING.values()
+    if pricing["api_request"] > 0
+]
+AVG_INPUT_COST_PER_TOKEN = (
+    np.mean(input_costs_litellm + input_costs_fallback)
+    if input_costs_litellm + input_costs_fallback
+    else 0
+)
 
 # Calculate average of non-zero output costs
-output_costs_litellm = [model_cost[model].get("output_cost_per_token", 0) 
-                       for model in model_cost 
-                       if model_cost[model].get("output_cost_per_token", 0) > 0]
-output_costs_fallback = [pricing["api_response"] 
-                        for pricing in FALLBACK_PRICING.values() 
-                        if pricing["api_response"] > 0]
-AVG_OUTPUT_COST_PER_TOKEN = np.mean(output_costs_litellm + output_costs_fallback) if output_costs_litellm + output_costs_fallback else 0
+output_costs_litellm = [
+    model_cost[model].get("output_cost_per_token", 0)
+    for model in model_cost
+    if model_cost[model].get("output_cost_per_token", 0) > 0
+]
+output_costs_fallback = [
+    pricing["api_response"]
+    for pricing in FALLBACK_PRICING.values()
+    if pricing["api_response"] > 0
+]
+AVG_OUTPUT_COST_PER_TOKEN = (
+    np.mean(output_costs_litellm + output_costs_fallback)
+    if output_costs_litellm + output_costs_fallback
+    else 0
+)
 
 # Define the raw SQL query
 usage_query = """
@@ -155,7 +171,9 @@ async def create_usage_record(
                     AVG_INPUT_COST_PER_TOKEN * prompt_tokens
                     + AVG_OUTPUT_COST_PER_TOKEN * completion_tokens
                 )
-                print(f"No fallback pricing found for model {model}, using avg costs: {total_cost}")
+                print(
+                    f"No fallback pricing found for model {model}, using avg costs: {total_cost}"
+                )
 
     params = [
         developer_id,

--- a/agents-api/agents_api/queries/usage/create_usage_record.py
+++ b/agents-api/agents_api/queries/usage/create_usage_record.py
@@ -7,7 +7,7 @@ from typing import Any
 from uuid import UUID
 
 from beartype import beartype
-from litellm import cost_per_token
+from litellm import cost_per_token, model_cost
 
 from ...common.utils.db_exceptions import common_db_exceptions
 from ...metrics.counters import query_metrics
@@ -56,6 +56,15 @@ FALLBACK_PRICING = {
         "api_response": 6 / 1000000,
     },
 }
+
+MAX_INPUT_COST_PER_TOKEN = max(
+    max((model_cost[model].get("input_cost_per_token", 0) for model in model_cost), default=0),
+    max((pricing["api_request"] for pricing in FALLBACK_PRICING.values()), default=0)
+)
+MAX_OUTPUT_COST_PER_TOKEN = max(
+    max((model_cost[model].get("output_cost_per_token", 0) for model in model_cost), default=0),
+    max((pricing["api_response"] for pricing in FALLBACK_PRICING.values()), default=0)
+)
 
 # Define the raw SQL query
 usage_query = """
@@ -132,7 +141,11 @@ async def create_usage_record(
                     + FALLBACK_PRICING[model]["api_response"] * completion_tokens
                 )
             else:
-                print(f"No fallback pricing found for model {model}")
+                total_cost = (
+                    MAX_INPUT_COST_PER_TOKEN * prompt_tokens
+                    + MAX_OUTPUT_COST_PER_TOKEN * completion_tokens
+                )
+                print(f"No fallback pricing found for model {model}, using max costs: {total_cost}")
 
     params = [
         developer_id,

--- a/agents-api/agents_api/queries/usage/get_user_cost.py
+++ b/agents-api/agents_api/queries/usage/get_user_cost.py
@@ -1,0 +1,52 @@
+"""
+This module contains functionality for creating usage records in the PostgreSQL database.
+It tracks token usage and costs for LLM API calls.
+"""
+
+from typing import Literal
+from uuid import UUID
+
+from beartype import beartype
+
+from ...common.utils.db_exceptions import common_db_exceptions
+from ...metrics.counters import query_metrics
+from ..utils import pg_query, rewrap_exceptions, wrap_in_class
+
+
+usage_query = """
+SELECT developer_id, active, tags, monthly_cost AS cost
+FROM usage_cost_monthly
+WHERE developer_id = $1
+LIMIT 1;
+"""
+
+
+@rewrap_exceptions(common_db_exceptions("usage", ["get"]))
+@wrap_in_class(
+    dict,
+    one=True,
+)
+@query_metrics("get_user_cost")
+@pg_query
+@beartype
+async def get_user_cost(
+    *,
+    developer_id: UUID,
+) -> tuple[str, list, Literal["fetch", "fetchmany", "fetchrow"]]:
+    """
+    Get the cost of a user's usage.
+
+    Parameters:
+        developer_id (UUID): The unique identifier for the developer.
+
+    Returns:
+        tuple[str, list]: SQL query and parameters for creating the usage record.
+    """
+
+    return (
+        usage_query,
+        [
+            developer_id,
+        ],
+        "fetchrow",
+    )

--- a/agents-api/agents_api/queries/usage/get_user_cost.py
+++ b/agents-api/agents_api/queries/usage/get_user_cost.py
@@ -13,9 +13,10 @@ from ...metrics.counters import query_metrics
 from ..utils import pg_query, rewrap_exceptions, wrap_in_class
 
 usage_query = """
-SELECT developer_id, active, tags, monthly_cost AS cost
-FROM usage_cost_monthly
+SELECT developer_id, active, tags, monthly_cost AS cost, bucket_start AS month
+FROM developer_cost_monthly
 WHERE developer_id = $1
+ORDER BY month DESC
 LIMIT 1;
 """
 

--- a/agents-api/agents_api/queries/usage/get_user_cost.py
+++ b/agents-api/agents_api/queries/usage/get_user_cost.py
@@ -26,15 +26,15 @@ LIMIT 1;
     dict,
     one=True,
 )
-@query_metrics("get_user_cost")
+@query_metrics("get_usage_cost")
 @pg_query
 @beartype
-async def get_user_cost(
+async def get_usage_cost(
     *,
     developer_id: UUID,
 ) -> tuple[str, list, Literal["fetch", "fetchmany", "fetchrow"]]:
     """
-    Get the cost of a user's usage.
+    Get the cost of a developer's usage.
 
     Parameters:
         developer_id (UUID): The unique identifier for the developer.

--- a/agents-api/agents_api/queries/usage/get_user_cost.py
+++ b/agents-api/agents_api/queries/usage/get_user_cost.py
@@ -12,7 +12,6 @@ from ...common.utils.db_exceptions import common_db_exceptions
 from ...metrics.counters import query_metrics
 from ..utils import pg_query, rewrap_exceptions, wrap_in_class
 
-
 usage_query = """
 SELECT developer_id, active, tags, monthly_cost AS cost
 FROM usage_cost_monthly

--- a/agents-api/agents_api/web.py
+++ b/agents-api/agents_api/web.py
@@ -310,7 +310,7 @@ async def usage_check_middleware(request: Request, call_next):
         # Check if user is active
         if not user_cost_data.get("active", False):
             return invalid_account_error
-        
+
         if request.method == "GET":
             return await call_next(request)
 
@@ -318,7 +318,7 @@ async def usage_check_middleware(request: Request, call_next):
         user_tags = user_cost_data.get("tags", []) or []
         if not isinstance(user_tags, list):
             user_tags = []
-            
+
         if "paid" in user_tags:
             return await call_next(request)
 
@@ -335,16 +335,16 @@ async def usage_check_middleware(request: Request, call_next):
                 },
             )
     except HTTPException as e:
-            if e.status_code == status.HTTP_404_NOT_FOUND:
-                return invalid_account_error
+        if e.status_code == status.HTTP_404_NOT_FOUND:
+            return invalid_account_error
 
-            return JSONResponse(
-                status_code=e.status_code,
-                content=e.detail,
-            )
+        return JSONResponse(
+            status_code=e.status_code,
+            content=e.detail,
+        )
     except asyncpg.NoDataFoundError:
         return invalid_account_error
-    except ValueError as e:
+    except ValueError:
         return JSONResponse(
             status_code=status.HTTP_400_BAD_REQUEST,
             content={

--- a/agents-api/agents_api/web.py
+++ b/agents-api/agents_api/web.py
@@ -25,7 +25,7 @@ from .common.exceptions import BaseCommonException
 from .dependencies.auth import get_api_key
 from .env import enable_responses, free_tier_cost_limit, sentry_dsn
 from .exceptions import PromptTooBigError
-from .queries.usage.get_user_cost import get_user_cost
+from .queries.usage.get_user_cost import get_usage_cost
 from .routers import (
     agents,
     docs,
@@ -305,7 +305,7 @@ async def usage_check_middleware(request: Request, call_next):
 
     try:
         developer_id = UUID(developer_id_str)
-        user_cost_data: dict = await get_user_cost(developer_id=developer_id)
+        user_cost_data: dict = await get_usage_cost(developer_id=developer_id)
 
         # Check if user is active
         if not user_cost_data.get("active", False):

--- a/agents-api/tests/test_developer_queries.py
+++ b/agents-api/tests/test_developer_queries.py
@@ -1,20 +1,14 @@
 # Tests for agent queries
 
-from unittest.mock import patch
-from uuid import uuid4
 
-from agents_api.app import app
 from agents_api.clients.pg import create_db_pool
 from agents_api.common.protocol.developers import Developer
-from agents_api.dependencies.developer_id import get_developer_id
 from agents_api.queries.developers.create_developer import create_developer
 from agents_api.queries.developers.get_developer import (
     get_developer,
 )
 from agents_api.queries.developers.patch_developer import patch_developer
 from agents_api.queries.developers.update_developer import update_developer
-from fastapi import Depends
-from fastapi.testclient import TestClient
 from uuid_extensions import uuid7
 from ward import raises, test
 

--- a/agents-api/tests/test_developer_queries.py
+++ b/agents-api/tests/test_developer_queries.py
@@ -96,36 +96,3 @@ async def _(dsn=pg_dsn, dev=test_new_developer, email=random_email):
     assert developer.active
     assert developer.tags == [*dev.tags, "tag2"]
     assert developer.settings == {**dev.settings, "key2": "val2"}
-
-
-@test("dependency: access denied for inactive developer")
-async def _(dsn=pg_dsn):
-    with patch("agents_api.dependencies.developer_id.multi_tenant_mode", True):
-        developer_id = uuid4()
-        # Add a test endpoint that requires authentication
-
-        @app.get("/test")
-        async def test_endpoint(x_developer_id=Depends(get_developer_id)):
-            return {"message": "success"}
-
-        # Create a test client
-        client = TestClient(app)
-
-        # Create an inactive developer
-        pool = await create_db_pool(dsn=dsn)
-        await create_developer(
-            email="inactive@test.com",
-            active=False,
-            developer_id=developer_id,
-            connection_pool=pool,
-        )
-
-        # Make a request with the inactive developer's ID
-        response = client.get(
-            "/test",
-            headers={"X-Developer-Id": str(developer_id)},
-        )
-
-        # Verify we get a 403 response
-        assert response.status_code == 403
-        assert response.json()["error"]["message"] == "Invalid developer account"

--- a/agents-api/tests/test_middleware.py
+++ b/agents-api/tests/test_middleware.py
@@ -3,457 +3,446 @@ Tests for HTTP middleware, specifically the usage_check_middleware
 """
 
 import uuid
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import asyncpg
+from agents_api.app import app
 from agents_api.env import free_tier_cost_limit
-from agents_api.web import usage_check_middleware
-from fastapi import HTTPException, Request, status
-from fastapi.responses import JSONResponse
-from starlette.datastructures import Headers
-from ward import test
+from fastapi import HTTPException, status
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+from ward import fixture, test
+
+
+class TestPayload(BaseModel):
+    """Test payload for POST/PUT handlers."""
+
+    message: str
+
+
+@fixture
+def client():
+    """Test client fixture that gets reset for each test."""
+    client = TestClient(app)
+    yield client
 
 
 @test("middleware: inactive free user receives forbidden response")
-async def _():
+async def _(client=client):
     """Test that requests from inactive users are blocked with 403 Forbidden."""
-    # Create mock request
-    mock_request = MagicMock(spec=Request)
-    mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
-    mock_request.method = "GET"
 
-    # Mock response from get_user_cost
+    # Create a test handler
+    @app.get("/test-inactive-user")
+    async def test_inactive_user():
+        return {"status": "success"}
+
+    # Create test data
+    developer_id = str(uuid.uuid4())
     mock_user_cost_data = {
         "active": False,
         "cost": 0.0,
-        "developer_id": mock_request.headers["X-Developer-Id"],
+        "developer_id": developer_id,
         "tags": [],
     }
 
     # Mock the get_user_cost function
     with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
-        # Set up mock for call_next
-        mock_call_next = AsyncMock()
-
-        # Call the middleware
-        response = await usage_check_middleware(mock_request, mock_call_next)
+        # Make request with the developer ID header
+        response = client.get("/test-inactive-user", headers={"X-Developer-Id": developer_id})
 
         # Verify response is 403 with correct message
         assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert "Invalid user account" in response.body.decode()
-        assert "invalid_user_account" in response.body.decode()
-
-        # Verify call_next was not called
-        mock_call_next.assert_not_called()
+        assert "Invalid user account" in response.text
+        assert "invalid_user_account" in response.text
 
 
 @test("middleware: inactive paid user receives forbidden response")
-async def _():
-    """Test that requests from inactive users are blocked with 403 Forbidden."""
-    # Create mock request
-    mock_request = MagicMock(spec=Request)
-    mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
-    mock_request.method = "GET"
+def _(client=client):
+    """Test that requests from inactive paid users are blocked with 403 Forbidden."""
 
-    # Mock response from get_user_cost
+    # Create a test handler
+    @app.get("/test-inactive-paid-user")
+    async def test_inactive_paid_user():
+        return {"status": "success"}
+
+    # Create test data
+    developer_id = str(uuid.uuid4())
     mock_user_cost_data = {
         "active": False,
         "cost": 0.0,
-        "developer_id": mock_request.headers["X-Developer-Id"],
-        "tags": [],
+        "developer_id": developer_id,
+        "tags": ["paid"],  # User has paid tag but is inactive
     }
 
     # Mock the get_user_cost function
     with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
-        # Set up mock for call_next
-        mock_call_next = AsyncMock()
-
-        # Call the middleware
-        response = await usage_check_middleware(mock_request, mock_call_next)
+        # Make request with the developer ID header
+        response = client.get(
+            "/test-inactive-paid-user", headers={"X-Developer-Id": developer_id}
+        )
 
         # Verify response is 403 with correct message
         assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert "Invalid user account" in response.body.decode()
-        assert "invalid_user_account" in response.body.decode()
-
-        # Verify call_next was not called
-        mock_call_next.assert_not_called()
+        assert "Invalid user account" in response.text
+        assert "invalid_user_account" in response.text
 
 
 @test("middleware: cost limit exceeded, all requests blocked except GET")
-async def _():
+def _(client=client):
     """Test that non-GET requests from users who exceeded cost limits are blocked with 403 Forbidden."""
-    # Create mock request
-    mock_request = MagicMock(spec=Request)
-    mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
-    mock_request.method = "POST"  # Use a non-GET method
 
-    # Mock response from get_user_cost with cost exceeding the limit
+    # Create test handlers for different methods
+    @app.get("/test-cost-limit/get")
+    async def test_cost_limit_get():
+        return {"status": "success", "method": "GET"}
+
+    @app.post("/test-cost-limit/post")
+    async def test_cost_limit_post(payload: TestPayload):
+        return {"status": "success", "method": "POST", "message": payload.message}
+
+    @app.put("/test-methods/put")
+    async def test_methods_put(payload: TestPayload):
+        return {"status": "success", "method": "PUT", "message": payload.message}
+
+    @app.delete("/test-methods/delete")
+    async def test_methods_delete():
+        return {"status": "success", "method": "DELETE"}
+
+    # Create test data
+    developer_id = str(uuid.uuid4())
     mock_user_cost_data = {
         "active": True,
         "cost": float(free_tier_cost_limit) + 1.0,  # Exceed the cost limit
-        "developer_id": mock_request.headers["X-Developer-Id"],
-        "tags": [],
+        "developer_id": developer_id,
+        "tags": [],  # No paid tag
     }
 
     # Mock the get_user_cost function
     with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
-        # Set up mock for call_next
-        mock_call_next = AsyncMock()
+        # Make a POST request that should be blocked
+        post_response = client.post(
+            "/test-cost-limit/post",
+            json={"message": "test"},
+            headers={"X-Developer-Id": developer_id},
+        )
 
-        # Call the middleware
-        response = await usage_check_middleware(mock_request, mock_call_next)
+        # Verify POST response is 403 with correct message
+        assert post_response.status_code == status.HTTP_403_FORBIDDEN
+        assert "Cost limit exceeded" in post_response.text
+        assert "cost_limit_exceeded" in post_response.text
 
-        # Verify response is 403 with correct message
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert "Cost limit exceeded" in response.body.decode()
-        assert "cost_limit_exceeded" in response.body.decode()
+        put_response = client.put(
+            "/test-methods/put",
+            json={"message": "test update"},
+            headers={"X-Developer-Id": developer_id},
+        )
 
-        # Verify call_next was not called
-        mock_call_next.assert_not_called()
+        # Verify PUT response is 403 with correct message
+        assert put_response.status_code == status.HTTP_403_FORBIDDEN
+        assert "Cost limit exceeded" in put_response.text
+        assert "cost_limit_exceeded" in put_response.text
+
+        # Make a DELETE request that should be blocked
+        delete_response = client.delete(
+            "/test-methods/delete", headers={"X-Developer-Id": developer_id}
+        )
+
+        # Verify DELETE response is 403 with correct message
+        assert delete_response.status_code == status.HTTP_403_FORBIDDEN
+        assert "Cost limit exceeded" in delete_response.text
+        assert "cost_limit_exceeded" in delete_response.text
+
+        # Make a GET request that should be allowed
+        get_response = client.get(
+            "/test-cost-limit/get", headers={"X-Developer-Id": developer_id}
+        )
+
+        # Verify GET response passes through
+        assert get_response.status_code == status.HTTP_200_OK
+        assert get_response.json()["method"] == "GET"
 
 
 @test("middleware: paid tag bypasses cost limit check")
-async def _():
+def _(client=client):
     """Test that users with 'paid' tag can make non-GET requests even when over the cost limit."""
-    # Create mock request
-    mock_request = MagicMock(spec=Request)
-    mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
-    mock_request.method = "POST"  # Use a non-GET method
 
-    # Mock response from get_user_cost with cost exceeding the limit but with paid tag
+    # Create test handlers for different methods
+    @app.post("/test-paid/post")
+    async def test_paid_post(payload: TestPayload):
+        return {"status": "success", "method": "POST", "message": payload.message}
+
+    @app.put("/test-paid-methods/put")
+    async def test_paid_methods_put(payload: TestPayload):
+        return {"status": "success", "method": "PUT", "message": payload.message}
+
+    @app.delete("/test-paid-methods/delete")
+    async def test_paid_methods_delete():
+        return {"status": "success", "method": "DELETE"}
+
+    # Create test data
+    developer_id = str(uuid.uuid4())
     mock_user_cost_data = {
         "active": True,
         "cost": float(free_tier_cost_limit) + 10.0,  # Significantly exceed the cost limit
-        "developer_id": mock_request.headers["X-Developer-Id"],
+        "developer_id": developer_id,
         "tags": ["test", "paid", "other-tag"],  # Include "paid" tag
     }
 
-    # Create a mock response for call_next
-    mock_response = JSONResponse(content={"message": "Success"})
-
     # Mock the get_user_cost function
     with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
-        # Set up mock for call_next
-        mock_call_next = AsyncMock(return_value=mock_response)
+        # Make a POST request that should be allowed due to paid tag
+        response = client.post(
+            "/test-paid/post",
+            json={"message": "test"},
+            headers={"X-Developer-Id": developer_id},
+        )
 
-        # Call the middleware
-        response = await usage_check_middleware(mock_request, mock_call_next)
+        # Verify the request was allowed
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["method"] == "POST"
+        assert response.json()["message"] == "test"
 
-        # Verify call_next was called once - request went through despite cost limit
-        mock_call_next.assert_called_once_with(mock_request)
+        put_response = client.put(
+            "/test-paid-methods/put",
+            json={"message": "test update"},
+            headers={"X-Developer-Id": developer_id},
+        )
 
-        # Verify the original response is returned
-        assert response == mock_response
+        # Verify the PUT request was allowed
+        assert put_response.status_code == status.HTTP_200_OK
+        assert put_response.json()["method"] == "PUT"
+
+        # Make a DELETE request that should be allowed due to paid tag
+        delete_response = client.delete(
+            "/test-paid-methods/delete", headers={"X-Developer-Id": developer_id}
+        )
+
+        # Verify the DELETE request was allowed
+        assert delete_response.status_code == status.HTTP_200_OK
+        assert delete_response.json()["method"] == "DELETE"
 
 
 @test("middleware: GET request with cost limit exceeded passes through")
-async def _():
+def _(client=client):
     """Test that GET requests from users who exceeded cost limits are allowed to proceed."""
-    # Create mock request
-    mock_request = MagicMock(spec=Request)
-    mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
-    mock_request.method = "GET"
 
-    # Mock response from get_user_cost with cost exceeding the limit
+    # Create a test handler
+    @app.get("/test-get-with-cost-limit")
+    async def test_get_with_cost_limit():
+        return {"status": "success", "method": "GET"}
+
+    # Create test data
+    developer_id = str(uuid.uuid4())
     mock_user_cost_data = {
         "active": True,
         "cost": float(free_tier_cost_limit) + 1.0,  # Exceed the cost limit
-        "developer_id": mock_request.headers["X-Developer-Id"],
+        "developer_id": developer_id,
         "tags": [],
     }
 
-    # Create a mock response for call_next
-    mock_response = JSONResponse(content={"message": "Success"})
-
     # Mock the get_user_cost function
     with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
-        # Set up mock for call_next
-        mock_call_next = AsyncMock(return_value=mock_response)
+        # Make a GET request
+        response = client.get(
+            "/test-get-with-cost-limit", headers={"X-Developer-Id": developer_id}
+        )
 
-        # Call the middleware
-        response = await usage_check_middleware(mock_request, mock_call_next)
-
-        # Verify call_next was called once
-        mock_call_next.assert_called_once_with(mock_request)
-
-        # Verify the original response is returned
-        assert response == mock_response
+        # Verify the request was allowed
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["method"] == "GET"
 
 
 @test("middleware: cost is None treats as exceeded limit")
-async def _():
+def _(client=client):
     """Test that non-GET requests with None cost value are treated as exceeding the limit."""
-    # Create mock request
-    mock_request = MagicMock(spec=Request)
-    mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
-    mock_request.method = "POST"  # Use a non-GET method
 
-    # Mock response from get_user_cost with None cost
+    # Create a test handler
+    @app.post("/test-none-cost")
+    async def test_none_cost(payload: TestPayload):
+        return {"status": "success", "method": "POST", "message": payload.message}
+
+    # Create test data
+    developer_id = str(uuid.uuid4())
     mock_user_cost_data = {
         "active": True,
         "cost": None,
-        "developer_id": mock_request.headers["X-Developer-Id"],
+        "developer_id": developer_id,
         "tags": [],
     }
 
     # Mock the get_user_cost function
     with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
-        # Set up mock for call_next
-        mock_call_next = AsyncMock()
-
-        # Call the middleware
-        response = await usage_check_middleware(mock_request, mock_call_next)
-
-        # Verify response is 403 with correct message
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert "Cost limit exceeded" in response.body.decode()
-        assert "cost_limit_exceeded" in response.body.decode()
-
-        # Verify call_next was not called
-        mock_call_next.assert_not_called()
-
-
-@test("middleware: non-list tags handled properly")
-async def _():
-    """Test that users with non-list tags field are handled properly when over cost limit."""
-    # Create mock request
-    mock_request = MagicMock(spec=Request)
-    mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
-    mock_request.method = "POST"  # Use a non-GET method
-
-    # Mock response from get_user_cost with cost exceeding the limit and corrupted tags
-    mock_user_cost_data = {
-        "active": True,
-        "cost": float(free_tier_cost_limit) + 5.0,  # Exceed the cost limit
-        "developer_id": mock_request.headers["X-Developer-Id"],
-        "tags": "corrupted-string-instead-of-list",  # Not a list - should be handled gracefully
-    }
-
-    # Mock the get_user_cost function
-    with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
-        # Set up mock for call_next
-        mock_call_next = AsyncMock()
-
-        # Call the middleware
-        response = await usage_check_middleware(mock_request, mock_call_next)
+        # Make a POST request
+        response = client.post(
+            "/test-none-cost",
+            json={"message": "test"},
+            headers={"X-Developer-Id": developer_id},
+        )
 
         # Verify response is 403 with correct message
         assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert "Cost limit exceeded" in response.body.decode()
-        assert "cost_limit_exceeded" in response.body.decode()
-
-        # Verify call_next was not called
-        mock_call_next.assert_not_called()
+        assert "Cost limit exceeded" in response.text
+        assert "cost_limit_exceeded" in response.text
 
 
 @test("middleware: null tags field handled properly")
-async def _():
-    """Test that users with null tags field are handled properly."""
-    # Create mock request
-    mock_request = MagicMock(spec=Request)
-    mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
-    mock_request.method = "POST"  # Use a non-GET method
+def _(client=client):
+    """Test that users with null tags field are handled properly when over cost limit."""
 
-    # Mock response from get_user_cost with cost exceeding the limit and null tags
+    # Create a test handler
+    @app.post("/test-null-tags")
+    async def test_null_tags(payload: TestPayload):
+        return {"status": "success", "method": "POST", "message": payload.message}
+
+    # Create test data
+    developer_id = str(uuid.uuid4())
     mock_user_cost_data = {
         "active": True,
         "cost": float(free_tier_cost_limit) + 5.0,  # Exceed the cost limit
-        "developer_id": mock_request.headers["X-Developer-Id"],
+        "developer_id": developer_id,
         "tags": None,  # Null field
     }
 
     # Mock the get_user_cost function
     with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
-        # Set up mock for call_next
-        mock_call_next = AsyncMock()
-
-        # Call the middleware
-        response = await usage_check_middleware(mock_request, mock_call_next)
+        # Make a POST request
+        response = client.post(
+            "/test-null-tags",
+            json={"message": "test"},
+            headers={"X-Developer-Id": developer_id},
+        )
 
         # Verify response is 403 with correct message
         assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert "Cost limit exceeded" in response.body.decode()
-        assert "cost_limit_exceeded" in response.body.decode()
-
-        # Verify call_next was not called
-        mock_call_next.assert_not_called()
+        assert "Cost limit exceeded" in response.text
+        assert "cost_limit_exceeded" in response.text
 
 
 @test("middleware: no developer_id header passes through")
-async def _():
+def _(client=client):
     """Test that requests without a developer_id header are allowed to proceed."""
-    # Create mock request with no X-Developer-Id header
-    mock_request = MagicMock(spec=Request)
-    mock_request.headers = Headers({})
 
-    # Create a mock response for call_next
-    mock_response = JSONResponse(content={"message": "Success"})
+    # Create a test handler
+    @app.get("/test-no-developer-id")
+    async def test_no_developer_id():
+        return {"status": "success", "message": "no developer ID needed"}
 
-    # Set up mock for call_next
-    mock_call_next = AsyncMock(return_value=mock_response)
+    # Make request with no developer ID header
+    response = client.get("/test-no-developer-id")
 
-    # Call the middleware
-    response = await usage_check_middleware(mock_request, mock_call_next)
-
-    # Verify call_next was called once
-    mock_call_next.assert_called_once_with(mock_request)
-
-    # Verify the original response is returned
-    assert response == mock_response
+    # Verify the request was allowed
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["message"] == "no developer ID needed"
 
 
 @test("middleware: forbidden, if user is not found")
-async def _():
-    """Test that requests resulting in NoDataFoundError from get_user_cost return 403."""
-    # Create mock request
-    mock_request = MagicMock(spec=Request)
-    mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
+def _(client=client):
+    """Test that requests resulting in NoDataFoundError return 403."""
+
+    # Create a test handler
+    @app.get("/test-user-not-found")
+    async def test_user_not_found():
+        return {"status": "success", "message": "user found"}
+
+    @app.get("/test-404-error")
+    async def test_404_error():
+        return {"status": "success", "message": "no 404 error"}
+
+    # Create a random developer ID
+    developer_id = str(uuid.uuid4())
 
     # Mock the get_user_cost function to raise NoDataFoundError
     with patch(
         "agents_api.web.get_user_cost", new=AsyncMock(side_effect=asyncpg.NoDataFoundError())
     ):
-        # Set up mock for call_next
-        mock_call_next = AsyncMock()
-
-        # Call the middleware
-        response = await usage_check_middleware(mock_request, mock_call_next)
+        # Make request with the developer ID header
+        response = client.get("/test-user-not-found", headers={"X-Developer-Id": developer_id})
 
         # Verify response is 403 with correct message
         assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert "Invalid user account" in response.body.decode()
-        assert "invalid_user_account" in response.body.decode()
+        assert "Invalid user account" in response.text
+        assert "invalid_user_account" in response.text
 
-        # Verify call_next was not called
-        mock_call_next.assert_not_called()
-
+    # Mock the get_user_cost function to raise HTTPException with 404
     http_404_error = HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
     with patch("agents_api.web.get_user_cost", new=AsyncMock(side_effect=http_404_error)):
-        # Set up mock for call_next
-        mock_call_next = AsyncMock()
-
-        # Call the middleware
-        response = await usage_check_middleware(mock_request, mock_call_next)
+        # Make request with the developer ID header
+        response = client.get("/test-404-error", headers={"X-Developer-Id": developer_id})
 
         # Verify response is 403 with correct message
         assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert "Invalid user account" in response.body.decode()
-        assert "invalid_user_account" in response.body.decode()
-
-        # Verify call_next was not called
-        mock_call_next.assert_not_called()
+        assert "Invalid user account" in response.text
+        assert "invalid_user_account" in response.text
 
 
-@test("middleware: non-404 HTTPException returns correct status")
-async def _():
-    """Test that HTTP exceptions other than 404 from get_user_cost return with correct status code."""
-    # Create mock request
-    mock_request = MagicMock(spec=Request)
-    mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
+@test("middleware: hand over all the http errors except of 404")
+def _(client=client):
+    """Test that HTTP exceptions other than 404 return with correct status code."""
+
+    # Create a test handler
+    @app.get("/test-500-error")
+    async def test_500_error():
+        return {"status": "success", "message": "no 500 error"}
+
+    # Create a random developer ID
+    developer_id = str(uuid.uuid4())
 
     # Mock the get_user_cost function to raise HTTPException with 500
     http_500_error = HTTPException(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Server error"
     )
-
     with patch("agents_api.web.get_user_cost", new=AsyncMock(side_effect=http_500_error)):
-        # Set up mock for call_next
-        mock_call_next = AsyncMock()
-
-        # Call the middleware
-        response = await usage_check_middleware(mock_request, mock_call_next)
+        # Make request with the developer ID header
+        response = client.get("/test-500-error", headers={"X-Developer-Id": developer_id})
 
         # Verify the response has the same status code as the exception
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
 
-        # Verify call_next was not called
-        mock_call_next.assert_not_called()
 
-
-@test("middleware: invalid uuid returns 400")
-async def _():
+@test("middleware: invalid uuid returns bad request")
+def _(client=client):
     """Test that requests with invalid UUID return 400 Bad Request."""
-    # Create mock request with invalid UUID
-    mock_request = MagicMock(spec=Request)
-    mock_request.headers = Headers({"X-Developer-Id": "invalid-uuid"})  # Invalid UUID
 
-    # Set up mock for call_next
-    mock_call_next = AsyncMock()
+    # Create a test handler
+    @app.get("/test-invalid-uuid")
+    async def test_invalid_uuid():
+        return {"status": "success", "message": "valid UUID"}
 
-    # Call the middleware
-    response = await usage_check_middleware(mock_request, mock_call_next)
+    # Make request with invalid UUID
+    response = client.get(
+        "/test-invalid-uuid",
+        headers={"X-Developer-Id": "invalid-uuid"},  # Invalid UUID
+    )
 
     # Verify response is 400 with correct message
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert "Invalid developer ID" in response.body.decode()
-    assert "invalid_developer_id" in response.body.decode()
-
-    # Verify call_next was not called
-    mock_call_next.assert_not_called()
-
-
-@test("middleware: other exceptions pass through")
-async def _():
-    """Test that other exceptions in the middleware don't block the request."""
-    # Create mock request
-    mock_request = MagicMock(spec=Request)
-    mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
-
-    # Create a mock response for call_next
-    mock_response = JSONResponse(content={"message": "Success"})
-
-    # Mock the get_user_cost function to raise a different exception
-    with patch(
-        "agents_api.web.get_user_cost", new=AsyncMock(side_effect=KeyError("Unexpected error"))
-    ):
-        # Set up mock for call_next
-        mock_call_next = AsyncMock(return_value=mock_response)
-
-        # We'll also mock logger.error to verify it's called
-        with patch("agents_api.web.logger.error") as mock_logger_error:
-            # Call the middleware
-            response = await usage_check_middleware(mock_request, mock_call_next)
-
-            # Verify logger.error was called
-            mock_logger_error.assert_called_once()
-
-            # Verify call_next was called once
-            mock_call_next.assert_called_once_with(mock_request)
-
-            # Verify the original response is returned
-            assert response == mock_response
+    assert "Invalid developer ID" in response.text
+    assert "invalid_developer_id" in response.text
 
 
 @test("middleware: valid user passes through")
-async def _():
+def _(client=client):
     """Test that requests from valid users are allowed to proceed."""
-    # Create mock request
-    mock_request = MagicMock(spec=Request)
-    mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
-    mock_request.method = "POST"
 
-    # Mock response from get_user_cost
+    # Create a test handler
+    @app.get("/test-valid-user")
+    async def test_valid_user():
+        return {"status": "success", "message": "valid user"}
+
+    # Create test data
+    developer_id = str(uuid.uuid4())
     mock_user_cost_data = {
         "active": True,
         "cost": 0.0,  # Below the limit
-        "developer_id": mock_request.headers["X-Developer-Id"],
+        "developer_id": developer_id,
         "tags": [],
     }
 
-    # Create a mock response for call_next
-    mock_response = JSONResponse(content={"message": "Success"})
-
     # Mock the get_user_cost function
     with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
-        # Set up mock for call_next
-        mock_call_next = AsyncMock(return_value=mock_response)
+        # Make request with the developer ID header
+        response = client.get("/test-valid-user", headers={"X-Developer-Id": developer_id})
 
-        # Call the middleware
-        response = await usage_check_middleware(mock_request, mock_call_next)
-
-        # Verify call_next was called once
-        mock_call_next.assert_called_once_with(mock_request)
-
-        # Verify the original response is returned
-        assert response == mock_response
+        # Verify the request was allowed
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["message"] == "valid user"

--- a/agents-api/tests/test_middleware.py
+++ b/agents-api/tests/test_middleware.py
@@ -1,0 +1,456 @@
+"""
+Tests for HTTP middleware, specifically the usage_check_middleware
+"""
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import asyncpg
+import pytest
+from fastapi import HTTPException, Request, status
+from fastapi.responses import JSONResponse
+from starlette.datastructures import Headers
+from ward import test
+
+from agents_api.env import free_tier_cost_limit
+from agents_api.web import usage_check_middleware
+
+
+@test("middleware: inactive free user receives forbidden response")
+async def _():
+    """Test that requests from inactive users are blocked with 403 Forbidden."""
+    # Create mock request
+    mock_request = MagicMock(spec=Request)
+    mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
+    mock_request.method = "GET"
+    
+    # Mock response from get_user_cost
+    mock_user_cost_data = {
+        "active": False,
+        "cost": 0.0,
+        "developer_id": mock_request.headers["X-Developer-Id"],
+        "tags": []
+    }
+    
+    # Mock the get_user_cost function
+    with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+        # Set up mock for call_next
+        mock_call_next = AsyncMock()
+        
+        # Call the middleware
+        response = await usage_check_middleware(mock_request, mock_call_next)
+        
+        # Verify response is 403 with correct message
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "Invalid user account" in response.body.decode()
+        assert "invalid_user_account" in response.body.decode()
+        
+        # Verify call_next was not called
+        mock_call_next.assert_not_called()
+
+
+@test("middleware: inactive paid user receives forbidden response")
+async def _():
+    """Test that requests from inactive users are blocked with 403 Forbidden."""
+    # Create mock request
+    mock_request = MagicMock(spec=Request)
+    mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
+    mock_request.method = "GET"
+    
+    # Mock response from get_user_cost
+    mock_user_cost_data = {
+        "active": False,
+        "cost": 0.0,
+        "developer_id": mock_request.headers["X-Developer-Id"],
+        "tags": []
+    }
+    
+    # Mock the get_user_cost function
+    with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+        # Set up mock for call_next
+        mock_call_next = AsyncMock()
+        
+        # Call the middleware
+        response = await usage_check_middleware(mock_request, mock_call_next)
+        
+        # Verify response is 403 with correct message
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "Invalid user account" in response.body.decode()
+        assert "invalid_user_account" in response.body.decode()
+        
+        # Verify call_next was not called
+        mock_call_next.assert_not_called()
+
+
+@test("middleware: cost limit exceeded, all requests blocked except GET")
+async def _():
+    """Test that non-GET requests from users who exceeded cost limits are blocked with 403 Forbidden."""
+    # Create mock request
+    mock_request = MagicMock(spec=Request)
+    mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
+    mock_request.method = "POST"  # Use a non-GET method
+    
+    # Mock response from get_user_cost with cost exceeding the limit
+    mock_user_cost_data = {
+        "active": True,
+        "cost": float(free_tier_cost_limit) + 1.0,  # Exceed the cost limit
+        "developer_id": mock_request.headers["X-Developer-Id"],
+        "tags": []
+    }
+    
+    # Mock the get_user_cost function
+    with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+        # Set up mock for call_next
+        mock_call_next = AsyncMock()
+        
+        # Call the middleware
+        response = await usage_check_middleware(mock_request, mock_call_next)
+        
+        # Verify response is 403 with correct message
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "Cost limit exceeded" in response.body.decode()
+        assert "cost_limit_exceeded" in response.body.decode()
+        
+        # Verify call_next was not called
+        mock_call_next.assert_not_called()
+
+
+@test("middleware: paid tag bypasses cost limit check")
+async def _():
+    """Test that users with 'paid' tag can make non-GET requests even when over the cost limit."""
+    # Create mock request
+    mock_request = MagicMock(spec=Request)
+    mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
+    mock_request.method = "POST"  # Use a non-GET method
+    
+    # Mock response from get_user_cost with cost exceeding the limit but with paid tag
+    mock_user_cost_data = {
+        "active": True,
+        "cost": float(free_tier_cost_limit) + 10.0,  # Significantly exceed the cost limit
+        "developer_id": mock_request.headers["X-Developer-Id"],
+        "tags": ["test", "paid", "other-tag"]  # Include "paid" tag
+    }
+    
+    # Create a mock response for call_next
+    mock_response = JSONResponse(content={"message": "Success"})
+    
+    # Mock the get_user_cost function
+    with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+        # Set up mock for call_next
+        mock_call_next = AsyncMock(return_value=mock_response)
+        
+        # Call the middleware
+        response = await usage_check_middleware(mock_request, mock_call_next)
+        
+        # Verify call_next was called once - request went through despite cost limit
+        mock_call_next.assert_called_once_with(mock_request)
+        
+        # Verify the original response is returned
+        assert response == mock_response
+
+
+@test("middleware: GET request with cost limit exceeded passes through")
+async def _():
+    """Test that GET requests from users who exceeded cost limits are allowed to proceed."""
+    # Create mock request
+    mock_request = MagicMock(spec=Request)
+    mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
+    mock_request.method = "GET"
+    
+    # Mock response from get_user_cost with cost exceeding the limit
+    mock_user_cost_data = {
+        "active": True,
+        "cost": float(free_tier_cost_limit) + 1.0,  # Exceed the cost limit
+        "developer_id": mock_request.headers["X-Developer-Id"],
+        "tags": []
+    }
+    
+    # Create a mock response for call_next
+    mock_response = JSONResponse(content={"message": "Success"})
+    
+    # Mock the get_user_cost function
+    with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+        # Set up mock for call_next
+        mock_call_next = AsyncMock(return_value=mock_response)
+        
+        # Call the middleware
+        response = await usage_check_middleware(mock_request, mock_call_next)
+        
+        # Verify call_next was called once
+        mock_call_next.assert_called_once_with(mock_request)
+        
+        # Verify the original response is returned
+        assert response == mock_response
+
+
+@test("middleware: cost is None treats as exceeded limit")
+async def _():
+    """Test that non-GET requests with None cost value are treated as exceeding the limit."""
+    # Create mock request
+    mock_request = MagicMock(spec=Request)
+    mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
+    mock_request.method = "POST"  # Use a non-GET method
+    
+    # Mock response from get_user_cost with None cost
+    mock_user_cost_data = {
+        "active": True,
+        "cost": None,
+        "developer_id": mock_request.headers["X-Developer-Id"],
+        "tags": []
+    }
+    
+    # Mock the get_user_cost function
+    with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+        # Set up mock for call_next
+        mock_call_next = AsyncMock()
+        
+        # Call the middleware
+        response = await usage_check_middleware(mock_request, mock_call_next)
+        
+        # Verify response is 403 with correct message
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "Cost limit exceeded" in response.body.decode()
+        assert "cost_limit_exceeded" in response.body.decode()
+        
+        # Verify call_next was not called
+        mock_call_next.assert_not_called()
+
+
+@test("middleware: non-list tags handled properly")
+async def _():
+    """Test that users with non-list tags field are handled properly when over cost limit."""
+    # Create mock request
+    mock_request = MagicMock(spec=Request)
+    mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
+    mock_request.method = "POST"  # Use a non-GET method
+    
+    # Mock response from get_user_cost with cost exceeding the limit and corrupted tags
+    mock_user_cost_data = {
+        "active": True,
+        "cost": float(free_tier_cost_limit) + 5.0,  # Exceed the cost limit
+        "developer_id": mock_request.headers["X-Developer-Id"],
+        "tags": "corrupted-string-instead-of-list"  # Not a list - should be handled gracefully
+    }
+    
+    # Mock the get_user_cost function
+    with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+        # Set up mock for call_next
+        mock_call_next = AsyncMock()
+        
+        # Call the middleware
+        response = await usage_check_middleware(mock_request, mock_call_next)
+        
+        # Verify response is 403 with correct message
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "Cost limit exceeded" in response.body.decode()
+        assert "cost_limit_exceeded" in response.body.decode()
+        
+        # Verify call_next was not called
+        mock_call_next.assert_not_called()
+
+
+@test("middleware: null tags field handled properly")
+async def _():
+    """Test that users with null tags field are handled properly."""
+    # Create mock request
+    mock_request = MagicMock(spec=Request)
+    mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
+    mock_request.method = "POST"  # Use a non-GET method
+    
+    # Mock response from get_user_cost with cost exceeding the limit and null tags
+    mock_user_cost_data = {
+        "active": True,
+        "cost": float(free_tier_cost_limit) + 5.0,  # Exceed the cost limit
+        "developer_id": mock_request.headers["X-Developer-Id"],
+        "tags": None  # Null field
+    }
+    
+    # Mock the get_user_cost function
+    with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+        # Set up mock for call_next
+        mock_call_next = AsyncMock()
+        
+        # Call the middleware
+        response = await usage_check_middleware(mock_request, mock_call_next)
+        
+        # Verify response is 403 with correct message
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "Cost limit exceeded" in response.body.decode()
+        assert "cost_limit_exceeded" in response.body.decode()
+        
+        # Verify call_next was not called
+        mock_call_next.assert_not_called()
+
+
+@test("middleware: no developer_id header passes through")
+async def _():
+    """Test that requests without a developer_id header are allowed to proceed."""
+    # Create mock request with no X-Developer-Id header
+    mock_request = MagicMock(spec=Request)
+    mock_request.headers = Headers({})
+    
+    # Create a mock response for call_next
+    mock_response = JSONResponse(content={"message": "Success"})
+    
+    # Set up mock for call_next
+    mock_call_next = AsyncMock(return_value=mock_response)
+    
+    # Call the middleware
+    response = await usage_check_middleware(mock_request, mock_call_next)
+    
+    # Verify call_next was called once
+    mock_call_next.assert_called_once_with(mock_request)
+    
+    # Verify the original response is returned
+    assert response == mock_response
+
+
+@test("middleware: forbidden, if user is not found")
+async def _():
+    """Test that requests resulting in NoDataFoundError from get_user_cost return 403."""
+    # Create mock request
+    mock_request = MagicMock(spec=Request)
+    mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
+    
+    # Mock the get_user_cost function to raise NoDataFoundError
+    with patch("agents_api.web.get_user_cost", new=AsyncMock(side_effect=asyncpg.NoDataFoundError())):
+        # Set up mock for call_next
+        mock_call_next = AsyncMock()
+        
+        # Call the middleware
+        response = await usage_check_middleware(mock_request, mock_call_next)
+        
+        # Verify response is 403 with correct message
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "Invalid user account" in response.body.decode()
+        assert "invalid_user_account" in response.body.decode()
+        
+        # Verify call_next was not called
+        mock_call_next.assert_not_called()
+    
+    http_404_error = HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    with patch("agents_api.web.get_user_cost", new=AsyncMock(side_effect=http_404_error)):
+        # Set up mock for call_next
+        mock_call_next = AsyncMock()
+        
+        # Call the middleware
+        response = await usage_check_middleware(mock_request, mock_call_next)
+        
+        # Verify response is 403 with correct message
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "Invalid user account" in response.body.decode()
+        assert "invalid_user_account" in response.body.decode()
+        
+        # Verify call_next was not called
+        mock_call_next.assert_not_called()
+
+
+@test("middleware: non-404 HTTPException returns correct status")
+async def _():
+    """Test that HTTP exceptions other than 404 from get_user_cost return with correct status code."""
+    # Create mock request
+    mock_request = MagicMock(spec=Request)
+    mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
+    
+    # Mock the get_user_cost function to raise HTTPException with 500
+    http_500_error = HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Server error")
+    
+    with patch("agents_api.web.get_user_cost", new=AsyncMock(side_effect=http_500_error)):
+        # Set up mock for call_next
+        mock_call_next = AsyncMock()
+        
+        # Call the middleware
+        response = await usage_check_middleware(mock_request, mock_call_next)
+        
+        # Verify the response has the same status code as the exception
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        
+        # Verify call_next was not called
+        mock_call_next.assert_not_called()
+
+
+@test("middleware: invalid uuid returns 400")
+async def _():
+    """Test that requests with invalid UUID return 400 Bad Request."""
+    # Create mock request with invalid UUID
+    mock_request = MagicMock(spec=Request)
+    mock_request.headers = Headers({"X-Developer-Id": "invalid-uuid"})  # Invalid UUID
+    
+    # Set up mock for call_next
+    mock_call_next = AsyncMock()
+    
+    # Call the middleware
+    response = await usage_check_middleware(mock_request, mock_call_next)
+    
+    # Verify response is 400 with correct message
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Invalid developer ID" in response.body.decode()
+    assert "invalid_developer_id" in response.body.decode()
+    
+    # Verify call_next was not called
+    mock_call_next.assert_not_called()
+
+
+@test("middleware: other exceptions pass through")
+async def _():
+    """Test that other exceptions in the middleware don't block the request."""
+    # Create mock request
+    mock_request = MagicMock(spec=Request)
+    mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
+    
+    # Create a mock response for call_next
+    mock_response = JSONResponse(content={"message": "Success"})
+    
+    # Mock the get_user_cost function to raise a different exception
+    with patch("agents_api.web.get_user_cost", new=AsyncMock(side_effect=KeyError("Unexpected error"))):
+        # Set up mock for call_next
+        mock_call_next = AsyncMock(return_value=mock_response)
+        
+        # We'll also mock logger.error to verify it's called
+        with patch("agents_api.web.logger.error") as mock_logger_error:
+            # Call the middleware
+            response = await usage_check_middleware(mock_request, mock_call_next)
+            
+            # Verify logger.error was called
+            mock_logger_error.assert_called_once()
+            
+            # Verify call_next was called once
+            mock_call_next.assert_called_once_with(mock_request)
+            
+            # Verify the original response is returned
+            assert response == mock_response
+
+
+@test("middleware: valid user passes through")
+async def _():
+    """Test that requests from valid users are allowed to proceed."""
+    # Create mock request
+    mock_request = MagicMock(spec=Request)
+    mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
+    mock_request.method = "POST"
+    
+    # Mock response from get_user_cost
+    mock_user_cost_data = {
+        "active": True,
+        "cost": 0.0,  # Below the limit
+        "developer_id": mock_request.headers["X-Developer-Id"],
+        "tags": []
+    }
+    
+    # Create a mock response for call_next
+    mock_response = JSONResponse(content={"message": "Success"})
+    
+    # Mock the get_user_cost function
+    with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+        # Set up mock for call_next
+        mock_call_next = AsyncMock(return_value=mock_response)
+        
+        # Call the middleware
+        response = await usage_check_middleware(mock_request, mock_call_next)
+        
+        # Verify call_next was called once
+        mock_call_next.assert_called_once_with(mock_request)
+        
+        # Verify the original response is returned
+        assert response == mock_response 

--- a/agents-api/tests/test_middleware.py
+++ b/agents-api/tests/test_middleware.py
@@ -2,19 +2,16 @@
 Tests for HTTP middleware, specifically the usage_check_middleware
 """
 
-import asyncio
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import asyncpg
-import pytest
+from agents_api.env import free_tier_cost_limit
+from agents_api.web import usage_check_middleware
 from fastapi import HTTPException, Request, status
 from fastapi.responses import JSONResponse
 from starlette.datastructures import Headers
 from ward import test
-
-from agents_api.env import free_tier_cost_limit
-from agents_api.web import usage_check_middleware
 
 
 @test("middleware: inactive free user receives forbidden response")
@@ -24,28 +21,28 @@ async def _():
     mock_request = MagicMock(spec=Request)
     mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
     mock_request.method = "GET"
-    
+
     # Mock response from get_user_cost
     mock_user_cost_data = {
         "active": False,
         "cost": 0.0,
         "developer_id": mock_request.headers["X-Developer-Id"],
-        "tags": []
+        "tags": [],
     }
-    
+
     # Mock the get_user_cost function
     with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
         # Set up mock for call_next
         mock_call_next = AsyncMock()
-        
+
         # Call the middleware
         response = await usage_check_middleware(mock_request, mock_call_next)
-        
+
         # Verify response is 403 with correct message
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert "Invalid user account" in response.body.decode()
         assert "invalid_user_account" in response.body.decode()
-        
+
         # Verify call_next was not called
         mock_call_next.assert_not_called()
 
@@ -57,28 +54,28 @@ async def _():
     mock_request = MagicMock(spec=Request)
     mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
     mock_request.method = "GET"
-    
+
     # Mock response from get_user_cost
     mock_user_cost_data = {
         "active": False,
         "cost": 0.0,
         "developer_id": mock_request.headers["X-Developer-Id"],
-        "tags": []
+        "tags": [],
     }
-    
+
     # Mock the get_user_cost function
     with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
         # Set up mock for call_next
         mock_call_next = AsyncMock()
-        
+
         # Call the middleware
         response = await usage_check_middleware(mock_request, mock_call_next)
-        
+
         # Verify response is 403 with correct message
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert "Invalid user account" in response.body.decode()
         assert "invalid_user_account" in response.body.decode()
-        
+
         # Verify call_next was not called
         mock_call_next.assert_not_called()
 
@@ -90,28 +87,28 @@ async def _():
     mock_request = MagicMock(spec=Request)
     mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
     mock_request.method = "POST"  # Use a non-GET method
-    
+
     # Mock response from get_user_cost with cost exceeding the limit
     mock_user_cost_data = {
         "active": True,
         "cost": float(free_tier_cost_limit) + 1.0,  # Exceed the cost limit
         "developer_id": mock_request.headers["X-Developer-Id"],
-        "tags": []
+        "tags": [],
     }
-    
+
     # Mock the get_user_cost function
     with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
         # Set up mock for call_next
         mock_call_next = AsyncMock()
-        
+
         # Call the middleware
         response = await usage_check_middleware(mock_request, mock_call_next)
-        
+
         # Verify response is 403 with correct message
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert "Cost limit exceeded" in response.body.decode()
         assert "cost_limit_exceeded" in response.body.decode()
-        
+
         # Verify call_next was not called
         mock_call_next.assert_not_called()
 
@@ -123,29 +120,29 @@ async def _():
     mock_request = MagicMock(spec=Request)
     mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
     mock_request.method = "POST"  # Use a non-GET method
-    
+
     # Mock response from get_user_cost with cost exceeding the limit but with paid tag
     mock_user_cost_data = {
         "active": True,
         "cost": float(free_tier_cost_limit) + 10.0,  # Significantly exceed the cost limit
         "developer_id": mock_request.headers["X-Developer-Id"],
-        "tags": ["test", "paid", "other-tag"]  # Include "paid" tag
+        "tags": ["test", "paid", "other-tag"],  # Include "paid" tag
     }
-    
+
     # Create a mock response for call_next
     mock_response = JSONResponse(content={"message": "Success"})
-    
+
     # Mock the get_user_cost function
     with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
         # Set up mock for call_next
         mock_call_next = AsyncMock(return_value=mock_response)
-        
+
         # Call the middleware
         response = await usage_check_middleware(mock_request, mock_call_next)
-        
+
         # Verify call_next was called once - request went through despite cost limit
         mock_call_next.assert_called_once_with(mock_request)
-        
+
         # Verify the original response is returned
         assert response == mock_response
 
@@ -157,29 +154,29 @@ async def _():
     mock_request = MagicMock(spec=Request)
     mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
     mock_request.method = "GET"
-    
+
     # Mock response from get_user_cost with cost exceeding the limit
     mock_user_cost_data = {
         "active": True,
         "cost": float(free_tier_cost_limit) + 1.0,  # Exceed the cost limit
         "developer_id": mock_request.headers["X-Developer-Id"],
-        "tags": []
+        "tags": [],
     }
-    
+
     # Create a mock response for call_next
     mock_response = JSONResponse(content={"message": "Success"})
-    
+
     # Mock the get_user_cost function
     with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
         # Set up mock for call_next
         mock_call_next = AsyncMock(return_value=mock_response)
-        
+
         # Call the middleware
         response = await usage_check_middleware(mock_request, mock_call_next)
-        
+
         # Verify call_next was called once
         mock_call_next.assert_called_once_with(mock_request)
-        
+
         # Verify the original response is returned
         assert response == mock_response
 
@@ -191,28 +188,28 @@ async def _():
     mock_request = MagicMock(spec=Request)
     mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
     mock_request.method = "POST"  # Use a non-GET method
-    
+
     # Mock response from get_user_cost with None cost
     mock_user_cost_data = {
         "active": True,
         "cost": None,
         "developer_id": mock_request.headers["X-Developer-Id"],
-        "tags": []
+        "tags": [],
     }
-    
+
     # Mock the get_user_cost function
     with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
         # Set up mock for call_next
         mock_call_next = AsyncMock()
-        
+
         # Call the middleware
         response = await usage_check_middleware(mock_request, mock_call_next)
-        
+
         # Verify response is 403 with correct message
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert "Cost limit exceeded" in response.body.decode()
         assert "cost_limit_exceeded" in response.body.decode()
-        
+
         # Verify call_next was not called
         mock_call_next.assert_not_called()
 
@@ -224,28 +221,28 @@ async def _():
     mock_request = MagicMock(spec=Request)
     mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
     mock_request.method = "POST"  # Use a non-GET method
-    
+
     # Mock response from get_user_cost with cost exceeding the limit and corrupted tags
     mock_user_cost_data = {
         "active": True,
         "cost": float(free_tier_cost_limit) + 5.0,  # Exceed the cost limit
         "developer_id": mock_request.headers["X-Developer-Id"],
-        "tags": "corrupted-string-instead-of-list"  # Not a list - should be handled gracefully
+        "tags": "corrupted-string-instead-of-list",  # Not a list - should be handled gracefully
     }
-    
+
     # Mock the get_user_cost function
     with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
         # Set up mock for call_next
         mock_call_next = AsyncMock()
-        
+
         # Call the middleware
         response = await usage_check_middleware(mock_request, mock_call_next)
-        
+
         # Verify response is 403 with correct message
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert "Cost limit exceeded" in response.body.decode()
         assert "cost_limit_exceeded" in response.body.decode()
-        
+
         # Verify call_next was not called
         mock_call_next.assert_not_called()
 
@@ -257,28 +254,28 @@ async def _():
     mock_request = MagicMock(spec=Request)
     mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
     mock_request.method = "POST"  # Use a non-GET method
-    
+
     # Mock response from get_user_cost with cost exceeding the limit and null tags
     mock_user_cost_data = {
         "active": True,
         "cost": float(free_tier_cost_limit) + 5.0,  # Exceed the cost limit
         "developer_id": mock_request.headers["X-Developer-Id"],
-        "tags": None  # Null field
+        "tags": None,  # Null field
     }
-    
+
     # Mock the get_user_cost function
     with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
         # Set up mock for call_next
         mock_call_next = AsyncMock()
-        
+
         # Call the middleware
         response = await usage_check_middleware(mock_request, mock_call_next)
-        
+
         # Verify response is 403 with correct message
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert "Cost limit exceeded" in response.body.decode()
         assert "cost_limit_exceeded" in response.body.decode()
-        
+
         # Verify call_next was not called
         mock_call_next.assert_not_called()
 
@@ -289,19 +286,19 @@ async def _():
     # Create mock request with no X-Developer-Id header
     mock_request = MagicMock(spec=Request)
     mock_request.headers = Headers({})
-    
+
     # Create a mock response for call_next
     mock_response = JSONResponse(content={"message": "Success"})
-    
+
     # Set up mock for call_next
     mock_call_next = AsyncMock(return_value=mock_response)
-    
+
     # Call the middleware
     response = await usage_check_middleware(mock_request, mock_call_next)
-    
+
     # Verify call_next was called once
     mock_call_next.assert_called_once_with(mock_request)
-    
+
     # Verify the original response is returned
     assert response == mock_response
 
@@ -312,36 +309,38 @@ async def _():
     # Create mock request
     mock_request = MagicMock(spec=Request)
     mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
-    
+
     # Mock the get_user_cost function to raise NoDataFoundError
-    with patch("agents_api.web.get_user_cost", new=AsyncMock(side_effect=asyncpg.NoDataFoundError())):
+    with patch(
+        "agents_api.web.get_user_cost", new=AsyncMock(side_effect=asyncpg.NoDataFoundError())
+    ):
         # Set up mock for call_next
         mock_call_next = AsyncMock()
-        
+
         # Call the middleware
         response = await usage_check_middleware(mock_request, mock_call_next)
-        
+
         # Verify response is 403 with correct message
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert "Invalid user account" in response.body.decode()
         assert "invalid_user_account" in response.body.decode()
-        
+
         # Verify call_next was not called
         mock_call_next.assert_not_called()
-    
+
     http_404_error = HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
     with patch("agents_api.web.get_user_cost", new=AsyncMock(side_effect=http_404_error)):
         # Set up mock for call_next
         mock_call_next = AsyncMock()
-        
+
         # Call the middleware
         response = await usage_check_middleware(mock_request, mock_call_next)
-        
+
         # Verify response is 403 with correct message
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert "Invalid user account" in response.body.decode()
         assert "invalid_user_account" in response.body.decode()
-        
+
         # Verify call_next was not called
         mock_call_next.assert_not_called()
 
@@ -352,20 +351,22 @@ async def _():
     # Create mock request
     mock_request = MagicMock(spec=Request)
     mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
-    
+
     # Mock the get_user_cost function to raise HTTPException with 500
-    http_500_error = HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Server error")
-    
+    http_500_error = HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Server error"
+    )
+
     with patch("agents_api.web.get_user_cost", new=AsyncMock(side_effect=http_500_error)):
         # Set up mock for call_next
         mock_call_next = AsyncMock()
-        
+
         # Call the middleware
         response = await usage_check_middleware(mock_request, mock_call_next)
-        
+
         # Verify the response has the same status code as the exception
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-        
+
         # Verify call_next was not called
         mock_call_next.assert_not_called()
 
@@ -376,18 +377,18 @@ async def _():
     # Create mock request with invalid UUID
     mock_request = MagicMock(spec=Request)
     mock_request.headers = Headers({"X-Developer-Id": "invalid-uuid"})  # Invalid UUID
-    
+
     # Set up mock for call_next
     mock_call_next = AsyncMock()
-    
+
     # Call the middleware
     response = await usage_check_middleware(mock_request, mock_call_next)
-    
+
     # Verify response is 400 with correct message
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert "Invalid developer ID" in response.body.decode()
     assert "invalid_developer_id" in response.body.decode()
-    
+
     # Verify call_next was not called
     mock_call_next.assert_not_called()
 
@@ -398,26 +399,28 @@ async def _():
     # Create mock request
     mock_request = MagicMock(spec=Request)
     mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
-    
+
     # Create a mock response for call_next
     mock_response = JSONResponse(content={"message": "Success"})
-    
+
     # Mock the get_user_cost function to raise a different exception
-    with patch("agents_api.web.get_user_cost", new=AsyncMock(side_effect=KeyError("Unexpected error"))):
+    with patch(
+        "agents_api.web.get_user_cost", new=AsyncMock(side_effect=KeyError("Unexpected error"))
+    ):
         # Set up mock for call_next
         mock_call_next = AsyncMock(return_value=mock_response)
-        
+
         # We'll also mock logger.error to verify it's called
         with patch("agents_api.web.logger.error") as mock_logger_error:
             # Call the middleware
             response = await usage_check_middleware(mock_request, mock_call_next)
-            
+
             # Verify logger.error was called
             mock_logger_error.assert_called_once()
-            
+
             # Verify call_next was called once
             mock_call_next.assert_called_once_with(mock_request)
-            
+
             # Verify the original response is returned
             assert response == mock_response
 
@@ -429,28 +432,28 @@ async def _():
     mock_request = MagicMock(spec=Request)
     mock_request.headers = Headers({"X-Developer-Id": str(uuid.uuid4())})
     mock_request.method = "POST"
-    
+
     # Mock response from get_user_cost
     mock_user_cost_data = {
         "active": True,
         "cost": 0.0,  # Below the limit
         "developer_id": mock_request.headers["X-Developer-Id"],
-        "tags": []
+        "tags": [],
     }
-    
+
     # Create a mock response for call_next
     mock_response = JSONResponse(content={"message": "Success"})
-    
+
     # Mock the get_user_cost function
     with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
         # Set up mock for call_next
         mock_call_next = AsyncMock(return_value=mock_response)
-        
+
         # Call the middleware
         response = await usage_check_middleware(mock_request, mock_call_next)
-        
+
         # Verify call_next was called once
         mock_call_next.assert_called_once_with(mock_request)
-        
+
         # Verify the original response is returned
-        assert response == mock_response 
+        assert response == mock_response

--- a/agents-api/tests/test_middleware.py
+++ b/agents-api/tests/test_middleware.py
@@ -46,7 +46,7 @@ async def _(client=client):
     }
 
     # Mock the get_user_cost function
-    with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+    with patch("agents_api.web.get_usage_cost", new=AsyncMock(return_value=mock_user_cost_data)):
         # Make request with the developer ID header
         response = client.get("/test-inactive-user", headers={"X-Developer-Id": developer_id})
 
@@ -75,7 +75,7 @@ def _(client=client):
     }
 
     # Mock the get_user_cost function
-    with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+    with patch("agents_api.web.get_usage_cost", new=AsyncMock(return_value=mock_user_cost_data)):
         # Make request with the developer ID header
         response = client.get(
             "/test-inactive-paid-user", headers={"X-Developer-Id": developer_id}
@@ -118,7 +118,7 @@ def _(client=client):
     }
 
     # Mock the get_user_cost function
-    with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+    with patch("agents_api.web.get_usage_cost", new=AsyncMock(return_value=mock_user_cost_data)):
         # Make a POST request that should be blocked
         post_response = client.post(
             "/test-cost-limit/post",
@@ -189,7 +189,7 @@ def _(client=client):
     }
 
     # Mock the get_user_cost function
-    with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+    with patch("agents_api.web.get_usage_cost", new=AsyncMock(return_value=mock_user_cost_data)):
         # Make a POST request that should be allowed due to paid tag
         response = client.post(
             "/test-paid/post",
@@ -241,7 +241,7 @@ def _(client=client):
     }
 
     # Mock the get_user_cost function
-    with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+    with patch("agents_api.web.get_usage_cost", new=AsyncMock(return_value=mock_user_cost_data)):
         # Make a GET request
         response = client.get(
             "/test-get-with-cost-limit", headers={"X-Developer-Id": developer_id}
@@ -271,7 +271,7 @@ def _(client=client):
     }
 
     # Mock the get_user_cost function
-    with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+    with patch("agents_api.web.get_usage_cost", new=AsyncMock(return_value=mock_user_cost_data)):
         # Make a POST request
         response = client.post(
             "/test-none-cost",
@@ -304,7 +304,7 @@ def _(client=client):
     }
 
     # Mock the get_user_cost function
-    with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+    with patch("agents_api.web.get_usage_cost", new=AsyncMock(return_value=mock_user_cost_data)):
         # Make a POST request
         response = client.post(
             "/test-null-tags",
@@ -353,7 +353,7 @@ def _(client=client):
 
     # Mock the get_user_cost function to raise NoDataFoundError
     with patch(
-        "agents_api.web.get_user_cost", new=AsyncMock(side_effect=asyncpg.NoDataFoundError())
+        "agents_api.web.get_usage_cost", new=AsyncMock(side_effect=asyncpg.NoDataFoundError())
     ):
         # Make request with the developer ID header
         response = client.get("/test-user-not-found", headers={"X-Developer-Id": developer_id})
@@ -365,7 +365,7 @@ def _(client=client):
 
     # Mock the get_user_cost function to raise HTTPException with 404
     http_404_error = HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
-    with patch("agents_api.web.get_user_cost", new=AsyncMock(side_effect=http_404_error)):
+    with patch("agents_api.web.get_usage_cost", new=AsyncMock(side_effect=http_404_error)):
         # Make request with the developer ID header
         response = client.get("/test-404-error", headers={"X-Developer-Id": developer_id})
 
@@ -391,7 +391,7 @@ def _(client=client):
     http_500_error = HTTPException(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Server error"
     )
-    with patch("agents_api.web.get_user_cost", new=AsyncMock(side_effect=http_500_error)):
+    with patch("agents_api.web.get_usage_cost", new=AsyncMock(side_effect=http_500_error)):
         # Make request with the developer ID header
         response = client.get("/test-500-error", headers={"X-Developer-Id": developer_id})
 
@@ -439,7 +439,7 @@ def _(client=client):
     }
 
     # Mock the get_user_cost function
-    with patch("agents_api.web.get_user_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+    with patch("agents_api.web.get_usage_cost", new=AsyncMock(return_value=mock_user_cost_data)):
         # Make request with the developer ID header
         response = client.get("/test-valid-user", headers={"X-Developer-Id": developer_id})
 

--- a/agents-api/tests/test_middleware.py
+++ b/agents-api/tests/test_middleware.py
@@ -46,7 +46,9 @@ async def _(client=client):
     }
 
     # Mock the get_user_cost function
-    with patch("agents_api.web.get_usage_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+    with patch(
+        "agents_api.web.get_usage_cost", new=AsyncMock(return_value=mock_user_cost_data)
+    ):
         # Make request with the developer ID header
         response = client.get("/test-inactive-user", headers={"X-Developer-Id": developer_id})
 
@@ -75,7 +77,9 @@ def _(client=client):
     }
 
     # Mock the get_user_cost function
-    with patch("agents_api.web.get_usage_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+    with patch(
+        "agents_api.web.get_usage_cost", new=AsyncMock(return_value=mock_user_cost_data)
+    ):
         # Make request with the developer ID header
         response = client.get(
             "/test-inactive-paid-user", headers={"X-Developer-Id": developer_id}
@@ -118,7 +122,9 @@ def _(client=client):
     }
 
     # Mock the get_user_cost function
-    with patch("agents_api.web.get_usage_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+    with patch(
+        "agents_api.web.get_usage_cost", new=AsyncMock(return_value=mock_user_cost_data)
+    ):
         # Make a POST request that should be blocked
         post_response = client.post(
             "/test-cost-limit/post",
@@ -189,7 +195,9 @@ def _(client=client):
     }
 
     # Mock the get_user_cost function
-    with patch("agents_api.web.get_usage_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+    with patch(
+        "agents_api.web.get_usage_cost", new=AsyncMock(return_value=mock_user_cost_data)
+    ):
         # Make a POST request that should be allowed due to paid tag
         response = client.post(
             "/test-paid/post",
@@ -241,7 +249,9 @@ def _(client=client):
     }
 
     # Mock the get_user_cost function
-    with patch("agents_api.web.get_usage_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+    with patch(
+        "agents_api.web.get_usage_cost", new=AsyncMock(return_value=mock_user_cost_data)
+    ):
         # Make a GET request
         response = client.get(
             "/test-get-with-cost-limit", headers={"X-Developer-Id": developer_id}
@@ -271,7 +281,9 @@ def _(client=client):
     }
 
     # Mock the get_user_cost function
-    with patch("agents_api.web.get_usage_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+    with patch(
+        "agents_api.web.get_usage_cost", new=AsyncMock(return_value=mock_user_cost_data)
+    ):
         # Make a POST request
         response = client.post(
             "/test-none-cost",
@@ -304,7 +316,9 @@ def _(client=client):
     }
 
     # Mock the get_user_cost function
-    with patch("agents_api.web.get_usage_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+    with patch(
+        "agents_api.web.get_usage_cost", new=AsyncMock(return_value=mock_user_cost_data)
+    ):
         # Make a POST request
         response = client.post(
             "/test-null-tags",
@@ -439,7 +453,9 @@ def _(client=client):
     }
 
     # Mock the get_user_cost function
-    with patch("agents_api.web.get_usage_cost", new=AsyncMock(return_value=mock_user_cost_data)):
+    with patch(
+        "agents_api.web.get_usage_cost", new=AsyncMock(return_value=mock_user_cost_data)
+    ):
         # Make request with the developer ID header
         response = client.get("/test-valid-user", headers={"X-Developer-Id": developer_id})
 

--- a/agents-api/tests/test_usage_cost.py
+++ b/agents-api/tests/test_usage_cost.py
@@ -3,13 +3,14 @@ Tests for the usage cost tracking functionality.
 """
 
 import asyncio
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
 from agents_api.clients.pg import create_db_pool
 from agents_api.queries.developers.create_developer import create_developer
 from agents_api.queries.usage.create_usage_record import create_usage_record
 from agents_api.queries.usage.get_user_cost import get_usage_cost
+from fastapi import HTTPException
 from uuid_extensions import uuid7
 from ward import test
 
@@ -41,18 +42,8 @@ async def _(dsn=pg_dsn, developer_id=test_developer_id) -> None:
     # Calculate expected cost
     expected_cost = record1[0]["cost"] + record2[0]["cost"]
 
-    # For testing purposes, directly insert into the aggregation table
-    # This simulates what the continuous aggregate would do
-    await pool.execute(
-        """
-        INSERT INTO usage_cost_monthly (developer_id, bucket_start, monthly_cost)
-        VALUES ($1, date_trunc('month', NOW()), $2)
-        ON CONFLICT (developer_id, bucket_start)
-        DO UPDATE SET monthly_cost = usage_cost_monthly.monthly_cost + $2
-        """,
-        developer_id,
-        expected_cost
-    )
+    # Force the continuous aggregate to refresh
+    await pool.execute("CALL refresh_continuous_aggregate('usage_cost_monthly', NULL, NULL)")
 
     # Give a small delay for the view to update
     await asyncio.sleep(0.1)
@@ -65,7 +56,9 @@ async def _(dsn=pg_dsn, developer_id=test_developer_id) -> None:
     assert cost_record["developer_id"] == developer_id
     assert "cost" in cost_record, "Should have a cost field"
     assert isinstance(cost_record["cost"], Decimal), "Cost should be a Decimal"
-    assert cost_record["cost"] == expected_cost, f"Cost should be {expected_cost}, got {cost_record['cost']}"
+    assert cost_record["cost"] == expected_cost, (
+        f"Cost should be {expected_cost}, got {cost_record['cost']}"
+    )
     assert "month" in cost_record, "Should have a month field"
     assert isinstance(cost_record["month"], datetime), "Month should be a datetime"
 
@@ -88,7 +81,7 @@ async def _(dsn=pg_dsn) -> None:
     )
 
     # Create usage records with custom API
-    custom_cost = await create_usage_record(
+    await create_usage_record(
         developer_id=dev_id,
         model="gpt-4o-mini",
         prompt_tokens=1000,
@@ -110,18 +103,8 @@ async def _(dsn=pg_dsn) -> None:
     # Calculate what the expected cost should be
     expected_cost = non_custom_cost[0]["cost"]
 
-    # For testing purposes, directly insert into the aggregation table
-    # This simulates what the continuous aggregate would do
-    await pool.execute(
-        """
-        INSERT INTO usage_cost_monthly (developer_id, bucket_start, monthly_cost)
-        VALUES ($1, date_trunc('month', NOW()), $2)
-        ON CONFLICT (developer_id, bucket_start)
-        DO UPDATE SET monthly_cost = usage_cost_monthly.monthly_cost + $2
-        """,
-        dev_id,
-        expected_cost
-    )
+    # Force the continuous aggregate to refresh
+    await pool.execute("CALL refresh_continuous_aggregate('usage_cost_monthly', NULL, NULL)")
 
     # Give a small delay for the view to update
     await asyncio.sleep(0.1)
@@ -132,9 +115,9 @@ async def _(dsn=pg_dsn) -> None:
     # Verify the record
     assert cost_record is not None, "Should have a cost record"
     assert cost_record["developer_id"] == dev_id
-    assert cost_record["cost"] == expected_cost, f"Cost should match expected: {expected_cost} but got {cost_record['cost']}"
-    # Custom API costs should be excluded
-    assert cost_record["cost"] != custom_cost[0]["cost"] + non_custom_cost[0]["cost"], "Custom API costs should be excluded"
+    assert cost_record["cost"] == expected_cost, (
+        f"Cost should match expected: {expected_cost} but got {cost_record['cost']}"
+    )
 
 
 @test("query: get_usage_cost returns None when no usage records exist")
@@ -154,11 +137,14 @@ async def _(dsn=pg_dsn) -> None:
         connection_pool=pool,
     )
 
-    # Get the usage cost
-    cost_record = await get_usage_cost(developer_id=dev_id, connection_pool=pool)
-
-    # Verify that no record is returned
-    assert cost_record is None, "Should not have a cost record for developer with no usage"
+    # Get the usage cost - should return None or raise 404
+    try:
+        cost_record = await get_usage_cost(developer_id=dev_id, connection_pool=pool)
+        assert cost_record is None, "Should not have a cost record for developer with no usage"
+    except HTTPException as ex:
+        # Accept either None or a 404 error
+        assert ex.status_code == 404, f"Expected 404 error, got {ex.status_code}"
+        assert "Usage not found" in ex.detail, f"Unexpected error detail: {ex.detail}"
 
 
 @test("query: get_usage_cost handles inactive developers correctly")
@@ -190,18 +176,8 @@ async def _(dsn=pg_dsn) -> None:
     # Calculate expected cost
     expected_cost = record[0]["cost"]
 
-    # For testing purposes, directly insert into the aggregation table
-    # This simulates what the continuous aggregate would do
-    await pool.execute(
-        """
-        INSERT INTO usage_cost_monthly (developer_id, bucket_start, monthly_cost)
-        VALUES ($1, date_trunc('month', NOW()), $2)
-        ON CONFLICT (developer_id, bucket_start)
-        DO UPDATE SET monthly_cost = usage_cost_monthly.monthly_cost + $2
-        """,
-        dev_id,
-        expected_cost
-    )
+    # Force the continuous aggregate to refresh
+    await pool.execute("CALL refresh_continuous_aggregate('usage_cost_monthly', NULL, NULL)")
 
     # Give a small delay for the view to update
     await asyncio.sleep(0.1)
@@ -213,7 +189,9 @@ async def _(dsn=pg_dsn) -> None:
     assert cost_record is not None, "Should have a cost record even for inactive developers"
     assert cost_record["developer_id"] == dev_id
     assert cost_record["active"] is False, "Developer should be marked as inactive"
-    assert cost_record["cost"] == expected_cost, f"Cost should be {expected_cost}, got {cost_record['cost']}"
+    assert cost_record["cost"] == expected_cost, (
+        f"Cost should be {expected_cost}, got {cost_record['cost']}"
+    )
 
 
 @test("query: get_usage_cost sorts by month correctly and returns the most recent")
@@ -233,51 +211,48 @@ async def _(dsn=pg_dsn) -> None:
         connection_pool=pool,
     )
 
-    # Calculate costs for different months
-    current_cost = Decimal("0.006000")
-    middle_cost = Decimal("0.004000")
-    oldest_cost = Decimal("0.002000")
-
-    # Get the dates for different months
-    now = datetime.now()
-    current_month = datetime(now.year, now.month, 1)
+    # Create usage records for different months - using timezone-aware datetimes
+    now = datetime.now(UTC)
+    current_month = datetime(now.year, now.month, 1, tzinfo=UTC)
     middle_month = current_month - timedelta(days=30)
     oldest_month = current_month - timedelta(days=60)
 
-    # For testing purposes, directly insert into the aggregation table for different months
-    # This simulates what the continuous aggregate would do
-    # Insert oldest month first
-    await pool.execute(
-        """
-        INSERT INTO usage_cost_monthly (developer_id, bucket_start, monthly_cost)
-        VALUES ($1, $2, $3)
-        """,
-        dev_id,
-        oldest_month,
-        oldest_cost
+    # Create a cost for the current month
+    current_cost_record = await create_usage_record(
+        developer_id=dev_id,
+        model="gpt-4o-mini",
+        prompt_tokens=600,
+        completion_tokens=1200,
+        connection_pool=pool,
     )
+    current_cost = current_cost_record[0]["cost"]
 
-    # Insert middle month
+    # Create a cost for the middle month (insert with timestamp)
     await pool.execute(
         """
-        INSERT INTO usage_cost_monthly (developer_id, bucket_start, monthly_cost)
-        VALUES ($1, $2, $3)
+        INSERT INTO usage (
+            developer_id, model, prompt_tokens, completion_tokens, cost, created_at
+        ) VALUES ($1, 'gpt-4o-mini', 400, 800, $2, $3)
         """,
         dev_id,
+        Decimal("0.004000"),
         middle_month,
-        middle_cost
     )
 
-    # Insert current month (should be returned by the query)
+    # Create a cost for the oldest month
     await pool.execute(
         """
-        INSERT INTO usage_cost_monthly (developer_id, bucket_start, monthly_cost)
-        VALUES ($1, $2, $3)
+        INSERT INTO usage (
+            developer_id, model, prompt_tokens, completion_tokens, cost, created_at
+        ) VALUES ($1, 'gpt-4o-mini', 200, 400, $2, $3)
         """,
         dev_id,
-        current_month,
-        current_cost
+        Decimal("0.002000"),
+        oldest_month,
     )
+
+    # Force the continuous aggregate to refresh
+    await pool.execute("CALL refresh_continuous_aggregate('usage_cost_monthly', NULL, NULL)")
 
     # Give a small delay for the view to update
     await asyncio.sleep(0.1)
@@ -290,8 +265,12 @@ async def _(dsn=pg_dsn) -> None:
     assert cost_record["developer_id"] == dev_id
 
     # The month in the record should be close to the current month's date
-    month_diff = abs((cost_record["month"] - current_month).total_seconds())
+    # Ensure both datetimes are timezone-aware
+    record_month = cost_record["month"]
+    month_diff = abs((record_month - current_month).total_seconds())
     assert month_diff < 86400, "Month should be near the start of the current month"
 
     # The cost should match only the current month
-    assert cost_record["cost"] == current_cost, f"Cost should match current month's usage only: expected {current_cost}, got {cost_record['cost']}"
+    assert cost_record["cost"] == current_cost, (
+        f"Cost should match current month's usage only: expected {current_cost}, got {cost_record['cost']}"
+    )

--- a/agents-api/tests/test_usage_cost.py
+++ b/agents-api/tests/test_usage_cost.py
@@ -1,0 +1,297 @@
+"""
+Tests for the usage cost tracking functionality.
+"""
+
+import asyncio
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+from agents_api.clients.pg import create_db_pool
+from agents_api.queries.developers.create_developer import create_developer
+from agents_api.queries.usage.create_usage_record import create_usage_record
+from agents_api.queries.usage.get_user_cost import get_usage_cost
+from uuid_extensions import uuid7
+from ward import test
+
+from .fixtures import pg_dsn, test_developer_id
+
+
+@test("query: get_usage_cost returns the correct cost when records exist")
+async def _(dsn=pg_dsn, developer_id=test_developer_id) -> None:
+    """Test that get_usage_cost returns the correct cost for a developer with usage records."""
+    pool = await create_db_pool(dsn=dsn)
+
+    # Create some usage records for the developer
+    record1 = await create_usage_record(
+        developer_id=developer_id,
+        model="gpt-4o-mini",
+        prompt_tokens=1000,
+        completion_tokens=2000,
+        connection_pool=pool,
+    )
+
+    record2 = await create_usage_record(
+        developer_id=developer_id,
+        model="gpt-4o-mini",
+        prompt_tokens=500,
+        completion_tokens=1500,
+        connection_pool=pool,
+    )
+
+    # Calculate expected cost
+    expected_cost = record1[0]["cost"] + record2[0]["cost"]
+
+    # For testing purposes, directly insert into the aggregation table
+    # This simulates what the continuous aggregate would do
+    await pool.execute(
+        """
+        INSERT INTO usage_cost_monthly (developer_id, bucket_start, monthly_cost)
+        VALUES ($1, date_trunc('month', NOW()), $2)
+        ON CONFLICT (developer_id, bucket_start)
+        DO UPDATE SET monthly_cost = usage_cost_monthly.monthly_cost + $2
+        """,
+        developer_id,
+        expected_cost
+    )
+
+    # Give a small delay for the view to update
+    await asyncio.sleep(0.1)
+
+    # Get the usage cost
+    cost_record = await get_usage_cost(developer_id=developer_id, connection_pool=pool)
+
+    # Verify the record
+    assert cost_record is not None, "Should have a cost record"
+    assert cost_record["developer_id"] == developer_id
+    assert "cost" in cost_record, "Should have a cost field"
+    assert isinstance(cost_record["cost"], Decimal), "Cost should be a Decimal"
+    assert cost_record["cost"] == expected_cost, f"Cost should be {expected_cost}, got {cost_record['cost']}"
+    assert "month" in cost_record, "Should have a month field"
+    assert isinstance(cost_record["month"], datetime), "Month should be a datetime"
+
+
+@test("query: get_usage_cost returns correct results for custom API usage")
+async def _(dsn=pg_dsn) -> None:
+    """Test that get_usage_cost only includes non-custom API usage in the cost calculation."""
+    pool = await create_db_pool(dsn=dsn)
+
+    # Create a new developer for this test
+    dev_id = uuid7()
+    email = f"test-{dev_id}@example.com"
+    await create_developer(
+        email=email,
+        active=True,
+        tags=["test"],
+        settings={},
+        developer_id=dev_id,
+        connection_pool=pool,
+    )
+
+    # Create usage records with custom API
+    custom_cost = await create_usage_record(
+        developer_id=dev_id,
+        model="gpt-4o-mini",
+        prompt_tokens=1000,
+        completion_tokens=2000,
+        custom_api_used=True,  # This shouldn't be counted in the cost
+        connection_pool=pool,
+    )
+
+    # Create usage records without custom API
+    non_custom_cost = await create_usage_record(
+        developer_id=dev_id,
+        model="gpt-4o-mini",
+        prompt_tokens=1000,
+        completion_tokens=2000,
+        custom_api_used=False,  # This should be counted
+        connection_pool=pool,
+    )
+
+    # Calculate what the expected cost should be
+    expected_cost = non_custom_cost[0]["cost"]
+
+    # For testing purposes, directly insert into the aggregation table
+    # This simulates what the continuous aggregate would do
+    await pool.execute(
+        """
+        INSERT INTO usage_cost_monthly (developer_id, bucket_start, monthly_cost)
+        VALUES ($1, date_trunc('month', NOW()), $2)
+        ON CONFLICT (developer_id, bucket_start)
+        DO UPDATE SET monthly_cost = usage_cost_monthly.monthly_cost + $2
+        """,
+        dev_id,
+        expected_cost
+    )
+
+    # Give a small delay for the view to update
+    await asyncio.sleep(0.1)
+
+    # Get the usage cost
+    cost_record = await get_usage_cost(developer_id=dev_id, connection_pool=pool)
+
+    # Verify the record
+    assert cost_record is not None, "Should have a cost record"
+    assert cost_record["developer_id"] == dev_id
+    assert cost_record["cost"] == expected_cost, f"Cost should match expected: {expected_cost} but got {cost_record['cost']}"
+    # Custom API costs should be excluded
+    assert cost_record["cost"] != custom_cost[0]["cost"] + non_custom_cost[0]["cost"], "Custom API costs should be excluded"
+
+
+@test("query: get_usage_cost returns None when no usage records exist")
+async def _(dsn=pg_dsn) -> None:
+    """Test that get_usage_cost returns None when no usage records exist for a developer."""
+    pool = await create_db_pool(dsn=dsn)
+
+    # Create a new developer without any usage records
+    dev_id = uuid7()
+    email = f"test-{dev_id}@example.com"
+    await create_developer(
+        email=email,
+        active=True,
+        tags=["test"],
+        settings={},
+        developer_id=dev_id,
+        connection_pool=pool,
+    )
+
+    # Get the usage cost
+    cost_record = await get_usage_cost(developer_id=dev_id, connection_pool=pool)
+
+    # Verify that no record is returned
+    assert cost_record is None, "Should not have a cost record for developer with no usage"
+
+
+@test("query: get_usage_cost handles inactive developers correctly")
+async def _(dsn=pg_dsn) -> None:
+    """Test that get_usage_cost correctly handles inactive developers."""
+    pool = await create_db_pool(dsn=dsn)
+
+    # Create a new inactive developer
+    dev_id = uuid7()
+    email = f"test-{dev_id}@example.com"
+    await create_developer(
+        email=email,
+        active=False,  # Developer is inactive
+        tags=["test"],
+        settings={},
+        developer_id=dev_id,
+        connection_pool=pool,
+    )
+
+    # Create usage records for the inactive developer
+    record = await create_usage_record(
+        developer_id=dev_id,
+        model="gpt-4o-mini",
+        prompt_tokens=1000,
+        completion_tokens=2000,
+        connection_pool=pool,
+    )
+
+    # Calculate expected cost
+    expected_cost = record[0]["cost"]
+
+    # For testing purposes, directly insert into the aggregation table
+    # This simulates what the continuous aggregate would do
+    await pool.execute(
+        """
+        INSERT INTO usage_cost_monthly (developer_id, bucket_start, monthly_cost)
+        VALUES ($1, date_trunc('month', NOW()), $2)
+        ON CONFLICT (developer_id, bucket_start)
+        DO UPDATE SET monthly_cost = usage_cost_monthly.monthly_cost + $2
+        """,
+        dev_id,
+        expected_cost
+    )
+
+    # Give a small delay for the view to update
+    await asyncio.sleep(0.1)
+
+    # Get the usage cost
+    cost_record = await get_usage_cost(developer_id=dev_id, connection_pool=pool)
+
+    # Verify the record
+    assert cost_record is not None, "Should have a cost record even for inactive developers"
+    assert cost_record["developer_id"] == dev_id
+    assert cost_record["active"] is False, "Developer should be marked as inactive"
+    assert cost_record["cost"] == expected_cost, f"Cost should be {expected_cost}, got {cost_record['cost']}"
+
+
+@test("query: get_usage_cost sorts by month correctly and returns the most recent")
+async def _(dsn=pg_dsn) -> None:
+    """Test that get_usage_cost returns the most recent month's cost when multiple months exist."""
+    pool = await create_db_pool(dsn=dsn)
+
+    # Create a new developer for this test
+    dev_id = uuid7()
+    email = f"test-{dev_id}@example.com"
+    await create_developer(
+        email=email,
+        active=True,
+        tags=["test"],
+        settings={},
+        developer_id=dev_id,
+        connection_pool=pool,
+    )
+
+    # Calculate costs for different months
+    current_cost = Decimal("0.006000")
+    middle_cost = Decimal("0.004000")
+    oldest_cost = Decimal("0.002000")
+
+    # Get the dates for different months
+    now = datetime.now()
+    current_month = datetime(now.year, now.month, 1)
+    middle_month = current_month - timedelta(days=30)
+    oldest_month = current_month - timedelta(days=60)
+
+    # For testing purposes, directly insert into the aggregation table for different months
+    # This simulates what the continuous aggregate would do
+    # Insert oldest month first
+    await pool.execute(
+        """
+        INSERT INTO usage_cost_monthly (developer_id, bucket_start, monthly_cost)
+        VALUES ($1, $2, $3)
+        """,
+        dev_id,
+        oldest_month,
+        oldest_cost
+    )
+
+    # Insert middle month
+    await pool.execute(
+        """
+        INSERT INTO usage_cost_monthly (developer_id, bucket_start, monthly_cost)
+        VALUES ($1, $2, $3)
+        """,
+        dev_id,
+        middle_month,
+        middle_cost
+    )
+
+    # Insert current month (should be returned by the query)
+    await pool.execute(
+        """
+        INSERT INTO usage_cost_monthly (developer_id, bucket_start, monthly_cost)
+        VALUES ($1, $2, $3)
+        """,
+        dev_id,
+        current_month,
+        current_cost
+    )
+
+    # Give a small delay for the view to update
+    await asyncio.sleep(0.1)
+
+    # Get the usage cost
+    cost_record = await get_usage_cost(developer_id=dev_id, connection_pool=pool)
+
+    # We expect the most recent month to be returned
+    assert cost_record is not None, "Should have a cost record"
+    assert cost_record["developer_id"] == dev_id
+
+    # The month in the record should be close to the current month's date
+    month_diff = abs((cost_record["month"] - current_month).total_seconds())
+    assert month_diff < 86400, "Month should be near the start of the current month"
+
+    # The cost should match only the current month
+    assert cost_record["cost"] == current_cost, f"Cost should match current month's usage only: expected {current_cost}, got {cost_record['cost']}"

--- a/agents-api/tests/test_usage_tracking.py
+++ b/agents-api/tests/test_usage_tracking.py
@@ -8,7 +8,11 @@ from unittest.mock import patch
 
 from agents_api.clients.pg import create_db_pool
 from agents_api.common.utils.usage import track_embedding_usage, track_usage
-from agents_api.queries.usage.create_usage_record import create_usage_record, AVG_INPUT_COST_PER_TOKEN, AVG_OUTPUT_COST_PER_TOKEN
+from agents_api.queries.usage.create_usage_record import (
+    AVG_INPUT_COST_PER_TOKEN,
+    AVG_OUTPUT_COST_PER_TOKEN,
+    create_usage_record,
+)
 from litellm import cost_per_token
 from litellm.utils import Message, ModelResponse, Usage, token_counter
 from ward import test
@@ -145,7 +149,9 @@ async def _(dsn=pg_dsn, developer_id=test_developer_id) -> None:
     actual_call = mock_print.call_args_list[-1].args[0]
     total_cost = AVG_INPUT_COST_PER_TOKEN * 100 + AVG_OUTPUT_COST_PER_TOKEN * 100
 
-    expected_call = f"No fallback pricing found for model {unknown_model}, using avg costs: {total_cost}"
+    expected_call = (
+        f"No fallback pricing found for model {unknown_model}, using avg costs: {total_cost}"
+    )
 
     assert len(response) == 1
     record = response[0]

--- a/agents-api/tests/test_usage_tracking.py
+++ b/agents-api/tests/test_usage_tracking.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 from agents_api.clients.pg import create_db_pool
 from agents_api.common.utils.usage import track_embedding_usage, track_usage
-from agents_api.queries.usage.create_usage_record import create_usage_record
+from agents_api.queries.usage.create_usage_record import create_usage_record, AVG_INPUT_COST_PER_TOKEN, AVG_OUTPUT_COST_PER_TOKEN
 from litellm import cost_per_token
 from litellm.utils import Message, ModelResponse, Usage, token_counter
 from ward import test
@@ -142,12 +142,14 @@ async def _(dsn=pg_dsn, developer_id=test_developer_id) -> None:
             completion_tokens=100,
             connection_pool=pool,
         )
-    expected_call = f"No fallback pricing found for model {unknown_model}"
     actual_call = mock_print.call_args_list[-1].args[0]
+    total_cost = AVG_INPUT_COST_PER_TOKEN * 100 + AVG_OUTPUT_COST_PER_TOKEN * 100
+
+    expected_call = f"No fallback pricing found for model {unknown_model}, using avg costs: {total_cost}"
 
     assert len(response) == 1
     record = response[0]
-    assert record["cost"] == Decimal("0.000000")
+    assert record["cost"] == Decimal(str(total_cost)).quantize(Decimal("0.000001"))
     assert record["estimated"] is True
     assert expected_call == actual_call
 

--- a/memory-store/migrations/000038_usage_cost_monthly.down.sql
+++ b/memory-store/migrations/000038_usage_cost_monthly.down.sql
@@ -6,7 +6,7 @@ SELECT remove_continuous_aggregate_policy('usage_cost_monthly');
 -- Drop the view
 DROP VIEW IF EXISTS developer_cost_monthly;
 
--- Drop the continuous aggregate
-DROP MATERIALIZED VIEW IF EXISTS usage_cost_monthly;
+-- Drop the continuous aggregate with CASCADE to remove any dependent objects (like the index)
+DROP MATERIALIZED VIEW IF EXISTS usage_cost_monthly CASCADE;
 
 COMMIT; 

--- a/memory-store/migrations/000038_usage_cost_monthly.down.sql
+++ b/memory-store/migrations/000038_usage_cost_monthly.down.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+-- Remove the continuous aggregate policy
+SELECT remove_continuous_aggregate_policy('usage_cost_monthly');
+
+-- Drop the view
+DROP VIEW IF EXISTS developer_cost_monthly;
+
+-- Drop the continuous aggregate
+DROP MATERIALIZED VIEW IF EXISTS usage_cost_monthly;
+
+COMMIT; 

--- a/memory-store/migrations/000038_usage_cost_monthly.up.sql
+++ b/memory-store/migrations/000038_usage_cost_monthly.up.sql
@@ -1,6 +1,6 @@
--- Create continuous aggregate for monthly cost per developer
+-- Create continuous aggregate for monthly cost per developer with real-time data
 CREATE MATERIALIZED VIEW usage_cost_monthly
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
     developer_id,
     time_bucket('1 month', created_at) AS bucket_start,
@@ -18,8 +18,8 @@ ON usage_cost_monthly (developer_id, bucket_start DESC);
 SELECT add_continuous_aggregate_policy(
     'usage_cost_monthly',
     start_offset => INTERVAL '3 months',
-    end_offset => INTERVAL '1 minute',
-    schedule_interval => INTERVAL '1 minute'
+    end_offset => INTERVAL '0 minute',
+    schedule_interval => INTERVAL '30 seconds'
 );
 
 -- Create view that joins with developers table for easy querying

--- a/memory-store/migrations/000038_usage_cost_monthly.up.sql
+++ b/memory-store/migrations/000038_usage_cost_monthly.up.sql
@@ -1,0 +1,44 @@
+BEGIN;
+
+-- Create continuous aggregate for monthly cost per developer
+CREATE MATERIALIZED VIEW usage_cost_monthly
+WITH (timescaledb.continuous) AS
+SELECT
+    developer_id,
+    time_bucket('1 month', created_at) AS bucket_start,
+    SUM(cost) FILTER (WHERE NOT custom_api_used) AS monthly_cost
+FROM usage
+WHERE created_at < NOW()
+GROUP BY developer_id, bucket_start
+WITH NO DATA;
+
+-- Create index for efficient querying
+CREATE INDEX IF NOT EXISTS idx_usage_cost_monthly_developer 
+ON usage_cost_monthly (developer_id, bucket_start DESC);
+
+-- Back-fill historical data
+REFRESH MATERIALIZED VIEW CONCURRENTLY usage_cost_monthly;
+
+-- Set up continuous aggregate policy to refresh every minute
+SELECT add_continuous_aggregate_policy(
+    'usage_cost_monthly',
+    start_offset => INTERVAL '1 month',
+    end_offset => INTERVAL '1 minute',
+    schedule_interval => INTERVAL '1 minute'
+);
+
+-- Create view that joins with developers table for easy querying
+CREATE OR REPLACE VIEW developer_cost_monthly AS
+SELECT 
+    m.bucket_start,
+    d.developer_id,
+    d.active,
+    d.tags,
+    m.monthly_cost
+FROM usage_cost_monthly AS m
+JOIN developers AS d USING (developer_id);
+
+COMMENT ON MATERIALIZED VIEW usage_cost_monthly IS 'Continuous aggregate tracking monthly costs per developer, excluding custom API usage';
+COMMENT ON VIEW developer_cost_monthly IS 'View combining monthly costs with developer metadata';
+
+COMMIT; 


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Add usage cost monthly aggregation and view in database
  - New migrations for monthly cost tracking and developer view

- Implement usage cost limit middleware for free tier users
  - Middleware blocks requests if cost limit exceeded or account inactive
  - Paid users bypass cost limit check

- Add and enhance usage cost calculation and fallback logic
  - Average cost fallback for unknown models
  - Expose usage cost query in API

- Add comprehensive tests for usage cost and middleware
  - Test cost limit, paid tag, error handling, and edge cases


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>developer_id.py</strong><dd><code>Remove developer active check from dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1351/files#diff-6223236a2e515b6140ff389ecd0cab0eb37b1f19cafc52bce8ac7ecacebb1182">+1/-12</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>env.py</strong><dd><code>Add free tier cost limit environment variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1351/files#diff-1f8c23dc72151bd249217763369b0b8837ce35a7bd5bedd304996b3e828f0493">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong><dd><code>Export get_usage_cost in usage queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1351/files#diff-28ce8d266837604fe3586e802c64d1c79336670f9549dfd3f950fa3a7214871c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>create_usage_record.py</strong><dd><code>Add average cost fallback for unknown models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1351/files#diff-c3c3933826f43f77d2313c0c3ef45a041fb709da69dd9d3eff344a7960652e06">+40/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>get_user_cost.py</strong><dd><code>Add get_usage_cost query for developer monthly cost</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1351/files#diff-ab11c72700686d36116dc1218c3c9337b560ac62d517541d9917f4c23ca967c8">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>web.py</strong><dd><code>Add usage cost limit middleware for free users</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1351/files#diff-6f6412b372aa58ba2fed61beed56f6a884c1797c8a91c0d8d9b715fa5c14fccf">+84/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>000038_usage_cost_monthly.down.sql</strong><dd><code>Add migration to drop monthly usage cost aggregates/views</code></dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1351/files#diff-fd909c2f2b8862804f86508d39adb4ed323b5f5cc62cfcd233f7b4ed85574dfc">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>000038_usage_cost_monthly.up.sql</strong><dd><code>Add migration for monthly usage cost aggregation and view</code></dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1351/files#diff-e513fe50e851718d61b087df51d9af0d6e6b03a73160eda6be320b27524d1333">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>get_developer.py</strong><dd><code>Minor SQL formatting update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1351/files#diff-c9425aed2b6db3867a3b82ba0534930f8fd5a758a4213253d7c63dd2948915a4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>test_developer_queries.py</strong><dd><code>Remove dependency test for inactive developer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1351/files#diff-5b526b150628811f95686e39efec3e1f66a65ce2aa2ad54b4c4bc41f607323c0">+0/-39</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_middleware.py</strong><dd><code>Add comprehensive tests for usage cost middleware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1351/files#diff-dc36c95a1896a611bd298b4db67de03c5beb54bc6f966ca08196932e27ce24b4">+464/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_usage_cost.py</strong><dd><code>Add tests for usage cost query and aggregation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1351/files#diff-9dc574814040bc04056041841663616c3de9894935338fdd91acb9ad51a44016">+276/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_usage_tracking.py</strong><dd><code>Update tests for fallback cost calculation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1351/files#diff-c6a3147204b376524acc103abd218636bc42fae3be3360292ff9b1ade155e84b">+11/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds monthly usage cost tracking, middleware for cost limit enforcement, and comprehensive tests for free-tier users.
> 
>   - **Behavior**:
>     - Adds monthly usage cost aggregation and view in the database with migrations `000038_usage_cost_monthly.up.sql` and `000038_usage_cost_monthly.down.sql`.
>     - Implements `usage_check_middleware` in `web.py` to block requests for free-tier users exceeding cost limits or inactive accounts.
>     - Paid users bypass cost checks.
>   - **Models**:
>     - Adds `get_usage_cost` query in `get_user_cost.py` to retrieve developer monthly costs.
>     - Updates `create_usage_record.py` to include average cost fallback for unknown models.
>   - **Environment**:
>     - Adds `free_tier_cost_limit` environment variable in `env.py`.
>   - **Tests**:
>     - Adds tests for usage cost and middleware in `test_usage_cost.py`, `test_middleware.py`, and `test_usage_tracking.py`.
>     - Removes inactive developer dependency test in `test_developer_queries.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 03173f177842272ce22c1d5dad15d7567edabe79. You can [customize](https://app.ellipsis.dev/julep-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->