### PR TITLE
Remove TODO references in CLI documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
   </h3>
 </div>
 
+# **Julep AI Changelog for 1 June 2025** ✨
+
+- **Docs Fix**: Removed TODO placeholders from CLI documentation.
+
 # **Julep AI Changelog for 9 May 2025** ✨
 
 - **Minor Docs**: Added links to cookbooks for Quick, Community, and Industry pages.

--- a/cli/README.md
+++ b/cli/README.md
@@ -70,7 +70,6 @@ The `julep` CLI tool provides a comprehensive command-line interface for interac
         - [Standard Input/Output Handling](#standard-inputoutput-handling)
         - [Quiet Mode](#quiet-mode)
         - [Color Output](#color-output)
-  - [TODO](#todo)
 
 ---
 
@@ -1238,6 +1237,3 @@ julep agents list --color     # Force enable colored output
 - `NO_COLOR`: Set this to any value to disable color output
 - `FORCE_COLOR`: Set this to any value to force color output
 
-## TODO
-
-- [x] Add `julep import agent --id <agent_id> --output=<path>`

--- a/cli/spec.md
+++ b/cli/spec.md
@@ -71,7 +71,6 @@ The `julep-cli` CLI tool provides a comprehensive command-line interface for int
         - [Standard Input/Output Handling](#standard-inputoutput-handling)
         - [Quiet Mode](#quiet-mode)
         - [Color Output](#color-output)
-  - [TODO](#todo)
 
 ---
 
@@ -1225,4 +1224,3 @@ julep agents list --color     # Force enable colored output
 
 ---
 
-## TODO


### PR DESCRIPTION
## Summary
- clean up TODO links and sections in CLI README and spec
- add CHANGELOG entry about docs fix

## Testing
- `pip install poethepoet` *(fails: cannot connect to proxy)*