### PR TITLE
Fix SetStep to store values

### DIFF
--- a/agents-api/agents_api/workflows/task_execution/__init__.py
+++ b/agents-api/agents_api/workflows/task_execution/__init__.py
@@ -523,6 +523,17 @@ class TaskExecutionWorkflow:
 
         output = self.outcome.output
         workflow.logger.debug(f"Set step: Completed evaluation with output: {output}")
+
+        # AIDEV-NOTE: Persist evaluated values so subsequent GetStep operations
+        # can retrieve them via workflow.memo_value.
+        if isinstance(output, dict):
+            for key, value in output.items():
+                workflow.upsert_memo({key: value})
+        else:
+            workflow.logger.error(
+                "SetStep output must be a dictionary for memo storage",
+            )
+
         return WorkflowResult(state=PartialTransition(output=output))
 
     async def _handle_GetStep(


### PR DESCRIPTION
## Summary
- persist evaluated values in `SetStep`

## Testing
- `ruff check agents-api`
- `ruff format agents-api`
- `uv run python -m ward --search execution_workflow tests` *(fails: No route to host)*