### PR TITLE
feat(agents-api): add decryption flag to secrets queries

### DIFF
--- a/agents-api/agents_api/clients/litellm.py
+++ b/agents-api/agents_api/clients/litellm.py
@@ -70,7 +70,9 @@ async def acompletion(
 
             with contextlib.suppress(SecretNotFoundError):
                 secret = await get_secret_by_name(
-                    developer_id=developer_id, name=api_key_env_var_name
+                    developer_id=developer_id,
+                    name=api_key_env_var_name,
+                    decrypt=True,
                 )
 
         custom_api_key = secret and secret.value

--- a/agents-api/agents_api/common/protocol/tasks.py
+++ b/agents-api/agents_api/common/protocol/tasks.py
@@ -208,7 +208,7 @@ class StepContext(BaseModel):
                 args=[
                     "list_secrets_query",
                     "secrets.list",
-                    {"developer_id": self.execution_input.developer_id},
+                    {"developer_id": self.execution_input.developer_id, "decrypt": True},
                 ],
                 schedule_to_close_timeout=timedelta(days=31),
                 retry_policy=DEFAULT_RETRY_POLICY,
@@ -216,7 +216,8 @@ class StepContext(BaseModel):
             )
         except _NotInWorkflowEventLoopError:
             secrets_query_result = await list_secrets_query(
-                developer_id=self.execution_input.developer_id
+                developer_id=self.execution_input.developer_id,
+                decrypt=True,
             )
 
         if tools:

--- a/agents-api/agents_api/common/utils/secrets.py
+++ b/agents-api/agents_api/common/utils/secrets.py
@@ -16,9 +16,7 @@ from ..retry_policies import DEFAULT_RETRY_POLICY
 
 
 @alru_cache(ttl=secrets_cache_ttl)
