### PR TITLE
Add user and agent file routes

### DIFF
--- a/agents-api/agents_api/routers/files/__init__.py
+++ b/agents-api/agents_api/routers/files/__init__.py
@@ -1,7 +1,19 @@
 # ruff: noqa: F401
 
-from .create_file import create_file
-from .delete_file import delete_file
+from .create_file import (
+    create_agent_file,
+    create_file,
+    create_user_file,
+)
+from .delete_file import (
+    delete_agent_file,
+    delete_file,
+    delete_user_file,
+)
 from .get_file import get_file
-from .list_files import list_files
+from .list_files import (
+    list_agent_files,
+    list_files,
+    list_user_files,
+)
 from .router import router

--- a/agents-api/agents_api/routers/files/create_file.py
+++ b/agents-api/agents_api/routers/files/create_file.py
@@ -37,3 +37,43 @@ async def create_file(
     await upload_file_content(file.id, data.content)
 
     return file
+
+
+@router.post("/users/{user_id}/files", status_code=HTTP_201_CREATED, tags=["files"])
+async def create_user_file(
+    user_id: UUID,
+    data: CreateFileRequest,
+    x_developer_id: Annotated[UUID, Depends(get_developer_id)],
+) -> File:
+    """Create a file owned by a user."""
+    # AIDEV-NOTE: new route for associating files with users
+    file = await create_file_query(
+        developer_id=x_developer_id,
+        owner_type="user",
+        owner_id=user_id,
+        data=data,
+    )
+
+    await upload_file_content(file.id, data.content)
+
+    return file
+
+
+@router.post("/agents/{agent_id}/files", status_code=HTTP_201_CREATED, tags=["files"])
+async def create_agent_file(
+    agent_id: UUID,
+    data: CreateFileRequest,
+    x_developer_id: Annotated[UUID, Depends(get_developer_id)],
+) -> File:
+    """Create a file owned by an agent."""
+    # AIDEV-NOTE: new route for associating files with agents
+    file = await create_file_query(
+        developer_id=x_developer_id,
+        owner_type="agent",
+        owner_id=agent_id,
+        data=data,
+    )
+
+    await upload_file_content(file.id, data.content)
+
+    return file

--- a/agents-api/agents_api/routers/files/delete_file.py
+++ b/agents-api/agents_api/routers/files/delete_file.py
@@ -30,3 +30,47 @@ async def delete_file(
     await delete_file_content(file_id)
 
     return resource_deleted
+
+
+@router.delete(
+    "/users/{user_id}/files/{file_id}", status_code=HTTP_202_ACCEPTED, tags=["files"]
+)
+async def delete_user_file(
+    file_id: UUID,
+    user_id: UUID,
+    x_developer_id: Annotated[UUID, Depends(get_developer_id)],
+) -> ResourceDeletedResponse:
+    """Delete a user-owned file."""
+    # AIDEV-NOTE: added user-specific file deletion
+    resource_deleted = await delete_file_query(
+        developer_id=x_developer_id,
+        file_id=file_id,
+        owner_type="user",
+        owner_id=user_id,
+    )
+
+    await delete_file_content(file_id)
+
+    return resource_deleted
+
+
+@router.delete(
+    "/agents/{agent_id}/files/{file_id}", status_code=HTTP_202_ACCEPTED, tags=["files"]
+)
+async def delete_agent_file(
+    file_id: UUID,
+    agent_id: UUID,
+    x_developer_id: Annotated[UUID, Depends(get_developer_id)],
+) -> ResourceDeletedResponse:
+    """Delete an agent-owned file."""
+    # AIDEV-NOTE: added agent-specific file deletion
+    resource_deleted = await delete_file_query(
+        developer_id=x_developer_id,
+        file_id=file_id,
+        owner_type="agent",
+        owner_id=agent_id,
+    )
+
+    await delete_file_content(file_id)
+
+    return resource_deleted

--- a/agents-api/agents_api/routers/files/list_files.py
+++ b/agents-api/agents_api/routers/files/list_files.py
@@ -22,3 +22,41 @@ async def list_files(
         file.content = await fetch_file_content(file.id)
 
     return files
+
+
+@router.get("/users/{user_id}/files", tags=["files"])
+async def list_user_files(
+    user_id: UUID,
+    x_developer_id: Annotated[UUID, Depends(get_developer_id)],
+) -> list[File]:
+    """List files owned by a user."""
+    # AIDEV-NOTE: added user-specific file listing
+    files = await list_files_query(
+        developer_id=x_developer_id,
+        owner_type="user",
+        owner_id=user_id,
+    )
+
+    for file in files:
+        file.content = await fetch_file_content(file.id)
+
+    return files
+
+
+@router.get("/agents/{agent_id}/files", tags=["files"])
+async def list_agent_files(
+    agent_id: UUID,
+    x_developer_id: Annotated[UUID, Depends(get_developer_id)],
+) -> list[File]:
+    """List files owned by an agent."""
+    # AIDEV-NOTE: added agent-specific file listing
+    files = await list_files_query(
+        developer_id=x_developer_id,
+        owner_type="agent",
+        owner_id=agent_id,
+    )
+
+    for file in files:
+        file.content = await fetch_file_content(file.id)
+
+    return files

--- a/typespec/files/endpoints.tsp
+++ b/typespec/files/endpoints.tsp
@@ -12,3 +12,13 @@ namespace Files;
 interface Endpoints
     extends GetEndpoint<File, "Get a File by its id">,
         CreateEndpoint<CreateFileRequest, File, "Create a new File"> {}
+
+interface UserEndpoints
+    extends ChildLimitOffsetPagination<File, "List Files owned by a User">,
+        ChildDeleteEndpoint<"Delete a File for this User">,
+        ChildCreateEndpoint<CreateFileRequest, File, "Create a File for this User"> {}
+
+interface AgentEndpoints
+    extends ChildLimitOffsetPagination<File, "List Files owned by an Agent">,
+        ChildDeleteEndpoint<"Delete a File for this Agent">,
+        ChildCreateEndpoint<CreateFileRequest, File, "Create a File for this Agent"> {}

--- a/typespec/main.tsp
+++ b/typespec/main.tsp
@@ -68,6 +68,9 @@ namespace Api {
     @route("/agents/{id}/docs")
     interface AgentDocsRoute extends Docs.AgentEndpoints, Docs.BulkDeleteEndpoints<"Bulk delete Docs owned by an Agent"> {}
 
+    @route("/agents/{id}/files")
+    interface AgentFilesRoute extends Files.AgentEndpoints {}
+
     @route("/agents/{id}/search")
     interface AgentsDocsSearchRoute extends Docs.SearchEndpoints<"Search Docs owned by an Agent"> {}
 
@@ -82,6 +85,9 @@ namespace Api {
 
     @route("/users/{id}/docs")
     interface UserDocsRoute extends Docs.UserEndpoints, Docs.BulkDeleteEndpoints<"Bulk delete Docs owned by a User"> {}
+
+    @route("/users/{id}/files")
+    interface UserFilesRoute extends Files.UserEndpoints {}
 
     @route("/users/{id}/search")
     interface UserDocsSearchRoute extends Docs.SearchEndpoints<"Search Docs owned by a User"> {}

--- a/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
+++ b/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
@@ -939,6 +939,144 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Files.File'
+
+  /users/{id}/files:
+    get:
+      operationId: UserFilesRoute_list
+      description: List Files owned by a User
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of parent
+          schema:
+            $ref: '#/components/schemas/Common.uuid'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Files.File'
+    post:
+      operationId: UserFilesRoute_create
+      description: Create a File for this User
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of parent resource
+          schema:
+            $ref: '#/components/schemas/Common.uuid'
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Files.File'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Files.CreateFileRequest'
+
+  /users/{id}/files/{child_id}:
+    delete:
+      operationId: UserFilesRoute_delete
+      description: Delete a File for this User
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of parent resource
+          schema:
+            $ref: '#/components/schemas/Common.uuid'
+        - name: child_id
+          in: path
+          required: true
+          description: ID of the resource to be deleted
+          schema:
+            $ref: '#/components/schemas/Common.uuid'
+      responses:
+        '202':
+          description: The request has been accepted for processing, but processing has not yet completed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Common.ResourceDeletedResponse'
+
+  /agents/{id}/files:
+    get:
+      operationId: AgentFilesRoute_list
+      description: List Files owned by an Agent
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of parent
+          schema:
+            $ref: '#/components/schemas/Common.uuid'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Files.File'
+    post:
+      operationId: AgentFilesRoute_create
+      description: Create a File for this Agent
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of parent resource
+          schema:
+            $ref: '#/components/schemas/Common.uuid'
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Files.File'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Files.CreateFileRequest'
+
+  /agents/{id}/files/{child_id}:
+    delete:
+      operationId: AgentFilesRoute_delete
+      description: Delete a File for this Agent
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of parent resource
+          schema:
+            $ref: '#/components/schemas/Common.uuid'
+        - name: child_id
+          in: path
+          required: true
+          description: ID of the resource to be deleted
+          schema:
+            $ref: '#/components/schemas/Common.uuid'
+      responses:
+        '202':
+          description: The request has been accepted for processing, but processing has not yet completed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Common.ResourceDeletedResponse'
   /jobs/{id}:
     get:
       operationId: JobRoute_get


### PR DESCRIPTION
## Summary
- extend file routing with user & agent CRUD endpoints
- expose new file endpoints in OpenAPI
- define user and agent file interfaces in TypeSpec

## Testing
- `ruff format agents-api/agents_api/routers/files/*.py`
- `ruff check agents-api/agents_api/routers/files/*.py`
- `pyright agents-api/agents_api/routers/files` *(fails: Arguments for ParamSpec errors)*