### PR TITLE
refactor: introduce julep_common env + exceptions

### DIFF
--- a/agents-api/Dockerfile
+++ b/agents-api/Dockerfile
@@ -20,14 +20,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-COPY .python-version pyproject.toml uv.lock ./
+COPY agents-api/.python-version agents-api/pyproject.toml agents-api/uv.lock ./
+COPY julep_common /julep_common
 
 RUN \
   uv sync --frozen --all-extras --no-group dev --color never --python-preference system
 
-COPY . ./
+COPY agents-api ./agents-api
 
 ENV PYTHONUNBUFFERED=1
 ENV GUNICORN_CMD_ARGS="--capture-output --enable-stdio-inheritance"
 
-ENTRYPOINT ["uv", "run", "--offline", "--no-sync", "gunicorn", "agents_api.web:app", "-c", "gunicorn_conf.py"]
+ENTRYPOINT ["uv", "run", "--offline", "--no-sync", "gunicorn", "agents_api.web:app", "-c", "agents-api/gunicorn_conf.py"]

--- a/agents-api/Dockerfile.worker
+++ b/agents-api/Dockerfile.worker
@@ -20,12 +20,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-COPY .python-version pyproject.toml uv.lock ./
+COPY agents-api/.python-version agents-api/pyproject.toml agents-api/uv.lock ./
+COPY julep_common /julep_common
 
 RUN \
   uv sync --frozen --all-extras --no-group dev --color never --python-preference system
 
-COPY . ./
+COPY agents-api ./agents-api
 
 ENV PYTHONUNBUFFERED=1
 ENV GUNICORN_CMD_ARGS="--capture-output --enable-stdio-inheritance"

--- a/agents-api/agents_api/activities/task_steps/transition_step.py
+++ b/agents-api/agents_api/activities/task_steps/transition_step.py
@@ -3,6 +3,7 @@ from typing import cast
 
 from beartype import beartype
 from fastapi import HTTPException
+from julep_common.exceptions import TooManyRequestsError
 from temporalio import activity
 
 from ...app import app
@@ -10,7 +11,7 @@ from ...autogen.openapi_model import CreateTransitionRequest, Transition
 from ...clients.temporal import get_workflow_handle
 from ...common.protocol.tasks import ExecutionInput, StepContext
 from ...env import temporal_activity_after_retry_timeout
-from ...exceptions import LastErrorInput, TooManyRequestsError
+from ...exceptions import LastErrorInput
 from ...queries.executions.create_execution_transition import (
     create_execution_transition,
 )

--- a/agents-api/agents_api/env.py
+++ b/agents-api/agents_api/env.py
@@ -8,10 +8,10 @@ import random
 from pprint import pprint
 from typing import TYPE_CHECKING, Any
 
-from environs import Env
+from julep_common.env import compute_gunicorn_workers, init_env
 
 # Initialize the Env object for environment variable parsing.
-env: Any = Env()
+env: Any = init_env()
 
 # Debug
 # -----
@@ -38,10 +38,7 @@ gunicorn_cpu_divisor: int = env.int("GUNICORN_CPU_DIVISOR", default=4)
 secrets_cache_ttl: int = env.int("SECRETS_CACHE_TTL", default=120)
 
 raw_workers: str | None = env.str("GUNICORN_WORKERS", default=None)
