### PR TITLE
Rename custom_api_used column

### DIFF
--- a/agents-api/agents_api/queries/usage/create_usage_record.py
+++ b/agents-api/agents_api/queries/usage/create_usage_record.py
@@ -98,7 +98,7 @@ INSERT INTO usage (
     completion_tokens,
     cost,
     estimated,
-    custom_api_used,
+    custom_key_used,
     metadata
 )
 VALUES (
@@ -108,10 +108,19 @@ VALUES (
     $4, -- completion_tokens
     $5, -- cost
     $6, -- estimated
-    $7, -- custom_api_used
+    $7, -- custom_key_used
     $8  -- metadata
 )
-RETURNING *;
+RETURNING
+    developer_id,
+    model,
+    prompt_tokens,
+    completion_tokens,
+    cost,
+    estimated,
+    custom_key_used AS custom_api_used,
+    metadata,
+    created_at;
 """
 
 

--- a/memory-store/migrations/000036_usage.up.sql
+++ b/memory-store/migrations/000036_usage.up.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS usage (
     completion_tokens INTEGER NOT NULL CONSTRAINT ct_usage_completion_tokens_positive CHECK (completion_tokens >= 0),
     cost NUMERIC(10, 6) NOT NULL CONSTRAINT ct_usage_cost_positive CHECK (cost >= 0),
     estimated BOOLEAN NOT NULL DEFAULT FALSE,
-    custom_api_used BOOLEAN NOT NULL DEFAULT FALSE,
+    custom_key_used BOOLEAN NOT NULL DEFAULT FALSE,
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     metadata JSONB NOT NULL DEFAULT '{}'::JSONB,
     CONSTRAINT fk_usage_developer FOREIGN KEY (developer_id) REFERENCES developers(developer_id),

--- a/memory-store/migrations/000038_usage_cost_monthly.up.sql
+++ b/memory-store/migrations/000038_usage_cost_monthly.up.sql
@@ -4,7 +4,7 @@ WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT
     developer_id,
     time_bucket('1 month', created_at) AS bucket_start,
-    SUM(cost) FILTER (WHERE NOT custom_api_used) AS monthly_cost
+    SUM(cost) FILTER (WHERE NOT custom_key_used) AS monthly_cost
 FROM usage
 GROUP BY developer_id, bucket_start
 WITH NO DATA;


### PR DESCRIPTION
### **User description**
## Summary
- rename `custom_api_used` column to `custom_key_used`
- update monthly cost view to use the renamed column
- adjust usage insert query to use new column and alias returned field

## Testing
- `poe check` *(fails: command not found)*


___

### **PR Type**
Enhancement


___

### **Description**
- Rename `custom_api_used` column to `custom_key_used` throughout codebase

- Update SQL queries and migrations to use new column name

- Adjust returned fields to maintain backward compatibility in API


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create_usage_record.py</strong><dd><code>Rename and alias `custom_api_used` column in usage record creation</code></dd></summary>
<hr>

agents-api/agents_api/queries/usage/create_usage_record.py

<li>Renamed <code>custom_api_used</code> to <code>custom_key_used</code> in SQL insert statement<br> <li> Updated query to return <code>custom_key_used</code> as <code>custom_api_used</code> for <br>compatibility<br> <li> Adjusted comments and parameter names accordingly


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1429/files#diff-c3c3933826f43f77d2313c0c3ef45a041fb709da69dd9d3eff344a7960652e06">+12/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>000036_usage.up.sql</strong><dd><code>Update usage table schema to use `custom_key_used`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

memory-store/migrations/000036_usage.up.sql

<li>Changed table schema to use <code>custom_key_used</code> instead of <code>custom_api_used</code><br> <li> Updated default value and constraints for new column name


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1429/files#diff-74117a88288c0517d5df9c5a637472260629f56d0a2482f46d7f1763b762732c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>000038_usage_cost_monthly.up.sql</strong><dd><code>Update monthly cost view to use `custom_key_used`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

memory-store/migrations/000038_usage_cost_monthly.up.sql

<li>Modified monthly cost view to reference <code>custom_key_used</code> column<br> <li> Ensured cost calculation uses new column name


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1429/files#diff-e513fe50e851718d61b087df51d9af0d6e6b03a73160eda6be320b27524d1333">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Rename `custom_api_used` column to `custom_key_used` and update related SQL queries and migrations.
> 
>   - **Database Schema**:
>     - Rename `custom_api_used` column to `custom_key_used` in `000036_usage.up.sql`.
>     - Update `000038_usage_cost_monthly.up.sql` to use `custom_key_used` in the monthly cost calculation.
>   - **SQL Queries**:
>     - Update `create_usage_record.py` to use `custom_key_used` in the `usage_query` and alias it as `custom_api_used` for backward compatibility.
>   - **Misc**:
>     - Adjust usage insert query to use the new column name and alias the returned field.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for f57eda42a0d549368529b843ab94797771d2d31e. You can [customize](https://app.ellipsis.dev/julep-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->