### PR TITLE
[AI] enforce strict message schema

### DIFF
--- a/agents-api/agents_api/autogen/openapi_model.py
+++ b/agents-api/agents_api/autogen/openapi_model.py
@@ -79,6 +79,7 @@ class ChatMLImageContentPart(ContentModel):
 class InputChatMLMessage(Message):
     pass
 
+
 # AIDEV-NOTE: forbid extra fields to prevent silently ignoring invalid message attributes
 Message.model_config = ConfigDict(**{**Message.model_config, "extra": "forbid"})
 InputChatMLMessage.model_config = ConfigDict(**{**Message.model_config, "extra": "forbid"})

--- a/agents-api/agents_api/autogen/openapi_model.py
+++ b/agents-api/agents_api/autogen/openapi_model.py
@@ -79,6 +79,10 @@ class ChatMLImageContentPart(ContentModel):
 class InputChatMLMessage(Message):
     pass
 
+# AIDEV-NOTE: forbid extra fields to prevent silently ignoring invalid message attributes
+Message.model_config = ConfigDict(**{**Message.model_config, "extra": "forbid"})
+InputChatMLMessage.model_config = ConfigDict(**{**Message.model_config, "extra": "forbid"})
+
 
 IntegrationDef = (
     BraveIntegrationDef


### PR DESCRIPTION
### **User description**
## Summary
- disallow unexpected fields on message objects so invalid YAML fails

## Testing
- `poe check` *(fails: command not found)*
- `poetry run poe check` in `agents-api` *(fails: Command not found: poe)*


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Forbid extra fields in `Message` and `InputChatMLMessage` models

- Prevents invalid message attributes from being silently ignored

- Enforces strict schema validation for message objects


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openapi_model.py</strong><dd><code>Forbid extra fields in message model configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/autogen/openapi_model.py

<li>Set <code>extra="forbid"</code> in <code>Message</code> and <code>InputChatMLMessage</code> model configs<br> <li> Prevents acceptance of arbitrary/invalid keys in message objects<br> <li> Adds a note explaining the rationale for stricter validation


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1421/files#diff-b4908fde0ee2c2d8853f798d6ae2b3e9122cbd30ca1cd8e1dc4ada653c74e631">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enforce strict message schema by forbidding extra fields in `Message` and `InputChatMLMessage` to prevent ignoring invalid attributes.
> 
>   - **Behavior**:
>     - Enforce strict message schema by forbidding extra fields in `Message` and `InputChatMLMessage` classes in `openapi_model.py`.
>     - Prevents silently ignoring invalid message attributes.
>   - **Testing**:
>     - `poe check` and `poetry run poe check` commands fail due to command not found.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for d564ebfc0b5b9ac2b2c08771759056a48343774e. You can [customize](https://app.ellipsis.dev/julep-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->