### PR TITLE
Support python expressions in prompt settings

### DIFF
--- a/agents-api/agents_api/activities/task_steps/prompt_step.py
+++ b/agents-api/agents_api/activities/task_steps/prompt_step.py
@@ -107,6 +107,9 @@ async def prompt_step(context: StepContext) -> StepOutcome:
     passed_settings.update(passed_settings.pop("settings", {}) or {})
     passed_settings["user"] = str(context.execution_input.developer_id)
 
+    # AIDEV-NOTE: Evaluate python expressions in settings before calling the LLM
+    passed_settings = await base_evaluate(passed_settings, context)
+
     if not passed_settings.get("tools"):
         passed_settings.pop("tool_choice", None)
 


### PR DESCRIPTION
### **User description**
## Summary
- evaluate prompt step settings using `base_evaluate`

## Testing
- `poetry run poe check` *(fails: `Failed to fetch https://pypi.org/simple/poethepoet/`)*


___

### **PR Type**
Enhancement


___

### **Description**
- Evaluate Python expressions in prompt step settings using `base_evaluate`

- Ensure settings are processed before LLM invocation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prompt_step.py</strong><dd><code>Evaluate and process prompt step settings before LLM call</code></dd></summary>
<hr>

agents-api/agents_api/activities/task_steps/prompt_step.py

<li>Added evaluation of Python expressions in <code>passed_settings</code> via <br><code>base_evaluate</code><br> <li> Ensured settings are processed asynchronously before LLM call


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1422/files#diff-568607bf9eff0a7b0bac363c2f9c64de9aec36b6e67497724377962151efb6f1">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Evaluate Python expressions in `prompt_step` settings using `base_evaluate` in `prompt_step.py`.
> 
>   - **Behavior**:
>     - In `prompt_step()` in `prompt_step.py`, evaluate Python expressions in `passed_settings` using `base_evaluate` before calling the language model.
>   - **Testing**:
>     - `poetry run poe check` fails due to a dependency fetch issue.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for ba318c39deca0bf274bf9b2622c9d817ca9b1bb7. You can [customize](https://app.ellipsis.dev/julep-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->