### PR TITLE
Enable tool loop for LLM calls

### DIFF
--- a/agents-api/agents_api/activities/task_steps/prompt_step.py
+++ b/agents-api/agents_api/activities/task_steps/prompt_step.py
@@ -1,5 +1,7 @@
 # AIDEV-NOTE: This module contains the activity for executing a prompt step, which interacts with the language model.
 from beartype import beartype
+import contextlib
+import json
 from litellm.types.utils import ModelResponse
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
@@ -10,54 +12,13 @@ from ...clients import (
 )
 from ...common.protocol.tasks import ExecutionInput, StepContext, StepOutcome
 from ...env import debug
+from ..execute_api_call import execute_api_call
+from ..execute_integration import execute_integration
+from ..execute_system import execute_system
 from .base_evaluate import base_evaluate
+from ...common.utils.tool_runner import format_tool, run_llm_with_tools
 
 COMPUTER_USE_BETA_FLAG = "computer-use-2024-10-22"
-
-
-# AIDEV-NOTE: Formats internal Tool definitions into the structure expected by the LLM (currently focused on OpenAI function tools).
-@beartype
-def format_tool(tool: Tool | CreateToolRequest) -> dict:
-    if tool.type == "function":
-        return {
-            "type": "function",
-            "function": {
-                "name": tool.name,
-                "description": tool.description,
-                "parameters": tool.function and tool.function.parameters,
-            },
-        }
-
-    # For other tool types, we need to translate them to the OpenAI function tool format
-    return {
-        "type": "function",
-        "function": {"name": tool.name, "description": tool.description},
-    }
-
-    # AIDEV-TODO: Implement system tools formatting.
-    # FIXME: Implement system tools
-    # if tool.type == "system":
-    #     handler: Callable = get_handler_with_filtered_params(tool.system)
-
-    #     lc_tool: BaseTool = tool_decorator(handler)
-
-    #     json_schema: dict = lc_tool.get_input_jsonschema()
-
-    #     formatted["function"]["description"] = formatted["function"][
-    #         "description"
-    #     ] or json_schema.get("description")
-
-    #     formatted["function"]["parameters"] = json_schema
-
-    # AIDEV-TODO: Implement integration tools formatting.
-    # FIXME: Implement integration tools
-    # elif tool.type == "integration":
-    #     raise NotImplementedError("Integration tools are not supported")
-
-    # AIDEV-TODO: Implement API call tools formatting.
-    # FIXME: Implement API call tools
-    # elif tool.type == "api_call":
-    #     raise NotImplementedError("API call tools are not supported")
 
 
 @activity.defn
@@ -110,80 +71,40 @@ async def prompt_step(context: StepContext) -> StepOutcome:
     if not passed_settings.get("tools"):
         passed_settings.pop("tool_choice", None)
 
-    # Format tools for litellm
-    formatted_tools = [format_tool(tool) for tool in await context.tools()]
+    all_tools = await context.tools()
 
-    # Map tools to their original objects
-    tools_mapping: dict[str, Tool] = {
-        fmt_tool.get("name") or fmt_tool.get("function", {}).get("name"): orig_tool
-        for fmt_tool, orig_tool in zip(formatted_tools, await context.tools())
-    }
+    async def run_tool(tool: Tool | CreateToolRequest, call: BaseChosenToolCall) -> ToolExecutionResult:
+        arguments = {}
+        if call.function and call.function.arguments:
+            with contextlib.suppress(Exception):
+                arguments = json.loads(call.function.arguments)
 
