### PR TITLE
feat(agents-api): integrate auto_run_tools with prompt step tool calling

### DIFF
--- a/changelog/dev/2025-07-02.md
+++ b/changelog/dev/2025-07-02.md
@@ -1,0 +1,17 @@
+---
+title: "Julep AI Changelog"
+date: 2025-07-02
+tags: [dev]
+---
+
+## Julep AI Changelog - July 2, 2025
+
+### Tool Calling Updates
+- Changed default value of `auto_run_tools` from `true` to `false` in PromptStep for safer defaults
+- Fixed tool call prevention when `auto_run_tools` is disabled by passing empty tools list to model
+- Added comprehensive test coverage for `auto_run_tools` behavior in both enabled and disabled states
+
+### API Schema Enhancements  
+- Renamed `ApiCallDef` to separate `ApiCallDef-Input` and `ApiCallDef-Output` variants for better type safety
+- Added new parameter schema definitions: `ParameterSchema-Input`, `ParameterSchema-Output`, and `ParameterSchemaUpdate`
+- Added property definition types: `PropertyDefinition-Input`, `PropertyDefinition-Output`, and `PropertyDefinitionUpdate`

--- a/src/agents-api/agents_api/activities/task_steps/prompt_step.py
+++ b/src/agents-api/agents_api/activities/task_steps/prompt_step.py
@@ -82,9 +82,14 @@ async def prompt_step(context: StepContext) -> StepOutcome:
             **passed_settings,
         }
 
+        # AIDEV-NOTE: When auto_run_tools=False, pass empty tools list to prevent
+        # model from making tool calls that won't be executed. This simplifies the
+        # flow as the model will always return a regular completion instead of tool calls.
+        tools_to_use = all_tools if context.current_step.auto_run_tools else []
+
         responses: list[dict] = await run_llm_with_tools(
             messages=prompt,
-            tools=all_tools,
+            tools=tools_to_use,
             settings=completion_data,
             run_tool_call=functools.partial(run_context_tool, context),
         )

--- a/src/agents-api/agents_api/autogen/Tasks.py
+++ b/src/agents-api/agents_api/autogen/Tasks.py
@@ -938,10 +938,10 @@ class PromptStep(BaseModel):
     """
     Whether to unwrap the output of the prompt step, equivalent to `response.choices[0].message.content`
     """
-    auto_run_tools: StrictBool = True
+    auto_run_tools: StrictBool = False
     """
     Whether to auto-run the tool and send the tool results to the model when available.
-    (default: true for prompt steps, false for sessions)
+    (default: false)
 
     If a tool call is made, the tool's output will be used as the model's input.
     If a tool call is not made, the model's output will be used as the next step's input.
@@ -986,10 +986,10 @@ class PromptStepUpdateItem(BaseModel):
     """
     Whether to unwrap the output of the prompt step, equivalent to `response.choices[0].message.content`
     """
-    auto_run_tools: StrictBool = True
+    auto_run_tools: StrictBool = False
     """
     Whether to auto-run the tool and send the tool results to the model when available.
-    (default: true for prompt steps, false for sessions)
+    (default: false)
 
     If a tool call is made, the tool's output will be used as the model's input.
     If a tool call is not made, the model's output will be used as the next step's input.

--- a/src/agents-api/tests/test_prompt_step_auto_tools.py
+++ b/src/agents-api/tests/test_prompt_step_auto_tools.py
@@ -48,7 +48,8 @@ async def _():
                 ]
 
                 # Create proper StepContext with real objects