-if raw_workers and raw_workers.strip():
-    gunicorn_workers: int = int(raw_workers)
-else:
-    gunicorn_workers: int = max(multiprocessing.cpu_count() // gunicorn_cpu_divisor, 1)
+gunicorn_workers: int = compute_gunicorn_workers(raw_workers, gunicorn_cpu_divisor)
 
 
 # Tasks

--- a/agents-api/agents_api/exceptions.py
+++ b/agents-api/agents_api/exceptions.py
@@ -1,7 +1,9 @@
 from dataclasses import dataclass
 
+from julep_common.exceptions import JulepError
 
-class AgentsBaseException(Exception):
+
+class AgentsBaseException(JulepError):
     pass
 
 
@@ -26,10 +28,6 @@ class UnknownTokenizerError(AgentsBaseException):
 
     def __init__(self) -> None:
         super().__init__("unknown tokenizer")
-
-
-class TooManyRequestsError(Exception):
-    pass
 
 
 @dataclass

--- a/agents-api/docker-compose.yml
+++ b/agents-api/docker-compose.yml
@@ -63,8 +63,8 @@ x--base-agents-api: &base-agents-api
   build:
     platforms:
       - linux/amd64
-    context: .
-    dockerfile: Dockerfile
+    context: ..
+    dockerfile: agents-api/Dockerfile
 
   restart: on-failure
 
@@ -114,8 +114,8 @@ services:
     build:
       platforms:
         - linux/amd64
-      context: .
-      dockerfile: Dockerfile.worker
+      context: ..
+      dockerfile: agents-api/Dockerfile.worker
 
     develop:
       watch:

--- a/agents-api/pyproject.toml
+++ b/agents-api/pyproject.toml
@@ -5,6 +5,7 @@ description = "Julep's backend API"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
 dependencies = [
+  "julep-common @ file://../julep_common",
   "aiobotocore>=2.15.2",
   "anyio>=4.4.0",
   "arrow>=1.3.0",

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -19,8 +19,8 @@ group "default" {
 }
 
 target "agents-api" {
-  context = "./agents-api"
-  dockerfile = "Dockerfile"
+  context = "."
+  dockerfile = "agents-api/Dockerfile"
   tags = [
     "julepai/agents-api:${TAG}",
     "julepai/agents-api:git-${GIT_SHA}"
@@ -28,8 +28,8 @@ target "agents-api" {
 }
 
 target "agents-api-worker" {
-  context = "./agents-api"
-  dockerfile = "Dockerfile.worker"
+  context = "."
+  dockerfile = "agents-api/Dockerfile.worker"
   tags = [
     "julepai/worker:${TAG}",
     "julepai/worker:git-${GIT_SHA}"
@@ -46,8 +46,8 @@ target "memory-store" {
 }
 
 target "integrations" {
-  context = "./integrations-service"
-  dockerfile = "Dockerfile"
+  context = "."
+  dockerfile = "integrations-service/Dockerfile"
   tags = [
     "julepai/integrations:${TAG}",
     "julepai/integrations:git-${GIT_SHA}"

--- a/integrations-service/Dockerfile
+++ b/integrations-service/Dockerfile
@@ -17,16 +17,17 @@ RUN apt-get update && apt-get install -y \
 
 COPY --from=ghcr.io/astral-sh/uv:0.5.5 /uv /uvx /bin/
 
-COPY .python-version pyproject.toml uv.lock ./
+COPY integrations-service/.python-version integrations-service/pyproject.toml integrations-service/uv.lock ./
+COPY julep_common /julep_common
 
 RUN \
   uv sync --frozen --all-extras --no-group dev --color never --python-preference system
 
-COPY . ./
+COPY integrations-service ./integrations-service
 
 # Set proper signal handling
 ENV PYTHONUNBUFFERED=1
 ENV GUNICORN_CMD_ARGS="--capture-output --enable-stdio-inheritance"
 
 # Run the application with proper signal handling
-ENTRYPOINT ["uv", "run", "gunicorn", "integrations.web:app", "-c", "gunicorn_conf.py"]
+ENTRYPOINT ["uv", "run", "gunicorn", "integrations.web:app", "-c", "integrations-service/gunicorn_conf.py"]

--- a/integrations-service/docker-compose.yml
+++ b/integrations-service/docker-compose.yml
@@ -27,8 +27,8 @@ services:
     build:
       platforms:
         - linux/amd64
-      context: .
-      dockerfile: Dockerfile
+      context: ..
+      dockerfile: integrations-service/Dockerfile
 
     environment:
       <<: *shared-environment

--- a/integrations-service/integrations/env.py
+++ b/integrations-service/integrations/env.py
@@ -1,10 +1,7 @@
-import multiprocessing
-
-from environs import Env
+from julep_common.env import compute_gunicorn_workers, init_env
 
 # Initialize the Env object for environment variable parsing.
-env = Env()
-env.read_env()  # Read .env file, if it exists
+env = init_env()
 
 # Load environment variables
 browserbase_api_key = env.str("BROWSERBASE_API_KEY", default=None)
@@ -27,7 +24,4 @@ algolia_application_id = env.str("ALGOLIA_APPLICATION_ID", default=None)
 gunicorn_cpu_divisor: int = env.int("GUNICORN_CPU_DIVISOR", default=4)
 
 raw_workers: str | None = env.str("GUNICORN_WORKERS", default=None)
-if raw_workers and raw_workers.strip():
-    gunicorn_workers: int = int(raw_workers)
-else:
-    gunicorn_workers: int = max(multiprocessing.cpu_count() // gunicorn_cpu_divisor, 1)
+gunicorn_workers: int = compute_gunicorn_workers(raw_workers, gunicorn_cpu_divisor)

--- a/integrations-service/pyproject.toml
+++ b/integrations-service/pyproject.toml
@@ -5,6 +5,7 @@ description = "julep integrations service"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
 dependencies = [
+  "julep-common @ file://../julep_common",
   "langchain-community~=0.3.0",
   "fastapi~=0.115.0",
   "uvicorn~=0.30.6",

--- a/julep_common/README.md
+++ b/julep_common/README.md
@@ -1,0 +1,3 @@
+# julep_common
+
+Shared utilities and exceptions for Julep services.

--- a/julep_common/julep_common/__init__.py
+++ b/julep_common/julep_common/__init__.py
@@ -1,0 +1,9 @@
+from .env import compute_gunicorn_workers, init_env
+from .exceptions import JulepError, TooManyRequestsError
+
+__all__ = [
+    "JulepError",
+    "TooManyRequestsError",
+    "compute_gunicorn_workers",
+    "init_env",
+]

--- a/julep_common/julep_common/env.py
+++ b/julep_common/julep_common/env.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import multiprocessing
+from typing import Any
+
+from environs import Env
+
+
+def init_env() -> Env:
+    """Initialize and return an :class:`Env` instance."""
+    env: Any = Env()
+    env.read_env()
+    return env
+
+
+def compute_gunicorn_workers(raw_workers: str | None, gunicorn_cpu_divisor: int) -> int:
+    """Return the number of Gunicorn workers to use."""
+    if raw_workers and raw_workers.strip():
+        return int(raw_workers)
+    return max(multiprocessing.cpu_count() // gunicorn_cpu_divisor, 1)

--- a/julep_common/julep_common/exceptions.py
+++ b/julep_common/julep_common/exceptions.py
@@ -1,0 +1,9 @@
+"""Common exception classes for Julep services."""
+
+
+class JulepError(Exception):
+    """Base exception for Julep."""
+
+
+class TooManyRequestsError(JulepError):
+    """Raised when a request rate limit is exceeded."""

--- a/julep_common/pyproject.toml
+++ b/julep_common/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "julep-common"
+version = "0.1.0"
+description = "Shared utilities for Julep services"
+readme = "README.md"
+requires-python = ">=3.12,<3.13"
+dependencies = [
+    "environs>=10.0",
+]
+
+[tool.setuptools]
+py-modules = ["julep_common"]


### PR DESCRIPTION
## Summary
- share `init_env` and `compute_gunicorn_workers` in new `julep_common` package
- add `JulepError` and `TooManyRequestsError` exceptions
- use shared utilities in agents-api and integrations service
- copy shared package in Docker builds
- update docker-bake and compose files

## Testing
- `ruff check`
- `ruff format`
