### PR TITLE
[AI] Enable tool calls in session chats

### DIFF
--- a/agents-api/agents_api/routers/responses/create_response.py
+++ b/agents-api/agents_api/routers/responses/create_response.py
@@ -104,6 +104,7 @@ async def create_response(
         messages,
         doc_references,
         _formatted_tools,
+        _tools,
         settings,
         new_messages,
         chat_context,


### PR DESCRIPTION
## Summary
- support tool execution in session chats
- format tools consistently and return them from render step
- loop over tool calls and execute them via session handlers

## Testing
- `poetry run poe lint`
- `poetry run poe typecheck` *(fails: KeyboardInterrupt)*
- `poetry run poe test` *(fails: ModuleNotFoundError)*