### PR TITLE
Fix MMR doc ordering

### DIFF
--- a/agents-api/agents_api/common/utils/mmr.py
+++ b/agents-api/agents_api/common/utils/mmr.py
@@ -143,7 +143,15 @@ def apply_mmr_to_docs(
             k=min(limit, len(docs_with_embeddings)),
             lambda_mult=1 - mmr_strength,
         )
-        return [doc for i, doc in enumerate(docs_with_embeddings) if i in set(indices)]
+        # Deduplicate indices while preserving their order
+        unique_indices: list[int] = []
+        seen: set[int] = set()
+        for idx in indices:
+            if idx not in seen:
+                seen.add(idx)
+                unique_indices.append(idx)
+
+        return [docs_with_embeddings[i] for i in unique_indices]
 
     # If docs are present but no embeddings are present for any of the docs, return the top k docs
     return docs[:limit]


### PR DESCRIPTION
## Summary
- preserve doc ranking order in `apply_mmr_to_docs`

## Testing
- `ruff check integrations-service/integrations/utils/integrations/browserbase.py agents-api/agents_api/common/utils/mmr.py`