### PR TITLE
Define CLI tool models

### DIFF
--- a/cli/src/julep_cli/models.py
+++ b/cli/src/julep_cli/models.py
@@ -1,6 +1,15 @@
 from typing import Annotated, Any, Literal
 
+# pyright: reportCallIssue=false
 from pydantic import BaseModel, ConfigDict, Field, StrictBool
+
+from .tool_models import (
+    ApiCallDef,
+    Bash20241022Def,
+    Computer20241022Def,
+    FunctionDef,
+    TextEditor20241022Def,
+)
 
 
 class CreateAgentRequest(BaseModel):
@@ -8,9 +17,9 @@ class CreateAgentRequest(BaseModel):
     Payload for creating an agent
     """
 
-    model_config = ConfigDict(
+    model_config = ConfigDict(  # pyright: ignore[call-issue]
         populate_by_name=True,
-    )
+    )  # pyright: ignore[call-issue]
     metadata: dict[str, Any] | None = None
     name: Annotated[str, Field(max_length=255, min_length=1)]
     """
@@ -46,9 +55,9 @@ class CreateToolRequest(BaseModel):
     Payload for creating a tool
     """
 
-    model_config = ConfigDict(
+    model_config = ConfigDict(  # pyright: ignore[call-issue]
         populate_by_name=True,
-    )
+    )  # pyright: ignore[call-issue]
     name: Annotated[str, Field(max_length=40, pattern="^[^\\W0-9]\\w*$")]
     """
     Name of the tool (must be unique for this agent and a valid python identifier string )
@@ -69,7 +78,7 @@ class CreateToolRequest(BaseModel):
     """
     Description of the tool
     """
-    function: Any | None = None  # TODO: Change to FunctionDef
+    function: FunctionDef | None = None
     """
     The function to call
     """
@@ -83,16 +92,16 @@ class CreateToolRequest(BaseModel):
     """
     The system to call
     """
-    api_call: Any | None = None  # TODO: Change to ApiCallDef
+    api_call: ApiCallDef | None = None
     """
     The API call to make
     """
-    computer_20241022: Any | None = None  # TODO: Change to Computer20241022Def
+    computer_20241022: Computer20241022Def | None = None
     """
     (Alpha) Anthropic new tools
     """
-    text_editor_20241022: Any | None = None  # TODO: Change to TextEditor20241022Def
-    bash_20241022: Any | None = None  # TODO: Change to Bash20241022Def
+    text_editor_20241022: TextEditor20241022Def | None = None
+    bash_20241022: Bash20241022Def | None = None
 
 
 class CreateTaskRequest(BaseModel):
@@ -100,9 +109,9 @@ class CreateTaskRequest(BaseModel):
     Payload for creating a task
     """
 
-    model_config = ConfigDict(
+    model_config = ConfigDict(  # pyright: ignore[call-issue]
         populate_by_name=True,
-    )
+    )  # pyright: ignore[call-issue]
     name: Annotated[str, Field(max_length=255, min_length=1)]
     """
     The name of the task.

