### PR TITLE
Mitigate DeadlockError

### DIFF
--- a/agents-api/agents_api/worker/__main__.py
+++ b/agents-api/agents_api/worker/__main__.py
@@ -35,8 +35,8 @@ async def main() -> None:
 
     client = await temporal.get_client_with_metrics()
     worker = create_worker(client)
-    if hasattr(worker, "_workflow_worker") and worker._workflow_worker:
-        worker._workflow_worker._deadlock_timeout_seconds = 60
+    if hasattr(worker, "_workflow_worker") and worker._workflow_worker:  # noqa: SLF001
+        worker._workflow_worker._deadlock_timeout_seconds = 60  # noqa: SLF001
 
     async with lifespan(app):
         # Start the worker to listen for and process tasks

--- a/agents-api/agents_api/worker/__main__.py
+++ b/agents-api/agents_api/worker/__main__.py
@@ -35,6 +35,8 @@ async def main() -> None:
 
     client = await temporal.get_client_with_metrics()
     worker = create_worker(client)
+    if hasattr(worker, "_workflow_worker") and worker._workflow_worker:
+        worker._workflow_worker._deadlock_timeout_seconds = 60
 
     async with lifespan(app):
         # Start the worker to listen for and process tasks

--- a/documentation/concepts/tasks.mdx
+++ b/documentation/concepts/tasks.mdx
@@ -44,6 +44,17 @@ input_schema:
       description: The text to summarize
 ```
 
+<Warning>
+  **⚠️ Workflow Input Size Warning**: Avoid passing extremely large objects as input to your workflows, as this can cause execution failures. Large inputs (such as massive JSON objects, extensive arrays, or huge text files) may exceed memory limits or hit serialization constraints.
+
+  **What to do instead:**
+  - **Break large data into smaller chunks** and process them iteratively
+  - **Use file uploads** and pass file references instead of raw content
+  - **Implement pagination** for large datasets
+
+  **Rule of thumb:** If your input data is larger than a few megabytes, consider alternative approaches.
+</Warning>
+
 ### Tools
 
 Tools are functions that can be used by an agent to perform tasks. Julep supports:


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement, Documentation


___

### **Description**
- Increased Temporal worker deadlock detection timeout to 60 seconds.

- Added object size threshold check before serialization to prevent failures.

- Introduced documentation warning about large workflow input sizes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__main__.py</strong><dd><code>Increase Temporal worker deadlock detection timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/worker/__main__.py

<li>Set <code>_deadlock_timeout_seconds</code> to 60 for the Temporal worker.<br> <li> Ensures longer timeout for deadlock detection.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1449/files#diff-c17fd12bdc812ce029d1a60d07a3f0583a46ec64334f49ba57fc5c6d9b1c19ca">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codec.py</strong><dd><code>Add object size threshold check before serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents-api/agents_api/worker/codec.py

<li>Defined <code>THRESHOLD_OBJECT_SIZE</code> constant (15MB).<br> <li> Added pre-serialization object size check raising ValueError if <br>exceeded.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1449/files#diff-aeee8d92747576eebd05832f4cdbbd543a72ac6c01981a406d0662f99561be9c">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tasks.mdx</strong><dd><code>Add warning about large workflow input sizes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

documentation/concepts/tasks.mdx

<li>Added warning about workflow input size limitations.<br> <li> Provided best practices for handling large inputs.


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1449/files#diff-86d431c7a6523f86a4213b8066c68fde08cdfddb2beff076700d79bc82f60732">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Mitigates deadlock and large object issues in Temporal worker by setting a deadlock timeout and adding a serialization size threshold, with documentation updates for handling large inputs.
> 
>   - **Deadlock Mitigation**:
>     - Set `_deadlock_timeout_seconds` to 60 in `__main__.py` for `worker._workflow_worker` if it exists.
>   - **Serialization**:
>     - Add `THRESHOLD_OBJECT_SIZE` (15MB) in `codec.py`.
>     - Raise `ValueError` in `serialize()` if object size exceeds threshold.
>   - **Documentation**:
>     - Add warning in `tasks.mdx` about large workflow inputs and suggest alternatives.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for c329f7f4eb5fe5b8d2dd9c07185cfb801c149d02. You can [customize](https://app.ellipsis.dev/julep-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->