-    # Check if using Claude model and has specific tool types
-    is_claude_model = agent_model.lower().startswith("claude-3.5")
+        if tool.type == "integration" and tool.integration:
+            output = await execute_integration(context, tool.name, tool.integration, arguments)
+            return ToolExecutionResult(id=call.id or "", name=tool.name, output=output)
+        if tool.type == "system" and tool.system:
+            system = tool.system.model_copy(update={"arguments": arguments})
+            output = await execute_system(context, system)
+            return ToolExecutionResult(id=call.id or "", name=tool.name, output=output)
+        if tool.type == "api_call" and tool.api_call:
+            output = await execute_api_call(tool.api_call, arguments)
+            return ToolExecutionResult(id=call.id or "", name=tool.name, output=output)
+        return ToolExecutionResult(id=call.id or "", name=tool.name, output={})
 
-    # AIDEV-FIXME: Hack to make the computer use tools compatible with litellm.
-    # Issue was: litellm expects type to be `computer_20241022` and spec to be
-    # `function` (see: https://docs.litellm.ai/docs/providers/anthropic#computer-tools)
-    # but we don't allow that (spec should match type).
-    formatted_tools = []
-    for i, tool in enumerate(await context.tools()):
-        if tool.type == "computer_20241022" and tool.computer_20241022:
-            function = tool.computer_20241022
-            tool = {
-                "type": tool.type,
-                "function": {
-                    "name": tool.name,
-                    "parameters": {
-                        k: v
-                        for k, v in function.model_dump().items()
-                        if k not in ["name", "type"]
-                    },
-                },
-            }
-            formatted_tools.append(tool)
-    # For non-Claude models, we don't need to send tools
-    # AIDEV-TODO: Enable formatted_tools once format-tools PR is merged.
-    # FIXME: Enable formatted_tools once format-tools PR is merged.
-    if not is_claude_model:
-        formatted_tools = None
-
-    # AIDEV-HOTFIX: for groq calls, litellm expects tool_calls_id not to be in the messages.
-    # AIDEV-FIXME: This is a temporary fix. We need to update the agent-api to use the new tool calling format.
-    # HOTFIX: for groq calls, litellm expects tool_calls_id not to be in the messages
-    # FIXME: This is a temporary fix. We need to update the agent-api to use the new tool calling format
-    # AIDEV-TODO: Enable formatted_tools once format-tools PR is merged.
-    # FIXME: Enable formatted_tools once format-tools PR is merged.
-    is_groq_model = agent_model.lower().startswith("llama-3.1")
-    if is_groq_model:
-        prompt = [
-            {
-                k: v
-                for k, v in message.items()
-                if k not in ["tool_calls", "tool_call_id", "user", "continue_", "name"]
-            }
-            for message in prompt
-        ]
-
-    # Remove None values from passed_settings (avoid overwriting agent's settings)
     passed_settings = {k: v for k, v in passed_settings.items() if v is not None}
 
-    # Use litellm for other models
     completion_data: dict = {
         "model": agent_model,
-        "tools": formatted_tools or None,
-        "messages": prompt,
         **agent_default_settings,
         **passed_settings,
     }
 
-    extra_body = {
-        "cache": {"no-cache": debug or context.current_step.disable_cache},
-    }
-
-    response: ModelResponse = await litellm.acompletion(
-        **completion_data,
-        extra_body=extra_body,
+    response: ModelResponse = await run_llm_with_tools(
+        messages=prompt,
+        tools=all_tools,
+        settings=completion_data,
+        run_tool_call=run_tool,
+        user=str(context.execution_input.developer_id),
     )
 
     if context.current_step.unwrap:
@@ -201,34 +122,7 @@ async def prompt_step(context: StepContext) -> StepOutcome:
             next=None,
         )
 
-    # AIDEV-NOTE: Re-convert tool-calls from LLM response back to internal integration/system call format if needed.
-    # Re-convert tool-calls to integration/system calls if needed
-    response_as_dict = response.model_dump()
-
-    for choice in response_as_dict["choices"]:
-        if choice["finish_reason"] == "tool_calls":
-            calls = choice["message"]["tool_calls"]
-
-            for call in calls:
-                call_name = call["function"]["name"]
-                call_args = call["function"]["arguments"]
-
-                original_tool = tools_mapping.get(call_name)
-                if not original_tool:
-                    msg = f"Tool {call_name} not found"
-                    raise ApplicationError(msg)
-
-                if original_tool.type == "function":
-                    continue
-
-                call.pop("function")
-                call["type"] = original_tool.type
-                call[original_tool.type] = {
-                    "name": call_name,
-                    "arguments": call_args,
-                }
-
     return StepOutcome(
-        output=response_as_dict,
+        output=response.model_dump(),
         next=None,
     )

