### PR TITLE
Enable pgaudit and enforce doc fk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@
   </h3>
 </div>
 
+# **Julep AI Changelog for 17 May 2025** ✨
+
+- **Security**: Enabled pgaudit in the development Docker stack.
+- **Integrity**: Added foreign key constraint for `doc_owners` to ensure docs exist.
+- **Maintenance**: Updated token counting trigger to use `NEW.model`.
+- **Migration**: Bumped to version `000042` with upgrade and rollback scripts.
+
 # **Julep AI Changelog for 9 May 2025** ✨
 
 - **Minor Docs**: Added links to cookbooks for Quick, Community, and Industry pages.

--- a/memory-store/docker-compose.yml
+++ b/memory-store/docker-compose.yml
@@ -11,11 +11,13 @@ services:
     volumes:
       - memory_store_data:/home/postgres/pgdata/data
 
-    # TODO: Fix this to install pgaudit
-    # entrypoint: []
-    # command: >-
-    #   sed -r -i "s/[#]*\s*(shared_preload_libraries)\s*=\s*'(.*)'/\1 = 'pgaudit,\2'/;s/,'/'/" /home/postgres/pgdata/data/postgresql.conf
-    #   && exec /docker-entrypoint.sh
+    # Install and enable pgaudit for logging
+    entrypoint: ["bash", "-c"]
+    command: >-
+      apt-get update && apt-get install -y postgresql-17-pgaudit &&
+      sed -ri "s/[#]*\s*(shared_preload_libraries)\s*=\s*'(.*)'/\1 = 'pgaudit,\2'/;s/,'/'/" /home/postgres/pgdata/data/postgresql.conf &&
+      echo "pgaudit.log = 'read, write'" >> /home/postgres/pgdata/data/postgresql.conf &&
+      exec /docker-entrypoint.sh postgres
 
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres || exit 1"]

--- a/memory-store/migrations/000006_docs.down.sql
+++ b/memory-store/migrations/000006_docs.down.sql
@@ -4,6 +4,7 @@ BEGIN;
 DROP TRIGGER IF EXISTS trg_validate_doc_owner ON doc_owners;
 DROP FUNCTION IF EXISTS validate_doc_owner();
 DROP INDEX IF EXISTS idx_doc_owners_owner;
+ALTER TABLE IF EXISTS doc_owners DROP CONSTRAINT IF EXISTS fk_doc_owners_doc;
 DROP TABLE IF EXISTS doc_owners CASCADE;
 
 -- Drop docs table and its dependencies
@@ -16,6 +17,7 @@ DROP INDEX IF EXISTS idx_docs_content_trgm;
 DROP INDEX IF EXISTS idx_docs_title_trgm;
 DROP INDEX IF EXISTS idx_docs_search_tsv;
 DROP INDEX IF EXISTS idx_docs_metadata;
+ALTER TABLE IF EXISTS docs DROP CONSTRAINT IF EXISTS uq_docs_developer_doc;
 
 -- Drop docs table
 DROP TABLE IF EXISTS docs CASCADE;

--- a/memory-store/migrations/000006_docs.up.sql
+++ b/memory-store/migrations/000006_docs.up.sql
@@ -32,6 +32,10 @@ CREATE TABLE IF NOT EXISTS docs (
     CONSTRAINT ct_metadata_is_object CHECK (jsonb_typeof(metadata) = 'object')
 );
 
+-- Ensure doc exists uniquely per developer
+ALTER TABLE docs
+ADD CONSTRAINT uq_docs_developer_doc UNIQUE (developer_id, doc_id);
+
 -- Create foreign key constraint if not exists (using DO block for safety)
 DO $$
 BEGIN
@@ -65,8 +69,8 @@ CREATE TABLE IF NOT EXISTS doc_owners (
     owner_type TEXT NOT NULL, -- 'user' or 'agent'
     owner_id UUID NOT NULL,
     CONSTRAINT pk_doc_owners PRIMARY KEY (developer_id, doc_id),
-    -- TODO: Ensure that doc exists (this constraint is not working)
-    -- CONSTRAINT fk_doc_owners_doc FOREIGN KEY (developer_id, doc_id) REFERENCES docs (developer_id, doc_id),
+    CONSTRAINT fk_doc_owners_doc FOREIGN KEY (developer_id, doc_id)
+        REFERENCES docs (developer_id, doc_id) ON DELETE CASCADE,
     CONSTRAINT ct_doc_owners_owner_type CHECK (owner_type IN ('user', 'agent'))
 );
 

