### PR TITLE
Remove 'n' parameter from responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 - **Minor Docs**: Added links to cookbooks for Quick, Community, and Industry pages.
 - **Minor Docs**: Updated cookbook links to use absolute GitHub URLs.
+- **Minor Docs**: Removed the `n` parameter from the Responses API; requests now return a single choice.
 
 # **Julep AI Changelog for 11 Apri 2025** ✨
 

--- a/documentation/responses/concepts.mdx
+++ b/documentation/responses/concepts.mdx
@@ -28,7 +28,7 @@ The Responses API offers a streamlined way to interact with language models with
 
 ### 2.1. Response Configuration Options
 
-When creating a response, you can leverage these configuration options to tailor the experience:
+When creating a response, you can leverage these configuration options to tailor the experience. The API always returns a single response, so the deprecated `n` parameter is no longer needed:
 
 | Option                | Type                                     | Description                                                                                       | Default        | Status        |
 |-----------------------|------------------------------------------|---------------------------------------------------------------------------------------------------|----------------|---------------|
@@ -41,8 +41,6 @@ When creating a response, you can leverage these configuration options to tailor
 | `max_tokens`          | `integer` \| `null`                      | Maximum number of tokens to generate                                                              | `None`         | Implemented   |
 | `temperature`         | `number`                                 | Controls randomness in response generation (0 to 1)                                               | `1`            | Implemented   |
 | `top_p`               | `number`                                 | Controls diversity in token selection (0 to 1)                                                    | `1`            | Implemented   |
-| `n`                   | `integer` \| `null`                      | Number of responses to generate                                                                   | `None`         | Implemented   |
-| `stop`                | `string` \| `array` \| `null`            | Sequence(s) where the model should stop generating                                                | `None`         | Implemented   |
 | `presence_penalty`    | `number` \| `null`                       | Penalty for new tokens based on presence in text so far                                           | `None`         | Implemented   |
 | `frequency_penalty`   | `number` \| `null`                       | Penalty for new tokens based on frequency in text so far                                          | `None`         | Implemented   |
 | `logit_bias`          | `object` \| `null`                       | Modify likelihood of specific tokens appearing                                                    | `None`         | Implemented   |

--- a/typespec/responses/models.tsp
+++ b/typespec/responses/models.tsp
@@ -40,7 +40,6 @@ model CreateResponse {
   max_tokens?: int32;
   temperature?: float = 1.0;
   top_p?: float = 1.0;
-  n?: int32;
   stop?: string | string[];
   presence_penalty?: float;
   frequency_penalty?: float;


### PR DESCRIPTION
### **User description**
## Summary
- remove deprecated `n` field from `CreateResponse`
- update docs to reflect single-choice responses
- mention change in changelog

## Testing
- `scripts/generate_openapi_code.sh` *(failed: invalid TypeSpec compiler setup)*
- `uvx poe lint` *(failed: failed to fetch poe)*


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Removed deprecated `n` parameter from Responses API.

- Updated documentation to reflect single-choice responses.

- Updated changelog to mention removal of `n` parameter.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>models.tsp</strong><dd><code>Remove `n` parameter from CreateResponse model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

typespec/responses/models.tsp

<li>Removed the <code>n</code> parameter from the <code>CreateResponse</code> model.<br> <li> Ensured API reflects single-response behavior.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1417/files#diff-881498a8f37634cdc7f067664de9a94c27078b6700f1645b761506b2bec3084f">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>concepts.mdx</strong><dd><code>Update docs to remove `n` and clarify single response</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

documentation/responses/concepts.mdx

<li>Updated configuration options to remove <code>n</code> parameter.<br> <li> Clarified that API always returns a single response.<br> <li> Removed <code>n</code> from options table.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1417/files#diff-7d7cac63fefda15459d8d549497915e5ee92dc03b209f89ae933459d23371372">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Add changelog entry for `n` parameter removal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Added entry noting removal of <code>n</code> parameter from Responses API.<br> <li> Clarified that requests now return a single choice.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1417/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove deprecated `n` parameter from `CreateResponse` and update documentation for single-choice responses.
> 
>   - **Behavior**:
>     - Remove deprecated `n` parameter from `CreateResponse` in `models.tsp`.
>     - Update `concepts.mdx` to reflect single-choice responses, removing mention of `n` parameter.
>   - **Documentation**:
>     - Update `CHANGELOG.md` to mention removal of `n` parameter and single-choice response behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for db957aff3330a89fdb67835ac31b362a534435be. You can [customize](https://app.ellipsis.dev/julep-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->