--- a/agents-api/agents_api/common/utils/tool_runner.py
+++ b/agents-api/agents_api/common/utils/tool_runner.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Awaitable, Callable, Sequence
+
+from beartype import beartype
+from litellm.utils import ModelResponse
+
+from ...clients import litellm
+from ...autogen.openapi_model import (
+    BaseChosenToolCall,
+    CreateToolRequest,
+    Tool,
+    ToolExecutionResult,
+)
+from ..utils.tool_executor import format_tool_results_for_llm
+
+
+@beartype
+def format_tool(tool: Tool | CreateToolRequest) -> dict:
+    """Format a Tool or CreateToolRequest for the LLM."""
+
+    if tool.type == "function":
+        return {
+            "type": "function",
+            "function": {
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": tool.function and tool.function.parameters,
+            },
+        }
+    if tool.type == "integration" and tool.integration is not None:
+        return {
+            "type": "function",
+            "function": {
+                "name": tool.name,
+                "description": tool.description
+                or f"Integration {tool.integration.provider}.{tool.integration.method}",
+                "parameters": {
+                    "type": "object",
+                    "additionalProperties": True,
+                },
+            },
+        }
+    if tool.type == "system" and tool.system is not None:
+        return {
+            "type": "function",
+            "function": {
+                "name": tool.name,
+                "description": tool.description
+                or f"System {tool.system.resource}.{tool.system.operation}",
+                "parameters": {
+                    "type": "object",
+                    "additionalProperties": True,
+                },
+            },
+        }
+    if tool.type == "api_call" and tool.api_call is not None:
+        return {
+            "type": "function",
+            "function": {
+                "name": tool.name,
+                "description": tool.description
+                or f"API call {tool.api_call.method} {tool.api_call.url}",
+                "parameters": {
+                    "type": "object",
+                    "additionalProperties": True,
+                },
+            },
+        }
+    return {
+        "type": "function",
+        "function": {"name": tool.name, "description": tool.description},
+    }
+
+
+@beartype
+async def run_llm_with_tools(
+    *,
+    messages: list[dict],
+    tools: Sequence[Tool | CreateToolRequest],
+    settings: dict[str, Any],
+    run_tool_call: Callable[[Tool | CreateToolRequest, BaseChosenToolCall], Awaitable[ToolExecutionResult]],
+    user: str | None = None,
+) -> ModelResponse:
+    """Run the LLM with a tool loop."""
+
+    formatted_tools = [format_tool(t) for t in tools]
+    tool_map = {t.name: t for t in tools}
+
+    while True:
+        response: ModelResponse = await litellm.acompletion(
+            tools=formatted_tools,
+            messages=messages,
+            user=user,
+            **settings,
+        )
+        choice = response.choices[0]
+        messages.append(choice.message.model_dump())
+
+        if choice.finish_reason != "tool_calls" or not choice.message.tool_calls:
+            return response
+
+        for call in choice.message.tool_calls:
+            tool = tool_map.get(call.function.name)
+            if tool is None:
+                continue
+            result = await run_tool_call(tool, call)
+            messages.append(format_tool_results_for_llm(result))
+
+


### PR DESCRIPTION
## Summary
- add tool runner util to manage LLM tool loops
- update prompt step to execute integration/system/api tools automatically
- enable tool loop in chat response router

## Testing
- `poe format` *(fails: `poe` not found)*
- `poe lint` *(fails: `poe` not found)*
- `poe typecheck` *(fails: `poe` not found)*