### PR TITLE
Enable text-only vector search

### DIFF
--- a/agents-api/agents_api/autogen/Docs.py
+++ b/agents-api/agents_api/autogen/Docs.py
@@ -175,7 +175,7 @@ class HybridDocSearchRequest(BaseDocSearchRequest):
     """
     Text to use in the search. In `hybrid` search mode, either `text` or both `text` and `vector` fields are required.
     """
-    vector: list[float]
+    vector: list[float] | None = None
     """
     Vector to use in the search. Must be the same dimensions as the embedding model or else an error will be thrown.
     """
@@ -252,9 +252,13 @@ class VectorDocSearchRequest(BaseDocSearchRequest):
     """
     The confidence cutoff level
     """
-    vector: list[float]
+    vector: list[float] | None = None
     """
     Vector to use in the search. Must be the same dimensions as the embedding model or else an error will be thrown.
+    """
+    text: str | None = None
+    """
+    Text to use in the search. If `vector` is not provided, this text will be automatically embedded.
     """
     mmr_strength: Annotated[float, Field(ge=0.0, lt=1.0)] = 0.5
     """

--- a/agents-api/tests/test_docs_routes.py
+++ b/agents-api/tests/test_docs_routes.py
@@ -249,6 +249,54 @@ async def _(make_request=make_request, user=test_user, doc=test_user_doc):
     assert len(docs) >= 1
 
 
+@test("route: vector search with text only")
+async def _(
+    make_request=make_request,
+    agent=test_agent,
+    doc=test_doc_with_embedding,
+    mocks=patch_embed_acompletion,
+):
+    (embed, _) = mocks
+    search_params = {
+        "text": doc.content[0],
+        "confidence": 0.8,
+        "limit": 1,
+    }
+
+    response = make_request(
+        method="POST",
+        url=f"/agents/{agent.id}/search",
+        json=search_params,
+    )
+
+    assert response.status_code == 200
+    embed.assert_called()
+
+
+@test("route: hybrid search with text only")
+async def _(
+    make_request=make_request,
+    agent=test_agent,
+    doc=test_doc_with_embedding,
+    mocks=patch_embed_acompletion,
+):
+    (embed, _) = mocks
+    search_params = {
+        "text": doc.content[0],
+        "alpha": 0.6,
+        "limit": 1,
+    }
+
+    response = make_request(
+        method="POST",
+        url=f"/agents/{agent.id}/search",
+        json=search_params,
+    )
+
+    assert response.status_code == 200
+    embed.assert_called()
+
+
 @test("route: search agent docs hybrid with mmr")
 async def _(make_request=make_request, agent=test_agent, doc=test_doc_with_embedding):
     EMBEDDING_SIZE = 1024

--- a/typespec/docs/models.tsp
+++ b/typespec/docs/models.tsp
@@ -124,10 +124,17 @@ model VectorDocSearchRequest extends BaseDocSearchRequest {
     @maxValue(1)
     confidence: float = 0.5;
 
-    /** Vector to use in the search. Must be the same dimensions as the embedding model or else an error will be thrown. */
-    vector: float[];
+    /**
+     * Vector to use in the search. Must be the same dimensions as the embedding model
+     * or else an error will be thrown.
+     */
+    vector?: float[];
 
-    text?: never;
+    /**
+     * Text to use for the search. If provided without `vector`, the server will
+     * automatically embed the text.
+     */
+    text?: string;
 
     /** MMR Strength (mmr_strength = 1 - mmr_lambda) */
     @minValue(0)
@@ -158,11 +165,17 @@ model HybridDocSearchRequest extends BaseDocSearchRequest {
     @maxValue(1)
     alpha: float = 0.5;
 
-    /** Text to use in the search. In `hybrid` search mode, either `text` or both `text` and `vector` fields are required. */
+    /**
+     * Text to use in the search. In `hybrid` search mode, either `text` or both
+     * `text` and `vector` fields are required.
+     */
     text: string;
 
-    /** Vector to use in the search. Must be the same dimensions as the embedding model or else an error will be thrown. */
-    vector: float[];
+    /**
+     * Vector to use in the search. Must be the same dimensions as the embedding
+     * model or else an error will be thrown.
+     */
+    vector?: float[];
 
     /** MMR Strength (mmr_strength = 1 - mmr_lambda) */
     @minValue(0)


### PR DESCRIPTION
## Summary
- make vector field optional in docs search models
- embed raw text automatically when vector search/hybrid search receives only text
- adjust router logic and add new tests

## Testing
- `ruff format agents-api/agents_api/routers/docs/search_docs.py agents-api/tests/test_docs_routes.py agents-api/agents_api/autogen/Docs.py`
- `ruff check agents-api/agents_api/routers/docs/search_docs.py agents-api/tests/test_docs_routes.py agents-api/agents_api/autogen/Docs.py`
- `pyright agents-api` *(fails: Import "ward" could not be resolved)*