-                step = PromptStep(prompt="Test prompt", unwrap=False)
+                # Note: auto_run_tools defaults to False now, so we need to explicitly set it to True
+                step = PromptStep(prompt="Test prompt", unwrap=False, auto_run_tools=True)
                 execution_input = ExecutionInput(
                     developer_id=uuid4(),
                     agent=Agent(
@@ -125,7 +126,8 @@ async def _():
                 ]
 
                 # Create proper StepContext with real objects
-                step = PromptStep(prompt="Test prompt", unwrap=True)
+                # Note: auto_run_tools defaults to False now, so we need to explicitly set it to True for this test
+                step = PromptStep(prompt="Test prompt", unwrap=True, auto_run_tools=True)
                 execution_input = ExecutionInput(
                     developer_id=uuid4(),
                     agent=Agent(
@@ -165,3 +167,185 @@ async def _():
 
                     # Check that output is unwrapped
                     assert result.output == "Unwrapped response"
+
+
+@test("prompt_step with auto_run_tools=False passes empty tools list")
+async def _():
+    tool = CreateToolRequest(
+        name="test_tool",
+        type="function",
+        function=FunctionDef(
+            parameters={"type": "object", "properties": {"param": {"type": "string"}}},
+        ),
+        description="Test function",
+    )
+
+    # Mock feature flag to be enabled
+    with patch(
+        "agents_api.activities.task_steps.prompt_step.get_feature_flag_value"
+    ) as mock_flag:
+        mock_flag.return_value = True
+
+        # Mock base_evaluate to just return the prompt unchanged
+        with patch("agents_api.activities.task_steps.prompt_step.base_evaluate") as mock_eval:
+            mock_eval.return_value = "Test prompt"
+
+            # Mock run_llm_with_tools
+            with patch(
+                "agents_api.activities.task_steps.prompt_step.run_llm_with_tools",
+                new_callable=AsyncMock,
+            ) as mock_run_llm:
+                mock_run_llm.return_value = [
+                    {"role": "user", "content": "Test prompt"},
+                    {"role": "assistant", "content": "Test response without tools"},
+                ]
+
+                # Create prompt step with auto_run_tools=False
+                step = PromptStep(prompt="Test prompt", unwrap=False, auto_run_tools=False)
+                execution_input = ExecutionInput(
+                    developer_id=uuid4(),
+                    agent=Agent(
+                        id=uuid4(),
+                        name="test_agent",
+                        model="gpt-4",
+                        default_settings={"temperature": 0.7},
+                        created_at=utcnow(),
+                        updated_at=utcnow(),
+                    ),
+                    agent_tools=[],
+                    arguments={},
+                    task=TaskSpecDef(
+                        name="test_task",
+                        tools=[],
+                        workflows=[Workflow(name="main", steps=[step])],
+                    ),
+                )
+
+                context = StepContext(
+                    execution_input=execution_input,
+                    current_input="test input",
+                    cursor=TransitionTarget(
+                        workflow="main",
+                        step=0,
+                        scope_id=uuid4(),
+                    ),
+                )
+
+                # Mock the tools method to return a tool
+                async def mock_tools_method(self):
+                    return [tool]
+
+                with patch.object(StepContext, "tools", mock_tools_method):
+                    # Run the activity
+                    result = await prompt_step(context)
+
+                    # Verify run_llm_with_tools was called with empty tools list
+                    mock_run_llm.assert_called_once()
+                    call_args = mock_run_llm.call_args
+                    assert call_args[1]["messages"] == [
+                        {"role": "user", "content": "Test prompt"}
+                    ]
+                    # IMPORTANT: Verify empty tools list was passed
+                    assert call_args[1]["tools"] == []
+
+                    # Check result
+                    assert result.output == [
+                        {"role": "user", "content": "Test prompt"},
+                        {"role": "assistant", "content": "Test response without tools"},
+                    ]
+
+
+@test("prompt_step with auto_run_tools=True passes all available tools")
+async def _():
+    tool1 = CreateToolRequest(
+        name="tool1",
+        type="function",
+        function=FunctionDef(
+            parameters={"type": "object", "properties": {"param": {"type": "string"}}},
+        ),
+        description="Test function 1",
+    )
+    tool2 = CreateToolRequest(
+        name="tool2",
+        type="function",
+        function=FunctionDef(
+            parameters={"type": "object", "properties": {"param": {"type": "number"}}},
+        ),
+        description="Test function 2",
+    )
+
+    # Mock feature flag to be enabled
+    with patch(
+        "agents_api.activities.task_steps.prompt_step.get_feature_flag_value"
+    ) as mock_flag:
+        mock_flag.return_value = True
+
+        # Mock base_evaluate to just return the prompt unchanged
+        with patch("agents_api.activities.task_steps.prompt_step.base_evaluate") as mock_eval:
+            mock_eval.return_value = "Test prompt"
+
+            # Mock run_llm_with_tools
+            with patch(
+                "agents_api.activities.task_steps.prompt_step.run_llm_with_tools",
+                new_callable=AsyncMock,
+            ) as mock_run_llm:
+                mock_run_llm.return_value = [
+                    {"role": "user", "content": "Test prompt"},
+                    {"role": "assistant", "content": "Test response with tools"},
+                ]
+
+                # Create prompt step with auto_run_tools=True (default)
+                step = PromptStep(prompt="Test prompt", unwrap=False, auto_run_tools=True)
+                execution_input = ExecutionInput(
+                    developer_id=uuid4(),
+                    agent=Agent(
+                        id=uuid4(),
+                        name="test_agent",
+                        model="gpt-4",
+                        default_settings={"temperature": 0.7},
+                        created_at=utcnow(),
+                        updated_at=utcnow(),
+                    ),
+                    agent_tools=[],
+                    arguments={},
+                    task=TaskSpecDef(
+                        name="test_task",
+                        tools=[],
+                        workflows=[Workflow(name="main", steps=[step])],
+                    ),
+                )
+
+                context = StepContext(
+                    execution_input=execution_input,
+                    current_input="test input",
+                    cursor=TransitionTarget(
+                        workflow="main",
+                        step=0,
+                        scope_id=uuid4(),
+                    ),
+                )
+
+                # Mock the tools method to return multiple tools
+                async def mock_tools_method(self):
+                    return [tool1, tool2]
+
+                with patch.object(StepContext, "tools", mock_tools_method):
+                    # Run the activity
+                    result = await prompt_step(context)
+
+                    # Verify run_llm_with_tools was called with all tools
+                    mock_run_llm.assert_called_once()
+                    call_args = mock_run_llm.call_args
+                    assert call_args[1]["messages"] == [
+                        {"role": "user", "content": "Test prompt"}
+                    ]
+                    # IMPORTANT: Verify all tools were passed
+                    assert len(call_args[1]["tools"]) == 2
+                    assert call_args[1]["tools"][0].name == "tool1"
+                    assert call_args[1]["tools"][1].name == "tool2"
+
+                    # Check result
+                    assert result.output == [
+                        {"role": "user", "content": "Test prompt"},
+                        {"role": "assistant", "content": "Test response with tools"},
+                    ]

--- a/src/agents-api/tests/test_task_execution_workflow.py
+++ b/src/agents-api/tests/test_task_execution_workflow.py
@@ -918,7 +918,7 @@ async def _():
         return StepOutcome(output="function_call")
 
     wf = TaskExecutionWorkflow()
-    step = PromptStep(prompt=[PromptItem(content="hi there", role="user")])
+    step = PromptStep(prompt=[PromptItem(content="hi there", role="user")], auto_run_tools=True)
     execution_input = ExecutionInput(
         developer_id=uuid.uuid4(),
         agent=Agent(

--- a/src/integrations-service/integrations/autogen/Tasks.py
+++ b/src/integrations-service/integrations/autogen/Tasks.py
@@ -902,10 +902,10 @@ class PromptStep(BaseModel):
     """
     Whether to unwrap the output of the prompt step, equivalent to `response.choices[0].message.content`
     """
-    auto_run_tools: StrictBool = True
+    auto_run_tools: StrictBool = False
     """
     Whether to auto-run the tool and send the tool results to the model when available.
-    (default: true for prompt steps, false for sessions)
+    (default: false)
 
     If a tool call is made, the tool's output will be used as the model's input.
     If a tool call is not made, the model's output will be used as the next step's input.
@@ -950,10 +950,10 @@ class PromptStepUpdateItem(BaseModel):
     """
     Whether to unwrap the output of the prompt step, equivalent to `response.choices[0].message.content`
     """
-    auto_run_tools: StrictBool = True
+    auto_run_tools: StrictBool = False
     """
     Whether to auto-run the tool and send the tool results to the model when available.
-    (default: true for prompt steps, false for sessions)
+    (default: false)
 
     If a tool call is made, the tool's output will be used as the model's input.
     If a tool call is not made, the model's output will be used as the next step's input.

--- a/src/schemas/create_agent_request.json
+++ b/src/schemas/create_agent_request.json
@@ -342,7 +342,7 @@
       "title": "AlgoliaSetupUpdate",
       "type": "object"
     },
-    "ApiCallDef": {
+    "ApiCallDef-Input": {
       "description": "API call definition",
       "properties": {
         "content": {
@@ -461,6 +461,196 @@
             }
           ],
           "title": "Params"
+        },
+        "params_schema": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ParameterSchema-Input"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "schema": {
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Schema"
+        },
+        "secrets": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "$ref": "#/$defs/SecretRef"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Secrets"
+        },
+        "timeout": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Timeout"
+        },
+        "url": {
+          "format": "uri",
+          "minLength": 1,
+          "title": "Url",
+          "type": "string"
+        }
+      },
+      "required": [
+        "method",
+        "url"
+      ],
+      "title": "ApiCallDef",
+      "type": "object"
+    },
+    "ApiCallDef-Output": {
+      "description": "API call definition",
+      "properties": {
+        "content": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Content"
+        },
+        "cookies": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Cookies"
+        },
+        "data": {
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Data"
+        },
+        "files": {
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Files"
+        },
+        "follow_redirects": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Follow Redirects"
+        },
+        "headers": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Headers"
+        },
+        "include_response_content": {
+          "default": true,
+          "title": "Include Response Content",
+          "type": "boolean"
+        },
+        "json": {
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Json"
+        },
+        "method": {
+          "enum": [
+            "GET",
+            "POST",
+            "PUT",
+            "DELETE",
+            "PATCH",
+            "HEAD",
+            "OPTIONS",
+            "CONNECT",
+            "TRACE"
+          ],
+          "title": "Method",
+          "type": "string"
+        },
+        "params": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Params"
+        },
+        "params_schema": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ParameterSchema-Output"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "schema": {
           "anyOf": [
@@ -638,6 +828,16 @@
             }
           ],
           "title": "Params"