--- a/memory-store/migrations/000015_entries.up.sql
+++ b/memory-store/migrations/000015_entries.up.sql
@@ -81,6 +81,7 @@ END $$;
 -- TODO: We should consider using a timescale background job to update the token count
 -- instead of a trigger.
 -- https://docs.timescale.com/use-timescale/latest/user-defined-actions/create-and-register/
+-- AIDEV-NOTE: Evaluate moving token updates to a background job if inserts remain slow.
 CREATE
 OR REPLACE FUNCTION optimized_update_token_count_after () RETURNS TRIGGER AS $$
 DECLARE
@@ -89,7 +90,7 @@ BEGIN
     -- Compute token_count outside the UPDATE statement for clarity and potential optimization
     calc_token_count := cardinality(
         ai.openai_tokenize(
-            'gpt-4o', -- FIXME: Use `NEW.model`
+            NEW.model,
             array_to_string(NEW.content::TEXT[], ' ')
         )
     );
@@ -110,6 +111,7 @@ $$ LANGUAGE plpgsql;
 -- We should consider using a timescale background job to update the token count
 -- instead of a trigger.
 -- https://docs.timescale.com/use-timescale/latest/user-defined-actions/create-and-register/
+-- AIDEV-NOTE: Monitor performance and offload to background job if needed.
 --
 -- CREATE TRIGGER trg_optimized_update_token_count_after
 -- AFTER INSERT

--- a/memory-store/migrations/000042_doc_fk_and_token_function.down.sql
+++ b/memory-store/migrations/000042_doc_fk_and_token_function.down.sql
@@ -1,0 +1,30 @@
+BEGIN;
+
+ALTER TABLE doc_owners
+DROP CONSTRAINT IF EXISTS fk_doc_owners_doc;
+
+ALTER TABLE docs
+DROP CONSTRAINT IF EXISTS uq_docs_developer_doc;
+
+CREATE OR REPLACE FUNCTION optimized_update_token_count_after () RETURNS TRIGGER AS $$
+DECLARE
+    calc_token_count INTEGER;
+BEGIN
+    calc_token_count := cardinality(
+        ai.openai_tokenize(
+            'gpt-4o',
+            array_to_string(NEW.content::TEXT[], ' ')
+        )
+    );
+
+    IF calc_token_count <> NEW.token_count THEN
+        UPDATE entries
+        SET token_count = calc_token_count
+        WHERE entry_id = NEW.entry_id;
+    END IF;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;

--- a/memory-store/migrations/000042_doc_fk_and_token_function.up.sql
+++ b/memory-store/migrations/000042_doc_fk_and_token_function.up.sql
@@ -1,0 +1,32 @@
+BEGIN;
+
+ALTER TABLE docs
+ADD CONSTRAINT IF NOT EXISTS uq_docs_developer_doc UNIQUE (developer_id, doc_id);
+
+ALTER TABLE doc_owners
+ADD CONSTRAINT IF NOT EXISTS fk_doc_owners_doc
+FOREIGN KEY (developer_id, doc_id)
+REFERENCES docs (developer_id, doc_id) ON DELETE CASCADE;
+
+CREATE OR REPLACE FUNCTION optimized_update_token_count_after () RETURNS TRIGGER AS $$
+DECLARE
+    calc_token_count INTEGER;
+BEGIN
+    calc_token_count := cardinality(
+        ai.openai_tokenize(
+            NEW.model,
+            array_to_string(NEW.content::TEXT[], ' ')
+        )
+    );
+
+    IF calc_token_count <> NEW.token_count THEN
+        UPDATE entries
+        SET token_count = calc_token_count
+        WHERE entry_id = NEW.entry_id;
+    END IF;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- enable pgaudit in memory-store docker compose
- enforce doc ownership with foreign key
- compute token counts using NEW.model
- add migration 000042 for prod rollout
- document the migration in CHANGELOG

## Testing
- `ruff format memory-store/docker-compose.yml memory-store/migrations/000006_docs.up.sql memory-store/migrations/000006_docs.down.sql memory-store/migrations/000015_entries.up.sql memory-store/migrations/000042_doc_fk_and_token_function.up.sql memory-store/migrations/000042_doc_fk_and_token_function.down.sql` *(fails: Failed to parse ...)*