--- a/cli/src/julep_cli/tool_models.py
+++ b/cli/src/julep_cli/tool_models.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+# pyright: reportCallIssue=false
+from typing import Annotated, Any, Literal
+
+from pydantic import AnyUrl, BaseModel, ConfigDict, Field, StrictBool
+
+# AIDEV-NOTE: These models duplicate a subset of API definitions for CLI usage.
+
+
+class SecretRef(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)  # pyright: ignore[call-issue]
+    name: str
+
+
+class FunctionDef(BaseModel):
+    """Function tool definition used in CLI models."""
+
+    model_config = ConfigDict(populate_by_name=True)  # pyright: ignore[call-issue]
+    name: Any | None = None
+    description: Any | None = None
+    parameters: dict[str, Any] | None = None
+
+
+class ApiCallDef(BaseModel):
+    """HTTP API call definition."""
+
+    model_config = ConfigDict(populate_by_name=True)  # pyright: ignore[call-issue]
+
+    method: Literal[
+        "GET",
+        "POST",
+        "PUT",
+        "DELETE",
+        "PATCH",
+        "HEAD",
+        "OPTIONS",
+        "CONNECT",
+        "TRACE",
+    ]
+    url: AnyUrl
+    schema_: Annotated[dict[str, Any] | None, Field(alias="schema")] = None
+    headers: dict[str, str] | None = None
+    secrets: dict[str, SecretRef] | None = None
+    content: str | None = None
+    data: dict[str, Any] | None = None
+    files: dict[str, Any] | None = None
+    json_: Annotated[dict[str, Any] | None, Field(alias="json")] = None
+    cookies: dict[str, str] | None = None
+    params: str | dict[str, Any] | None = None
+    follow_redirects: StrictBool | None = None
+    timeout: int | None = None
+    include_response_content: StrictBool = True
+
+
+class Computer20241022Def(BaseModel):
+    """Anthropic computer tool definition."""
+
+    model_config = ConfigDict(populate_by_name=True)  # pyright: ignore[call-issue]
+    type: Literal["computer_20241022"] = "computer_20241022"
+    name: str = "computer"
+    display_width_px: Annotated[int, Field(ge=600)] = 1024
+    display_height_px: Annotated[int, Field(ge=400)] = 768
+    display_number: Annotated[int, Field(ge=1, le=10)] = 1
+
+
+class TextEditor20241022Def(BaseModel):
+    """Anthropic text editor tool definition."""
+
+    model_config = ConfigDict(populate_by_name=True)  # pyright: ignore[call-issue]
+    type: Literal["text_editor_20241022"] = "text_editor_20241022"
+    name: str = "str_replace_editor"
+
+
+class Bash20241022Def(BaseModel):
+    """Anthropic bash tool definition."""
+
+    model_config = ConfigDict(populate_by_name=True)  # pyright: ignore[call-issue]
+    type: Literal["bash_20241022"] = "bash_20241022"
+    name: str = "bash"


### PR DESCRIPTION
### **User description**
## Summary
- add pydantic models for tool definitions used by the CLI
- switch CreateToolRequest to use the new models

## Testing
- `ruff check src/julep_cli/tool_models.py src/julep_cli/models.py`
- `pyright --project pyproject.toml src/julep_cli/tool_models.py src/julep_cli/models.py`
- `ward --version` *(fails: command not found)*


___

### **PR Type**
enhancement


___

### **Description**
- Introduce explicit Pydantic models for CLI tool definitions
  - Adds `FunctionDef`, `ApiCallDef`, `Computer20241022Def`, `TextEditor20241022Def`, and `Bash20241022Def`

- Refactor `CreateToolRequest` to use new tool models
  - Replaces generic `Any` types with specific model classes

- Improve type safety and code clarity in CLI models


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tool_models.py</strong><dd><code>Add Pydantic models for CLI tool definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/src/julep_cli/tool_models.py

<li>Introduces new Pydantic models for tool definitions<br> <li> Adds <code>FunctionDef</code>, <code>ApiCallDef</code>, and Anthropic tool models<br> <li> Provides type-safe structures for CLI tool payloads<br> <li> Includes helper class <code>SecretRef</code>


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1387/files#diff-b8a1a7c4bafe72528b01efff6da8c070f07db611b57691e0387c7f1a6c85104e">+80/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>models.py</strong><dd><code>Refactor CreateToolRequest to use explicit tool models</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/src/julep_cli/models.py

<li>Imports and uses new tool models in <code>CreateToolRequest</code><br> <li> Replaces <code>Any</code> types with explicit model classes for tool fields<br> <li> Updates model config usage for type checking


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1387/files#diff-f0395eda491458e50bb4077b5314b0be259f66290e92f40ccd473a026b007dd8">+20/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Pydantic models for CLI tool definitions and update `CreateToolRequest` to use these models for improved type safety.
> 
>   - **Models**:
>     - Add new Pydantic models in `tool_models.py`: `FunctionDef`, `ApiCallDef`, `Computer20241022Def`, `TextEditor20241022Def`, `Bash20241022Def`.
>     - Update `CreateToolRequest` in `models.py` to use new models: `FunctionDef`, `ApiCallDef`, `Computer20241022Def`, `TextEditor20241022Def`, `Bash20241022Def`.
>   - **Testing**:
>     - Run `ruff`, `pyright`, and `ward` for static analysis and testing (note: `ward` command not found).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 7702e4a470ba941bafae297aeec3b432cf496baf. You can [customize](https://app.ellipsis.dev/julep-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->