### PR TITLE
Update session lookup for party model

### DIFF
--- a/memory-store/migrations/000043_session_lookup_party_model.down.sql
+++ b/memory-store/migrations/000043_session_lookup_party_model.down.sql
@@ -1,0 +1,55 @@
+-- Revert session_lookup to participant-based model
+ALTER TABLE session_lookup DROP CONSTRAINT IF EXISTS fk_session_lookup_party;
+ALTER TABLE session_lookup DROP CONSTRAINT IF EXISTS session_lookup_pkey;
+
+-- Recreate participant_type enum
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'participant_type') THEN
+        CREATE TYPE participant_type AS ENUM ('user', 'agent');
+    END IF;
+END $$;
+
+ALTER TABLE session_lookup ADD COLUMN IF NOT EXISTS participant_type participant_type;
+ALTER TABLE session_lookup ADD COLUMN IF NOT EXISTS participant_id UUID;
+
+UPDATE session_lookup sl
+SET participant_type = p.party_type,
+    participant_id = p.party_id
+FROM parties p
+WHERE sl.party_id = p.party_id
+  AND sl.developer_id = p.developer_id;
+
+ALTER TABLE session_lookup ALTER COLUMN participant_type SET NOT NULL;
+ALTER TABLE session_lookup ALTER COLUMN participant_id SET NOT NULL;
+ALTER TABLE session_lookup ADD PRIMARY KEY (developer_id, session_id, participant_type, participant_id);
+DROP INDEX IF EXISTS idx_session_lookup_by_party;
+CREATE INDEX IF NOT EXISTS idx_session_lookup_by_participant ON session_lookup (developer_id, participant_type, participant_id);
+ALTER TABLE session_lookup DROP COLUMN IF EXISTS party_id;
+
+-- Recreate legacy owner tables
+CREATE TABLE IF NOT EXISTS doc_owners (
+    developer_id UUID NOT NULL,
+    doc_id UUID NOT NULL,
+    owner_type TEXT NOT NULL,
+    owner_id UUID NOT NULL,
+    PRIMARY KEY (developer_id, doc_id)
+);
+INSERT INTO doc_owners (developer_id, doc_id, owner_type, owner_id)
+SELECT d.developer_id, d.doc_id, p.party_type, p.party_id
+FROM document_owners d
+JOIN parties p ON d.developer_id = p.developer_id AND d.party_id = p.party_id;
+
+CREATE TABLE IF NOT EXISTS file_owners (
+    developer_id UUID NOT NULL,
+    file_id UUID NOT NULL,
+    owner_type TEXT NOT NULL,
+    owner_id UUID NOT NULL,
+    PRIMARY KEY (developer_id, file_id)
+);
+ALTER TABLE file_owners_party RENAME TO file_owners_tmp;
+INSERT INTO file_owners (developer_id, file_id, owner_type, owner_id)
+SELECT f.developer_id, f.file_id, p.party_type, p.party_id
+FROM file_owners_tmp f
+JOIN parties p ON f.developer_id = p.developer_id AND f.party_id = p.party_id;
+DROP TABLE file_owners_tmp;

