### PR TITLE
Fix mmr doc order bug

### DIFF
--- a/agents-api/agents_api/common/utils/mmr.py
+++ b/agents-api/agents_api/common/utils/mmr.py
@@ -143,7 +143,8 @@ def apply_mmr_to_docs(
             k=min(limit, len(docs_with_embeddings)),
             lambda_mult=1 - mmr_strength,
         )
-        return [doc for i, doc in enumerate(docs_with_embeddings) if i in set(indices)]
+        # Preserve the ranking returned by the MMR algorithm
+        return [docs_with_embeddings[i] for i in indices]
 
     # If docs are present but no embeddings are present for any of the docs, return the top k docs
     return docs[:limit]

--- a/agents-api/agents_api/queries/projects/__init__.py
+++ b/agents-api/agents_api/queries/projects/__init__.py
@@ -10,7 +10,6 @@ The `project` module within the `queries` package provides a comprehensive suite
 Each function in this module constructs and returns SQL queries along with their parameters for database operations.
 """
 
-
 from .create_project import create_project
 from .list_projects import list_projects
 

--- a/agents-api/agents_api/queries/projects/__init__.py
+++ b/agents-api/agents_api/queries/projects/__init__.py
@@ -10,7 +10,6 @@ The `project` module within the `queries` package provides a comprehensive suite
 Each function in this module constructs and returns SQL queries along with their parameters for database operations.
 """
 
-# ruff: noqa: F401, F403, F405
 
 from .create_project import create_project
 from .list_projects import list_projects


### PR DESCRIPTION
### **User description**
## Summary
- fix ordering bug in MMR util so docs remain ranked
- cleanup unused ruff noqa in projects queries

## Testing
- `ruff check agents-api/agents_api`


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixes MMR document ordering to preserve ranking.

- Removes unused ruff noqa directive from project queries.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mmr.py</strong><dd><code>Preserve MMR document ranking in output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/common/utils/mmr.py

<li>Changes MMR output to preserve ranking order.<br> <li> Ensures returned docs match MMR algorithm's ranking.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1374/files#diff-618f417b0650fb17e2e1c18fbfbc7beeb2f6dd6d0ea75fb5d72da97033a8f426">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Remove unused ruff noqa from project queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/queries/projects/__init__.py

<li>Removes unused ruff noqa lint directive.<br> <li> No functional code changes.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1374/files#diff-4645a18ae123dd61e0673fdbe4603d447e34da6e0653186eca45684ec346f3d2">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>