### PR TITLE
fix: Make sessions.forward_tool_calls not nullable

### DIFF
--- a/memory-store/migrations/000041_non_null_forward_tool_calls.down.sql
+++ b/memory-store/migrations/000041_non_null_forward_tool_calls.down.sql
@@ -1,0 +1,5 @@
+-- Remove the not null constraint
+ALTER TABLE sessions ALTER COLUMN forward_tool_calls DROP NOT NULL;
+
+-- Remove the comment
+COMMENT ON COLUMN sessions.forward_tool_calls IS NULL; 

--- a/memory-store/migrations/000041_non_null_forward_tool_calls.up.sql
+++ b/memory-store/migrations/000041_non_null_forward_tool_calls.up.sql
@@ -1,0 +1,8 @@
+-- Update existing null values to false
+UPDATE sessions SET forward_tool_calls = false WHERE forward_tool_calls IS NULL;
+
+-- Make the column not null
+ALTER TABLE sessions ALTER COLUMN forward_tool_calls SET NOT NULL;
+
+-- Add comment to explain the change
+COMMENT ON COLUMN sessions.forward_tool_calls IS 'Whether to forward tool calls directly to the model. Default is false.'; 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Enforces non-null constraint on `sessions.forward_tool_calls` column

- Updates existing null values to `false` before constraint

- Adds and removes explanatory comment for the column


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>000041_non_null_forward_tool_calls.up.sql</strong><dd><code>Migration to enforce NOT NULL and document column</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

memory-store/migrations/000041_non_null_forward_tool_calls.up.sql

<li>Sets all null <code>forward_tool_calls</code> values to <code>false</code><br> <li> Alters column to be NOT NULL<br> <li> Adds a descriptive comment to the column


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1365/files#diff-c5e45744381158b1c95bda5843e08f170effa38f353c6fb9fcafbf01c942fd15">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>000041_non_null_forward_tool_calls.down.sql</strong><dd><code>Migration to revert NOT NULL constraint and comment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

memory-store/migrations/000041_non_null_forward_tool_calls.down.sql

<li>Drops NOT NULL constraint from <code>forward_tool_calls</code><br> <li> Removes the column comment


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1365/files#diff-55f37a7a65677fec0b6d0f89d94e86474e484057fd4a6f9adbf3e04c0738af44">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add migration to make `sessions.forward_tool_calls` non-nullable, updating nulls to false and adding a comment.
> 
>   - **Database Migration**:
>     - Adds `000041_non_null_forward_tool_calls.up.sql` to update `sessions.forward_tool_calls` to non-nullable, setting nulls to false.
>     - Adds `000041_non_null_forward_tool_calls.down.sql` to revert the column to nullable.
>   - **Comments**:
>     - Adds a comment to `sessions.forward_tool_calls` explaining its purpose in the up migration.
>     - Removes the comment in the down migration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for d7c220d42b3f5a7670320ed1895bc2b940ba0eaa. You can [customize](https://app.ellipsis.dev/julep-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->