### PR TITLE
docs: dev journey guides + architecture diagram

### DIFF
--- a/documentation/advanced/architecture-deep-dive.mdx
+++ b/documentation/advanced/architecture-deep-dive.mdx
@@ -28,6 +28,14 @@ To help you visualize this, here's a diagram:
     height={1000}
   />
 </Frame>
+<Frame caption="System Architecture">
+  <img
+    src="/images/architecture-diagram.svg"
+    width={1000}
+    height={600}
+  />
+</Frame>
+
 
 ## Core Components
 

--- a/documentation/docs.json
+++ b/documentation/docs.json
@@ -125,6 +125,8 @@
                   "guides/getting-started/chat-with-an-agent",
                   "guides/getting-started/create-and-execute-julep-task",
                   "guides/using-secrets",
+                  "guides/adding-tool-integration",
+                  "guides/modifying-agent-workflow",
                   {
                     "group": "Getting Started Examples",
                     "pages": [

--- a/documentation/guides/adding-tool-integration.mdx
+++ b/documentation/guides/adding-tool-integration.mdx
@@ -1,0 +1,20 @@
+---
+title: 'Adding a Tool Integration'
+description: 'Extend Julep with your own tool or API'
+---
+
+# Adding a Tool Integration
+
+This guide explains how to connect a new external tool or API to Julep. You will create a small service that wraps the tool and exposes actions that agents can call.
+
+## 1. Create an Integration Service
+
+Use the Julep SDK to define your integration service. Each action should accept structured inputs and return structured outputs.
+
+## 2. Register the Service
+
+Deploy the service and register its OpenAPI specification with your Julep project. The new actions become available to your agents.
+
+## 3. Invoke From a Task
+
+Call the actions from your task steps. The agent can now leverage your custom tool as part of its workflow.

--- a/documentation/guides/modifying-agent-workflow.mdx
+++ b/documentation/guides/modifying-agent-workflow.mdx
@@ -1,0 +1,20 @@
+---
+title: 'Modifying Agent Workflow'
+description: 'Customize how your agents process tasks'
+---
+
+# Modifying Agent Workflow
+
+Julep tasks are flexible workflows that control how an agent operates. This guide shows how to adjust the default behavior.
+
+## 1. Edit the Task YAML
+
+Add, remove, or reorder steps in your task definition. You can insert tool calls, conditional logic, or loops to suit your needs.
+
+## 2. Update Agent Configuration
+
+Point your agent to the new task file or update its task list via the SDK. Your changes apply immediately to new sessions.
+
+## 3. Test Iteratively
+
+Run the task locally or through the API to verify each modification. Adjust prompts and steps until the workflow produces the desired output.

--- a/documentation/images/architecture-diagram.svg
+++ b/documentation/images/architecture-diagram.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300" viewBox="0 0 600 300">
+  <rect x="20" y="40" width="150" height="60" fill="#E6F7FF" stroke="#004E64" />
+  <text x="95" y="75" font-size="14" text-anchor="middle" fill="#004E64">Client App</text>
+
+  <rect x="225" y="20" width="200" height="100" fill="#F0FFF4" stroke="#004E64" />
+  <text x="325" y="45" font-size="14" text-anchor="middle" fill="#004E64">Julep Cloud</text>
+  <rect x="245" y="60" width="70" height="40" fill="#FFFFFF" stroke="#004E64" />
+  <text x="280" y="85" font-size="12" text-anchor="middle" fill="#004E64">Agents</text>
+  <rect x="335" y="60" width="70" height="40" fill="#FFFFFF" stroke="#004E64" />
+  <text x="370" y="85" font-size="12" text-anchor="middle" fill="#004E64">Workflows</text>
+
+  <rect x="450" y="40" width="130" height="60" fill="#FFF5F5" stroke="#004E64" />
+  <text x="515" y="75" font-size="14" text-anchor="middle" fill="#004E64">External Tools</text>
+
+  <line x1="170" y1="70" x2="225" y2="70" stroke="#004E64" marker-end="url(#arrow)" />
+  <line x1="425" y1="70" x2="450" y2="70" stroke="#004E64" marker-end="url(#arrow)" />
+
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="10" refY="5" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,5 L0,10 z" fill="#004E64" />
+    </marker>
+  </defs>
+</svg>


### PR DESCRIPTION
## Summary
- add guides for adding tool integrations and modifying agent workflows
- create system architecture diagram
- embed the new diagram in the architecture deep dive
- link the new pages in docs navigation

## Testing
- `npx mintlify dev` *(fails: EHOSTUNREACH)*