### PR TITLE
Add YAML/JSON agent definition support to CLI

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -458,9 +458,9 @@ Parent command for managing agents. Includes subcommands to create, update, dele
    - `--default-settings`, (optional): Default settings for the agent. Value is parsed as json.
    - `--metadata`, (optional): Metadata for the agent. Value is parsed as json.
    - `--instructions`, (optional): Instructions for the agent, repeat the option to add multiple.
-   - `--definition`, `-d` (optional): Path to an agent definition file.
+   - `--definition`, `-d` (optional): Path to an agent definition file (YAML or JSON).
 
-   Either provide a definition file or use the other options to create the agent.
+   Either provide a YAML/JSON definition file or use the other options to create the agent.
 
    **Example:**
 
@@ -1187,8 +1187,8 @@ The CLI supports reading from standard input (stdin) and writing to standard out
 
 Reading definition from stdin:
 ```bash
-cat agent.yaml | julep agents create -d -  # Read definition from stdin
-echo '{"name": "MyAgent"}' | julep agents create -i -  # Read JSON from stdin
+cat agent.yaml | julep agents create -d -  # Read YAML from stdin
+echo '{"name": "MyAgent"}' | julep agents create -d -  # Read JSON from stdin
 ```
 
 Piping between commands:

--- a/cli/cli-reference.md
+++ b/cli/cli-reference.md
@@ -213,7 +213,7 @@ $ julep agents create [OPTIONS]
 * `--default-settings TEXT`: Default settings for the agent (JSON string)
 * `--metadata TEXT`: Metadata for the agent (JSON string)
 * `--instructions TEXT`: Instructions for the agent, can be specified multiple times
-* `-d, --definition TEXT`: Path to an agent definition file
+* `-d, --definition TEXT`: Path to an agent definition file (YAML or JSON)
 * `--help`: Show this message and exit.
 
 ### `julep agents update`

--- a/documentation/julepcli/commands.mdx
+++ b/documentation/julepcli/commands.mdx
@@ -320,7 +320,7 @@ The commands in `julep agents` are used to manage your agents.
     </ParamField>
 
     <ParamField path="--definition" type="string">
-      Path to agent definition file
+      Path to agent definition file (YAML or JSON)
     </ParamField>
 
     **Examples:**


### PR DESCRIPTION
### **User description**
## Summary
- allow passing YAML or JSON files via `--definition`
- parse definition file and create agent from it
- document that `--definition` accepts YAML/JSON

## Testing
- `ruff format src/julep_cli/agents.py`
- `ruff check src/julep_cli/agents.py`
- `pyright` *(fails: Import "typer" could not be resolved)*
- `ward` *(command not found)*


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Add support for agent creation from YAML/JSON definition files
  - Accepts file path or stdin via `--definition`
  - Parses YAML or JSON, with error handling
  - Allows override of fields via CLI options

- Update CLI documentation to reflect YAML/JSON support
  - Clarify usage and examples for stdin/file input
  - Update parameter descriptions in docs and reference


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agents.py</strong><dd><code>Add YAML/JSON agent definition support and refactor creation logic</code></dd></summary>
<hr>

cli/src/julep_cli/agents.py

<li>Add <code>_load_definition</code> to parse YAML/JSON from file or stdin<br> <li> Implement agent creation from definition file with field overrides<br> <li> Improve error handling for parsing and input validation<br> <li> Refactor payload construction for clarity and flexibility


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1409/files#diff-b1a41e513192e4a5242984e21cf301b79bc446ea66f55830104268d9780065a9">+66/-25</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update documentation for YAML/JSON agent definition support</code></dd></summary>
<hr>

cli/README.md

<li>Update <code>--definition</code> option description to mention YAML/JSON<br> <li> Clarify that definition file can be YAML or JSON<br> <li> Fix stdin example to use <code>-d</code> for both YAML and JSON


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1409/files#diff-a60fd8fcc968f85dd50305193d1af8e94118afb7439f90c07bb434acd3490fab">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cli-reference.md</strong><dd><code>Clarify agent definition file format in CLI reference</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/cli-reference.md

- Update `--definition` option to specify YAML/JSON support


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1409/files#diff-d97869b243a8b18624688b6697039436e431cd9d14c7bb88d8878d6d6b66de83">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>commands.mdx</strong><dd><code>Document YAML/JSON support for agent definition parameter</code></dd></summary>
<hr>

documentation/julepcli/commands.mdx

- Update `--definition` parameter description to mention YAML/JSON


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1409/files#diff-5abc8a0c19e861f9737b5ead14d6c70d168f8832583f7fa0f039902b3d283eb1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>