+        },
+        "params_schema": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ParameterSchemaUpdate"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "schema": {
           "anyOf": [
@@ -4438,7 +4638,7 @@
         "api_call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/ApiCallDef"
+              "$ref": "#/$defs/ApiCallDef-Output"
             },
             {
               "type": "null"
@@ -8618,6 +8818,133 @@
       "title": "ParallelStep",
       "type": "object"
     },
+    "ParameterSchema-Input": {
+      "description": "JSON Schema for API call parameters",
+      "properties": {
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Additionalproperties"
+        },
+        "properties": {
+          "additionalProperties": {
+            "$ref": "#/$defs/PropertyDefinition-Input"
+          },
+          "title": "Properties",
+          "type": "object"
+        },
+        "required": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Required",
+          "type": "array"
+        },
+        "type": {
+          "default": "object",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "title": "ParameterSchema",
+      "type": "object"
+    },
+    "ParameterSchema-Output": {
+      "description": "JSON Schema for API call parameters",
+      "properties": {
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Additionalproperties"
+        },
+        "properties": {
+          "additionalProperties": {
+            "$ref": "#/$defs/PropertyDefinition-Output"
+          },
+          "title": "Properties",
+          "type": "object"
+        },
+        "required": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Required",
+          "type": "array"
+        },
+        "type": {
+          "default": "object",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "title": "ParameterSchema",
+      "type": "object"
+    },
+    "ParameterSchemaUpdate": {
+      "description": "JSON Schema for API call parameters",
+      "properties": {
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Additionalproperties"
+        },
+        "properties": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "$ref": "#/$defs/PropertyDefinitionUpdate"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Properties"
+        },
+        "required": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Required",
+          "type": "array"
+        },
+        "type": {
+          "default": "object",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "title": "ParameterSchemaUpdate",
+      "type": "object"
+    },
     "PatchAgentRequest": {
       "description": "Payload for patching a agent",
       "properties": {
@@ -9553,6 +9880,157 @@
         "prompt"
       ],
       "title": "PromptStep",
+      "type": "object"
+    },
+    "PropertyDefinition-Input": {
+      "description": "Property definition for parameter schema",
+      "properties": {
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Description"
+        },
+        "enum": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Enum"
+        },
+        "items": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PropertyDefinition-Input"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "type": {
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "PropertyDefinition",
+      "type": "object"
+    },
+    "PropertyDefinition-Output": {
+      "description": "Property definition for parameter schema",
+      "properties": {
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Description"
+        },
+        "enum": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Enum"
+        },
+        "items": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PropertyDefinition-Output"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "type": {
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "PropertyDefinition",
+      "type": "object"
+    },
+    "PropertyDefinitionUpdate": {
+      "description": "Property definition for parameter schema",
+      "properties": {
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Description"
+        },
+        "enum": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Enum"
+        },
+        "items": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PropertyDefinitionUpdate"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "type": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Type"
+        }
+      },
+      "title": "PropertyDefinitionUpdate",
       "type": "object"
     },
     "Relation": {
@@ -11150,7 +11628,7 @@
         "api_call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/ApiCallDef"
+              "$ref": "#/$defs/ApiCallDef-Input"
             },
             {
               "type": "null"
@@ -11330,7 +11808,7 @@
         "api_call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/ApiCallDef"
+              "$ref": "#/$defs/ApiCallDef-Output"
             },
             {
               "type": "null"
@@ -11922,7 +12400,7 @@
         "api_call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/ApiCallDef"
+              "$ref": "#/$defs/ApiCallDef-Output"
             },
             {
               "type": "null"
@@ -12909,7 +13387,7 @@
         "api_call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/ApiCallDef"
+              "$ref": "#/$defs/ApiCallDef-Input"
             },
             {
               "type": "null"
@@ -14193,7 +14671,7 @@
         "api_call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/ApiCallDef"
+              "$ref": "#/$defs/ApiCallDef-Input"
             },
             {
               "type": "null"
@@ -14367,7 +14845,7 @@
         "api_call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/ApiCallDef"
+              "$ref": "#/$defs/ApiCallDef-Input"
             },
             {
               "type": "null"

--- a/src/schemas/create_task_request.json
+++ b/src/schemas/create_task_request.json
@@ -342,7 +342,7 @@
       "title": "AlgoliaSetupUpdate",
       "type": "object"
     },