-async def get_secret_by_name(
-    developer_id: UUID, name: str, decrypt: bool = False
-) -> Secret:
+async def get_secret_by_name(developer_id: UUID, name: str, decrypt: bool = False) -> Secret:
     # FIXME: Should use workflow.in_workflow() instead ?
     try:
         secret = await workflow.execute_activity(

--- a/agents-api/agents_api/queries/secrets/get_by_name.py
+++ b/agents-api/agents_api/queries/secrets/get_by_name.py
@@ -13,7 +13,7 @@ query = """
 SELECT
     secret_id, developer_id, name, description,
     created_at, updated_at, metadata,
-    decrypt_secret(value_encrypted, $3) as value
+    CASE WHEN $4 = True THEN decrypt_secret(value_encrypted, $3) ELSE 'ENCRYPTED' END as value
 FROM secrets
 WHERE (
     developer_id = $1 AND
@@ -35,6 +35,7 @@ async def get_secret_by_name_query(
     *,
     developer_id: UUID,
     name: str,
+    decrypt: bool = False,
 ) -> tuple[str, list]:
     return (
         query,
@@ -42,6 +43,7 @@ async def get_secret_by_name_query(
             developer_id,
             name,
             secrets_master_key,
+            decrypt,
         ],
     )
 

--- a/agents-api/agents_api/queries/secrets/list.py
+++ b/agents-api/agents_api/queries/secrets/list.py
@@ -13,7 +13,7 @@ query = """
 SELECT
     secret_id, developer_id, name, description,
     created_at, updated_at, metadata,
-    decrypt_secret(value_encrypted, $4) as value
+    CASE WHEN $5 = True THEN decrypt_secret(value_encrypted, $4) ELSE 'ENCRYPTED' END as value
 FROM secrets
 WHERE (
     developer_id = $1
@@ -35,6 +35,7 @@ async def list_secrets_query(
     developer_id: UUID,
     limit: int = 100,
     offset: int = 0,
+    decrypt: bool = False,
 ) -> tuple[str, list]:
     return (
         query,
@@ -43,6 +44,7 @@ async def list_secrets_query(
             limit,
             offset,
             secrets_master_key,
+            decrypt,
         ],
     )
 

--- a/agents-api/agents_api/routers/sessions/render.py
+++ b/agents-api/agents_api/routers/sessions/render.py
@@ -170,7 +170,10 @@ async def render_chat_input(
     ):
         secrets = {
             secret.name: secret.value
-            for secret in await list_secrets_query(developer_id=developer.id)
+            for secret in await list_secrets_query(
+                developer_id=developer.id,
+                decrypt=True,
+            )
         }
 
     for tool in tools:

--- a/agents-api/tests/fixtures.py
+++ b/agents-api/tests/fixtures.py
@@ -31,6 +31,8 @@ from agents_api.queries.executions.create_execution_transition import (
 from agents_api.queries.executions.create_temporal_lookup import create_temporal_lookup
 from agents_api.queries.files.create_file import create_file
 from agents_api.queries.projects.create_project import create_project
+from agents_api.queries.secrets.delete import delete_secret
+from agents_api.queries.secrets.list import list_secrets
 from agents_api.queries.sessions.create_session import create_session
 from agents_api.queries.tasks.create_task import create_task
 from agents_api.queries.tools.create_tools import create_tools
@@ -50,8 +52,7 @@ from .utils import (
 from .utils import (
     patch_embed_acompletion as patch_embed_acompletion_ctx,
 )
-from agents_api.queries.secrets.list import list_secrets
-from agents_api.queries.secrets.delete import delete_secret
+
 
 @fixture(scope="global")
 def pg_dsn():
@@ -507,7 +508,6 @@ async def s3_client():
         finally:
             await s3_client.close()
             app.state.s3_client = None
-
 
 
 @fixture(scope="test")

--- a/agents-api/tests/test_secrets_queries.py
+++ b/agents-api/tests/test_secrets_queries.py
@@ -11,7 +11,7 @@ from agents_api.queries.secrets.list import list_secrets
 from agents_api.queries.secrets.update import update_secret
 from ward import test
 
-from tests.fixtures import pg_dsn, test_developer_id, clean_secrets
+from tests.fixtures import clean_secrets, pg_dsn, test_developer_id
 
 
 @test("query: create secret")
@@ -44,8 +44,6 @@ async def _(clean_secrets=clean_secrets, dsn=pg_dsn, developer_id=test_developer
 @test("query: list secrets")
 async def _(clean_secrets=clean_secrets, dsn=pg_dsn, developer_id=test_developer_id):
     pool = await create_db_pool(dsn=dsn)
-    
-
 
     # Create test secrets first - use unique but valid identifiers
     secret_name1 = f"list_test_key_a{uuid4().hex[:6]}"
@@ -89,12 +87,9 @@ async def _(clean_secrets=clean_secrets, dsn=pg_dsn, developer_id=test_developer
     assert any(secret.value == "sk_test_list_2" for secret in secrets)
 
 
-
 @test("query: list secrets (decrypt=False)")
 async def _(clean_secrets=clean_secrets, dsn=pg_dsn, developer_id=test_developer_id):
     pool = await create_db_pool(dsn=dsn)
-
-
 
     # Create test secrets first - use unique but valid identifiers
     secret_name1 = f"list_test_key_a{uuid4().hex[:6]}"
@@ -137,12 +132,9 @@ async def _(clean_secrets=clean_secrets, dsn=pg_dsn, developer_id=test_developer
     assert all(secret.value == "ENCRYPTED" for secret in secrets)
 
 
-
 @test("query: get secret by name")
 async def _(clean_secrets=clean_secrets, dsn=pg_dsn, developer_id=test_developer_id):
     pool = await create_db_pool(dsn=dsn)
-
-
 
     # Create a test secret first
     secret_name = f"get_test_key_a{uuid4().hex[:6]}"
@@ -172,8 +164,6 @@ async def _(clean_secrets=clean_secrets, dsn=pg_dsn, developer_id=test_developer
 async def _(clean_secrets=clean_secrets, dsn=pg_dsn, developer_id=test_developer_id):
     pool = await create_db_pool(dsn=dsn)
 
-
-
     # Create a test secret first
     secret_name = f"get_test_key_a{uuid4().hex[:6]}"
     await create_secret(
@@ -201,8 +191,6 @@ async def _(clean_secrets=clean_secrets, dsn=pg_dsn, developer_id=test_developer
 @test("query: update secret")
 async def _(clean_secrets=clean_secrets, dsn=pg_dsn, developer_id=test_developer_id):
     pool = await create_db_pool(dsn=dsn)
-
-
 
     # Create a test secret first
     original_name = f"update_test_key_a{uuid4().hex[:6]}"
@@ -259,8 +247,6 @@ async def _(clean_secrets=clean_secrets, dsn=pg_dsn, developer_id=test_developer
 async def _(clean_secrets=clean_secrets, dsn=pg_dsn, developer_id=test_developer_id):
     pool = await create_db_pool(dsn=dsn)
 
-
-
     # Create a test secret first
     delete_test_name = f"delete_test_key_a{uuid4().hex[:6]}"
     test_secret = await create_secret(
@@ -309,4 +295,3 @@ async def _(clean_secrets=clean_secrets, dsn=pg_dsn, developer_id=test_developer
 
     assert agent_delete_result is not None
     assert agent_delete_result.id == agent_secret.id
-

--- a/agents-api/tests/test_secrets_queries.py
+++ b/agents-api/tests/test_secrets_queries.py
@@ -21,7 +21,7 @@ async def clean_secrets(developer_id, connection_pool):
         developer_id=developer_id,
         connection_pool=connection_pool,
     )
-    
+
     # Delete each secret
     for secret in secrets:
         await delete_secret(
@@ -29,19 +29,21 @@ async def clean_secrets(developer_id, connection_pool):
             developer_id=developer_id,
             connection_pool=connection_pool,
         )
-    
+
     # Verify all secrets are deleted
     remaining_secrets = await list_secrets(
         developer_id=developer_id,
         connection_pool=connection_pool,
     )
-    assert len(remaining_secrets) == 0, f"Failed to clean up all secrets, {len(remaining_secrets)} remaining"
+    assert len(remaining_secrets) == 0, (
+        f"Failed to clean up all secrets, {len(remaining_secrets)} remaining"
+    )
 
 
 @test("query: create secret")
 async def _(dsn=pg_dsn, developer_id=test_developer_id):
     pool = await create_db_pool(dsn=dsn)
-    
+
     # Clean up any existing secrets first
     await clean_secrets(developer_id, pool)
 
@@ -66,7 +68,7 @@ async def _(dsn=pg_dsn, developer_id=test_developer_id):
     assert isinstance(agent_secret, Secret)
     assert agent_secret.name == agent_secret_data["name"]
     assert agent_secret.value == "ENCRYPTED"
-    
+
     # Clean up after test
     await clean_secrets(developer_id, pool)
 
@@ -74,7 +76,7 @@ async def _(dsn=pg_dsn, developer_id=test_developer_id):
 @test("query: list secrets")
 async def _(dsn=pg_dsn, developer_id=test_developer_id):
     pool = await create_db_pool(dsn=dsn)
-    
+
     # Clean up any existing secrets first
     await clean_secrets(developer_id, pool)
 
@@ -204,6 +206,7 @@ async def _(dsn=pg_dsn, developer_id=test_developer_id):
 
     await clean_secrets(developer_id, pool)
 
+
 @test("query: get secret by name (decrypt=False)")
 async def _(dsn=pg_dsn, developer_id=test_developer_id):
     pool = await create_db_pool(dsn=dsn)
@@ -235,6 +238,7 @@ async def _(dsn=pg_dsn, developer_id=test_developer_id):
     assert retrieved_secret.value == "ENCRYPTED"
 
     await clean_secrets(developer_id, pool)
+
 
 @test("query: update secret")
 async def _(dsn=pg_dsn, developer_id=test_developer_id):
@@ -294,6 +298,7 @@ async def _(dsn=pg_dsn, developer_id=test_developer_id):
     assert partial_update.metadata == updated_metadata  # Should remain from previous update
 
     await clean_secrets(developer_id, pool)
+
 
 @test("query: delete secret")
 async def _(dsn=pg_dsn, developer_id=test_developer_id):

--- a/agents-api/tests/test_secrets_routes.py
+++ b/agents-api/tests/test_secrets_routes.py
@@ -80,6 +80,7 @@ def _(make_request=make_request, developer_id=test_developer_id):
     assert len(secrets) > 0
     # Find our test secret
     assert any(secret["name"] == secret_name for secret in secrets)
+    assert all(secret["value"] == "ENCRYPTED" for secret in secrets)
 
 
 @test("route: update secret")


### PR DESCRIPTION
- **fix(agents-api): keep secrets encrypted for external use**
- **refactor: Lint agents-api (CI)**
- **chore(agents-api): add tests for decryption flag**

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add decryption flag to secret queries, allowing retrieval of secrets in encrypted or decrypted form, with corresponding tests and refactoring.
> 
>   - **Behavior**:
>     - Add `decrypt` flag to `get_secret_by_name` and `list_secrets_query` to control decryption of secrets.
>     - Modify SQL queries in `get_by_name.py` and `list.py` to return 'ENCRYPTED' if `decrypt` is `False`.
>     - Update `acompletion` in `litellm.py` to use `decrypt=True` when fetching secrets.
>   - **Tests**:
>     - Add tests in `test_secrets_queries.py` for both decrypted and encrypted secret retrieval.
>     - Add `clean_secrets` fixture in `fixtures.py` to ensure test isolation.
>   - **Misc**:
>     - Minor linting and refactoring in `agents-api` to improve code quality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 72734bbda83160cbc6169603a2558a0100c52577. You can [customize](https://app.ellipsis.dev/julep-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->