### PR TITLE
docs: fix parameters typo

### DIFF
--- a/documentation/integrations/supported-models.mdx
+++ b/documentation/integrations/supported-models.mdx
@@ -120,7 +120,7 @@ Though the models mention above support different embedding dimensions, Julep us
 
 ## Supported Parameters
 
-Following are a list of different paramters that can be used to control the behavior of the models.
+Following are a list of different parameters that can be used to control the behavior of the models.
 
 <AccordionGroup>
   <Accordion title="Core Parameters" icon="sliders" defaultOpen={true}>


### PR DESCRIPTION
## Summary
- fix a minor typo in supported models docs

## Testing
- `grep -n paramters -r documentation/integrations/supported-models.mdx`