-    "ApiCallDef": {
+    "ApiCallDef-Input": {
       "description": "API call definition",
       "properties": {
         "content": {
@@ -461,6 +461,196 @@
             }
           ],
           "title": "Params"
+        },
+        "params_schema": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ParameterSchema-Input"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "schema": {
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Schema"
+        },
+        "secrets": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "$ref": "#/$defs/SecretRef"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Secrets"
+        },
+        "timeout": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Timeout"
+        },
+        "url": {
+          "format": "uri",
+          "minLength": 1,
+          "title": "Url",
+          "type": "string"
+        }
+      },
+      "required": [
+        "method",
+        "url"
+      ],
+      "title": "ApiCallDef",
+      "type": "object"
+    },
+    "ApiCallDef-Output": {
+      "description": "API call definition",
+      "properties": {
+        "content": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Content"
+        },
+        "cookies": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Cookies"
+        },
+        "data": {
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Data"
+        },
+        "files": {
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Files"
+        },
+        "follow_redirects": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Follow Redirects"
+        },
+        "headers": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Headers"
+        },
+        "include_response_content": {
+          "default": true,
+          "title": "Include Response Content",
+          "type": "boolean"
+        },
+        "json": {
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Json"
+        },
+        "method": {
+          "enum": [
+            "GET",
+            "POST",
+            "PUT",
+            "DELETE",
+            "PATCH",
+            "HEAD",
+            "OPTIONS",
+            "CONNECT",
+            "TRACE"
+          ],
+          "title": "Method",
+          "type": "string"
+        },
+        "params": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Params"
+        },
+        "params_schema": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ParameterSchema-Output"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "schema": {
           "anyOf": [
@@ -638,6 +828,16 @@
             }
           ],
           "title": "Params"
