### PR TITLE
Add cookbook links in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@
   </h3>
 </div>
 
+# **Julep AI Changelog for 9 May 2025** ✨
+
+- **Minor Docs**: Added links to cookbooks for Quick, Community, and Industry pages.
+- **Minor Docs**: Updated cookbook links to use absolute GitHub URLs.
+
 # **Julep AI Changelog for 11 Apri 2025** ✨
 
 - **Major Feature**: Introduced support for Gemini models in `litellm-config.yaml` ✨

--- a/documentation/guides/cookbooks/community-examples.mdx
+++ b/documentation/guides/cookbooks/community-examples.mdx
@@ -8,4 +8,11 @@ groups: ['admin']
 
 Showcase of examples from the Julep community.
 
-[Placeholder content] 
+- [Hook Generator](https://github.com/julep-ai/julep/blob/dev/cookbooks/04-hook-generator-trending-reels.ipynb)
+  Generate hook lines for trending reels.
+- [Reel Generator](https://github.com/julep-ai/julep/blob/dev/cookbooks/10-reel-generator.ipynb)
+  Create short-form video scripts.
+- [Companion Agent](https://github.com/julep-ai/julep/blob/dev/cookbooks/09-companion-agent.ipynb)
+  Story-driven companion agent.
+- [Video Processing](https://github.com/julep-ai/julep/blob/dev/cookbooks/05-video-processing-with-natural-language.ipynb)
+  Process videos with natural language.

--- a/documentation/guides/cookbooks/industry-solutions.mdx
+++ b/documentation/guides/cookbooks/industry-solutions.mdx
@@ -8,4 +8,11 @@ groups: ['admin']
 
 Examples of Julep implementations across different industries.
 
-[Placeholder content] 
+- [Website Crawler](https://github.com/julep-ai/julep/blob/dev/cookbooks/01-website-crawler.ipynb)
+  Spider-based website crawler.
+- [Trip Planning Assistant](https://github.com/julep-ai/julep/blob/dev/cookbooks/03-trip-planning-assistant.ipynb)
+  Trip planning with weather data.
+- [Research Assistant](https://github.com/julep-ai/julep/blob/dev/cookbooks/07-personalized-research-assistant.ipynb)
+  Tailored research assistant.
+- [Video Processing](https://github.com/julep-ai/julep/blob/dev/cookbooks/05-video-processing-with-natural-language.ipynb)
+  Process videos with natural language.

--- a/documentation/guides/cookbooks/quick-solutions.mdx
+++ b/documentation/guides/cookbooks/quick-solutions.mdx
@@ -8,4 +8,11 @@ groups: ['admin']
 
 Collection of ready-to-use solutions for common scenarios.
 
-[Placeholder content] 
+- [Devfest Email Assistant](https://github.com/julep-ai/julep/blob/dev/cookbooks/00-Devfest-Email-Assistant.ipynb)
+  Event email management.
+- [Sarcastic Headlines](https://github.com/julep-ai/julep/blob/dev/cookbooks/02-sarcastic-news-headline-generator.ipynb)
+  Generate witty news headlines.
+- [Browser Use](https://github.com/julep-ai/julep/blob/dev/cookbooks/06-browser-use.ipynb)
+  Automate web browsing tasks.
+- [RAG Chatbot](https://github.com/julep-ai/julep/blob/dev/cookbooks/08-rag-chatbot.ipynb)
+  RAG chatbot demonstration.


### PR DESCRIPTION
## Summary
- link to notebooks from Quick Solutions, Community Examples and Industry Solutions using GitHub URLs
- update changelog

## Testing
- `ruff format documentation/guides/cookbooks/quick-solutions.mdx documentation/guides/cookbooks/community-examples.mdx documentation/guides/cookbooks/industry-solutions.mdx CHANGELOG.md` *(fails: Failed to parse)*