--- a/memory-store/migrations/000043_session_lookup_party_model.up.sql
+++ b/memory-store/migrations/000043_session_lookup_party_model.up.sql
@@ -1,0 +1,48 @@
+-- AIDEV-NOTE: Normalize session_lookup to use parties
+-- Add party_id column
+ALTER TABLE session_lookup ADD COLUMN IF NOT EXISTS party_id UUID;
+
+-- Populate party_id from existing participant columns
+UPDATE session_lookup sl
+SET party_id = u.party_id
+FROM users u
+WHERE sl.participant_type = 'user'
+  AND sl.developer_id = u.developer_id
+  AND sl.participant_id = u.user_id;
+
+UPDATE session_lookup sl
+SET party_id = a.party_id
+FROM agents a
+WHERE sl.participant_type = 'agent'
+  AND sl.developer_id = a.developer_id
+  AND sl.participant_id = a.agent_id;
+
+-- Enforce not null and add foreign key
+ALTER TABLE session_lookup ALTER COLUMN party_id SET NOT NULL;
+ALTER TABLE session_lookup
+    ADD CONSTRAINT fk_session_lookup_party FOREIGN KEY (developer_id, party_id)
+        REFERENCES parties (developer_id, party_id) ON DELETE CASCADE;
+
+-- Update primary key and indexes
+ALTER TABLE session_lookup DROP CONSTRAINT IF EXISTS session_lookup_pkey;
+ALTER TABLE session_lookup ADD PRIMARY KEY (developer_id, session_id, party_id);
+DROP INDEX IF EXISTS idx_session_lookup_by_participant;
+CREATE INDEX IF NOT EXISTS idx_session_lookup_by_party ON session_lookup (developer_id, party_id);
+
+-- Remove old validation triggers and columns
+DROP TRIGGER IF EXISTS trg_validate_participant_before_insert ON session_lookup;
+DROP TRIGGER IF EXISTS trg_validate_participant_before_update ON session_lookup;
+DROP FUNCTION IF EXISTS validate_participant();
+ALTER TABLE session_lookup DROP COLUMN IF EXISTS participant_type;
+ALTER TABLE session_lookup DROP COLUMN IF EXISTS participant_id;
+DROP TYPE IF EXISTS participant_type;
+
+-- Drop legacy owner tables and rename new ones
+DROP TRIGGER IF EXISTS trg_validate_doc_owner ON doc_owners;
+DROP FUNCTION IF EXISTS validate_doc_owner();
+DROP TABLE IF EXISTS doc_owners CASCADE;
+
+DROP TRIGGER IF EXISTS trg_validate_file_owner ON file_owners;
+DROP FUNCTION IF EXISTS validate_file_owner();
+DROP TABLE IF EXISTS file_owners;
+ALTER TABLE IF EXISTS file_owners_party RENAME TO file_owners;


### PR DESCRIPTION
### **User description**
## Summary
- add migration to normalize session lookup table using party ids
- include down migration for reversal

## Testing
- `poe check` *(fails: command not found)*


___

### **PR Type**
Enhancement


___

### **Description**
- Normalize `session_lookup` table to use `party_id` instead of participant columns
  - Add and populate `party_id` column, update constraints and indexes
  - Remove participant-based columns, triggers, and types

- Clean up and rename document and file owner tables
  - Drop legacy owner tables and triggers, rename new tables

- Provide full down migration to revert all changes
  - Restore participant-based model and legacy tables


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>000043_session_lookup_party_model.up.sql</strong><dd><code>Normalize session_lookup to party-based model, clean up owner tables</code></dd></summary>
<hr>

memory-store/migrations/000043_session_lookup_party_model.up.sql

<li>Adds migration to normalize <code>session_lookup</code> using <code>party_id</code><br> <li> Populates new column from users/agents, updates constraints and <br>indexes<br> <li> Removes participant columns, triggers, types, and legacy owner tables<br> <li> Renames and cleans up file owner tables


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1426/files#diff-77a3d2e40cff64017e95ac6dbed1438cf502f41cd0ebc722fb18c177435663a3">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>000043_session_lookup_party_model.down.sql</strong><dd><code>Down migration to restore participant-based session_lookup</code></dd></summary>
<hr>

memory-store/migrations/000043_session_lookup_party_model.down.sql

<li>Adds down migration to revert to participant-based model<br> <li> Restores participant columns, types, and legacy owner tables<br> <li> Recreates indexes and migrates data back<br> <li> Drops party-based columns and structures


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1426/files#diff-09baa6aa908da44cd6c720907d990ef5ffa7305dde45f01ab7612c636238b7d2">+55/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add migration to normalize `session_lookup` using `party_id` and provide a down migration to revert changes.
> 
>   - **Migration**:
>     - `000043_session_lookup_party_model.up.sql`: Adds `party_id` to `session_lookup`, populates it from `users` and `agents`, enforces not null, adds foreign key, updates primary key and indexes, removes old triggers and columns, and drops legacy owner tables.
>     - `000043_session_lookup_party_model.down.sql`: Reverts to participant-based model, recreates `participant_type` enum, restores columns, updates data from `parties`, recreates legacy owner tables, and renames temporary tables.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for e0009d59025e5cc5623415f281ef126ab7631ab1. You can [customize](https://app.ellipsis.dev/julep-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->