+        },
+        "params_schema": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ParameterSchemaUpdate"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "schema": {
           "anyOf": [
@@ -4438,7 +4638,7 @@
         "api_call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/ApiCallDef"
+              "$ref": "#/$defs/ApiCallDef-Output"
             },
             {
               "type": "null"
@@ -8618,6 +8818,133 @@
       "title": "ParallelStep",
       "type": "object"
     },
+    "ParameterSchema-Input": {
+      "description": "JSON Schema for API call parameters",
+      "properties": {
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Additionalproperties"
+        },
+        "properties": {
+          "additionalProperties": {
+            "$ref": "#/$defs/PropertyDefinition-Input"
+          },
+          "title": "Properties",
+          "type": "object"
+        },
+        "required": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Required",
+          "type": "array"
+        },
+        "type": {
+          "default": "object",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "title": "ParameterSchema",
+      "type": "object"
+    },
+    "ParameterSchema-Output": {
+      "description": "JSON Schema for API call parameters",
+      "properties": {
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Additionalproperties"
+        },
+        "properties": {
+          "additionalProperties": {
+            "$ref": "#/$defs/PropertyDefinition-Output"
+          },
+          "title": "Properties",
+          "type": "object"
+        },
+        "required": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Required",
+          "type": "array"
+        },
+        "type": {
+          "default": "object",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "title": "ParameterSchema",
+      "type": "object"
+    },
+    "ParameterSchemaUpdate": {
+      "description": "JSON Schema for API call parameters",
+      "properties": {
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Additionalproperties"
+        },
+        "properties": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "$ref": "#/$defs/PropertyDefinitionUpdate"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Properties"
+        },
+        "required": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Required",
+          "type": "array"
+        },
+        "type": {
+          "default": "object",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "title": "ParameterSchemaUpdate",
+      "type": "object"
+    },
     "PatchAgentRequest": {
       "description": "Payload for patching a agent",
       "properties": {
@@ -9553,6 +9880,157 @@
         "prompt"
       ],
       "title": "PromptStep",
+      "type": "object"
+    },
+    "PropertyDefinition-Input": {
+      "description": "Property definition for parameter schema",
+      "properties": {
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Description"
+        },
+        "enum": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Enum"
+        },
+        "items": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PropertyDefinition-Input"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "type": {
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "PropertyDefinition",
+      "type": "object"
+    },
+    "PropertyDefinition-Output": {
+      "description": "Property definition for parameter schema",
+      "properties": {
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Description"
+        },
+        "enum": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Enum"
+        },
+        "items": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PropertyDefinition-Output"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "type": {
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "PropertyDefinition",
+      "type": "object"
+    },
+    "PropertyDefinitionUpdate": {
+      "description": "Property definition for parameter schema",
+      "properties": {
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Description"
+        },
+        "enum": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Enum"
+        },
+        "items": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PropertyDefinitionUpdate"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "type": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Type"
+        }
+      },
+      "title": "PropertyDefinitionUpdate",
       "type": "object"
     },
     "Relation": {
@@ -11150,7 +11628,7 @@
         "api_call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/ApiCallDef"
+              "$ref": "#/$defs/ApiCallDef-Input"
             },
             {
               "type": "null"
@@ -11330,7 +11808,7 @@
         "api_call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/ApiCallDef"
+              "$ref": "#/$defs/ApiCallDef-Output"
             },
             {
               "type": "null"
@@ -11922,7 +12400,7 @@
         "api_call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/ApiCallDef"
+              "$ref": "#/$defs/ApiCallDef-Output"
             },
             {
               "type": "null"
@@ -12909,7 +13387,7 @@
         "api_call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/ApiCallDef"
+              "$ref": "#/$defs/ApiCallDef-Input"
             },
             {
               "type": "null"
@@ -14193,7 +14671,7 @@
         "api_call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/ApiCallDef"
+              "$ref": "#/$defs/ApiCallDef-Input"
             },
             {
               "type": "null"
@@ -14367,7 +14845,7 @@
         "api_call": {
           "anyOf": [
             {
-              "$ref": "#/$defs/ApiCallDef"
+              "$ref": "#/$defs/ApiCallDef-Input"
             },
             {
               "type": "null"

--- a/src/typespec/tasks/steps.tsp
+++ b/src/typespec/tasks/steps.tsp
@@ -115,11 +115,11 @@ model PromptStepDef {
     unwrap?: boolean = false;
 
     /** Whether to auto-run the tool and send the tool results to the model when available.
-     * (default: true for prompt steps, false for sessions)
+     * (default: false)
      *
      * If a tool call is made, the tool's output will be used as the model's input.
      * If a tool call is not made, the model's output will be used as the next step's input. */
-    auto_run_tools: boolean = true;
+    auto_run_tools: boolean = false;
 
     /** Whether to disable caching for the prompt step */
     disable_cache: boolean = false;

--- a/src/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
+++ b/src/typespec/tsp-output/@typespec/openapi3/openapi-1.0.0.yaml
@@ -8095,11 +8095,11 @@ components:
           type: boolean
           description: |-
             Whether to auto-run the tool and send the tool results to the model when available.
-            (default: true for prompt steps, false for sessions)
+            (default: false)
 
             If a tool call is made, the tool's output will be used as the model's input.
             If a tool call is not made, the model's output will be used as the next step's input.
-          default: true
+          default: false
         disable_cache:
           type: boolean
           description: Whether to disable caching for the prompt step
@@ -8305,11 +8305,11 @@ components:
           type: boolean
           description: |-
             Whether to auto-run the tool and send the tool results to the model when available.
-            (default: true for prompt steps, false for sessions)
+            (default: false)
 
             If a tool call is made, the tool's output will be used as the model's input.
             If a tool call is not made, the model's output will be used as the next step's input.
-          default: true
+          default: false
         disable_cache:
           type: boolean
           description: Whether to disable caching for the prompt step


### PR DESCRIPTION
### **User description**
- **feat(agents-api): set default value of auto_run_tools to false**
- **fix(agents-api): prevent tool calls when auto_run_tools is disabled**
- **chore(agents-api): add tests for auto_run_tools**


___

### **PR Type**
Enhancement


___

### **Description**
- Change `auto_run_tools` default from `true` to `false`

- Prevent tool calls when `auto_run_tools` is disabled

- Add comprehensive tests for `auto_run_tools` behavior

- Update schema definitions and documentation


___

### **Changes diagram**

```mermaid
flowchart LR
  A["PromptStep"] --> B["auto_run_tools=false"]
  B --> C["Empty tools list"]
  C --> D["No tool calls"]
  B --> E["auto_run_tools=true"]
  E --> F["All tools available"]
  F --> G["Tool calls enabled"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>prompt_step.py</strong><dd><code>Implement conditional tool passing logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1515/files#diff-59f7933f84e18162334518f016cb3ef9d5130b8e0839d3de220dab496a863eca">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>Tasks.py</strong><dd><code>Change auto_run_tools default to false</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1515/files#diff-5e350089f279450d2c991f47cae7ec3ddd151657d5e7c5bc8a39f1d1370c9085">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Tasks.py</strong><dd><code>Update auto_run_tools default value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1515/files#diff-525caedd95de30966f3b6af8a35eb9472d7e6b5e1e4030d94eff872e9eb31af3">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>create_agent_request.json</strong><dd><code>Update schema with new API definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1515/files#diff-cfd7cc08cd3466a45f2d8f03f119ff6e8d5ef6198c80c7fe5415bd66657c68dc">+486/-8</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>create_task_request.json</strong><dd><code>Update schema with new API definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1515/files#diff-7913d5e5a329eb269dadd9d935bf04275836ed5e98bacb6c000e2a830d35eeac">+486/-8</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>steps.tsp</strong><dd><code>Update TypeSpec definition for auto_run_tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1515/files#diff-72b966c65c5eb36c8595b6c98e98dfce1a9cd0443754115337bf36ccc2b36f7d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>openapi-1.0.0.yaml</strong><dd><code>Update OpenAPI spec with new defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1515/files#diff-c5a8733ed3dbfa169e425dccc9d2906af440fb282ef2ba817a6e44ce49487569">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>test_prompt_step_auto_tools.py</strong><dd><code>Add comprehensive auto_run_tools tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/julep/pull/1515/files#diff-117fa3817793bcc9b970006aed370c42b73292b0e9aef0e968cc92550f901809">+186/-2</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `auto_run_tools` default to false, prevent tool calls when disabled, and update tests and schema.
> 
>   - **Behavior**:
>     - Change `auto_run_tools` default from `true` to `false` in `Tasks.py` and `prompt_step.py`.
>     - Prevent tool calls by passing an empty tools list when `auto_run_tools` is disabled in `prompt_step.py`.
>   - **Tests**:
>     - Add tests in `test_prompt_step_auto_tools.py` to cover `auto_run_tools` behavior for both enabled and disabled states.
>   - **Schema**:
>     - Update `create_agent_request.json` and `create_task_request.json` with new API definitions.
>     - Rename `ApiCallDef` to `ApiCallDef-Input` and `ApiCallDef-Output` in schema files.
>   - **Documentation**:
>     - Update OpenAPI spec in `openapi-1.0.0.yaml` to reflect new defaults.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for b0542952fdf9aaa73b9ddbe04501eaae0384e1cf. You can [customize](https://app.ellipsis.dev/julep-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->