### PR TITLE
feat(memory-store): Add usage cost monthly migrations (cont agg + view)

### DIFF
--- a/memory-store/migrations/000038_usage_cost_monthly.down.sql
+++ b/memory-store/migrations/000038_usage_cost_monthly.down.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+-- Remove the continuous aggregate policy
+SELECT remove_continuous_aggregate_policy('usage_cost_monthly');
+
+-- Drop the view
+DROP VIEW IF EXISTS developer_cost_monthly;
+
+-- Drop the continuous aggregate
+DROP MATERIALIZED VIEW IF EXISTS usage_cost_monthly;
+
+COMMIT; 

--- a/memory-store/migrations/000038_usage_cost_monthly.up.sql
+++ b/memory-store/migrations/000038_usage_cost_monthly.up.sql
@@ -1,0 +1,44 @@
+BEGIN;
+
+-- Create continuous aggregate for monthly cost per developer
+CREATE MATERIALIZED VIEW usage_cost_monthly
+WITH (timescaledb.continuous) AS
+SELECT
+    developer_id,
+    time_bucket('1 month', created_at) AS bucket_start,
+    SUM(cost) FILTER (WHERE NOT custom_api_used) AS monthly_cost
+FROM usage
+WHERE created_at < NOW()
+GROUP BY developer_id, bucket_start
+WITH NO DATA;
+
+-- Create index for efficient querying
+CREATE INDEX IF NOT EXISTS idx_usage_cost_monthly_developer 
+ON usage_cost_monthly (developer_id, bucket_start DESC);
+
+-- Back-fill historical data
+REFRESH MATERIALIZED VIEW CONCURRENTLY usage_cost_monthly;
+
+-- Set up continuous aggregate policy to refresh every minute
+SELECT add_continuous_aggregate_policy(
+    'usage_cost_monthly',
+    start_offset => INTERVAL '1 month',
+    end_offset => INTERVAL '1 minute',
+    schedule_interval => INTERVAL '1 minute'
+);
+
+-- Create view that joins with developers table for easy querying
+CREATE OR REPLACE VIEW developer_cost_monthly AS
+SELECT 
+    m.bucket_start,
+    d.developer_id,
+    d.active,
+    d.tags,
+    m.monthly_cost
+FROM usage_cost_monthly AS m
+JOIN developers AS d USING (developer_id);
+
+COMMENT ON MATERIALIZED VIEW usage_cost_monthly IS 'Continuous aggregate tracking monthly costs per developer, excluding custom API usage';
+COMMENT ON VIEW developer_cost_monthly IS 'View combining monthly costs with developer metadata';
+
+COMMIT; 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add SQL migrations for continuous aggregate and view to track monthly usage costs per developer in `memory-store`.
> 
>   - **Migrations**:
>     - Add `000038_usage_cost_monthly.up.sql` to create a continuous aggregate `usage_cost_monthly` for monthly developer costs, excluding custom API usage.
>     - Add index `idx_usage_cost_monthly_developer` for efficient querying in `000038_usage_cost_monthly.up.sql`.
>     - Add continuous aggregate policy to refresh `usage_cost_monthly` every minute in `000038_usage_cost_monthly.up.sql`.
>     - Create view `developer_cost_monthly` joining `usage_cost_monthly` with `developers` for easy querying in `000038_usage_cost_monthly.up.sql`.
>     - Add `000038_usage_cost_monthly.down.sql` to remove the continuous aggregate policy, view, and materialized view.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 23a52842d912648d05cd2e45f7bc00c2d262da04. You can [customize](https://app.ellipsis.dev/julep-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->