### PR TITLE
Remove connection_pool args and extend chat processing

### DIFF
--- a/agents-api/agents_api/routers/docs/create_doc.py
+++ b/agents-api/agents_api/routers/docs/create_doc.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Any
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import Depends
@@ -15,7 +15,6 @@ async def create_user_doc(
     user_id: UUID,
     data: CreateDocRequest,
     x_developer_id: Annotated[UUID, Depends(get_developer_id)],
-    connection_pool: Any = None,  # FIXME: Placeholder that should be removed
 ) -> Doc:
     """
     Creates a new document for a user.
@@ -44,7 +43,6 @@ async def create_agent_doc(
     agent_id: UUID,
     data: CreateDocRequest,
     x_developer_id: Annotated[UUID, Depends(get_developer_id)],
-    connection_pool: Any = None,  # FIXME: Placeholder that should be removed
 ) -> Doc:
     doc: Doc = await create_doc_query(
         developer_id=x_developer_id,

--- a/agents-api/agents_api/routers/docs/search_docs.py
+++ b/agents-api/agents_api/routers/docs/search_docs.py
@@ -1,5 +1,5 @@
 import time
-from typing import Annotated, Any
+from typing import Annotated
 from uuid import UUID
 
 import numpy as np
@@ -23,7 +23,6 @@ async def search_user_docs(
     x_developer_id: Annotated[UUID, Depends(get_developer_id)],
     search_params: (TextOnlyDocSearchRequest | VectorDocSearchRequest | HybridDocSearchRequest),
     user_id: UUID,
-    connection_pool: Any = None,  # FIXME: Placeholder that should be removed
 ) -> DocSearchResponse:
     """
     Searches for documents associated with a specific user.
@@ -76,7 +75,6 @@ async def search_agent_docs(
     x_developer_id: Annotated[UUID, Depends(get_developer_id)],
     search_params: (TextOnlyDocSearchRequest | VectorDocSearchRequest | HybridDocSearchRequest),
     agent_id: UUID,
-    connection_pool: Any = None,  # FIXME: Placeholder that should be removed
 ) -> DocSearchResponse:
     """
     Searches for documents associated with a specific agent.


### PR DESCRIPTION
## Summary
- drop unused `connection_pool` parameters from docs and chat endpoints
- store all response choices in session history
- add streaming support
- handle truncation, datetime serialization and tool formatting in render

## Testing
- `ruff format --diff --quiet .`
- `ruff check agents-api/agents_api/routers/sessions/chat.py agents-api/agents_api/routers/docs/create_doc.py agents-api/agents_api/routers/docs/search_docs.py agents-api/agents_api/routers/responses/create_response.py agents-api/agents_api/routers/sessions/render.py`
