### PR TITLE
Fix Issue 1467

### DIFF
--- a/src/agents-api/agents_api/clients/litellm.py
+++ b/src/agents-api/agents_api/clients/litellm.py
@@ -137,7 +137,7 @@ async def aembedding(
     **settings,
 ) -> list[list[float]]:
     if not custom_api_key:
-        model = f"openai/{model}"  # This is needed for litellm
+        model = f"openai/{model.removeprefix('openai/')}" # This is needed for litellm
 
     input = (
         [inputs]


### PR DESCRIPTION
### **User description**
### fix: prevent double `openai/` prefix in `aembedding` model name

Fixes an issue where `aembedding` prepended `openai/` multiple times to the model name, resulting in malformed names like `openai/openai/text-embedding-3-large`.

Embedding requests now route correctly
Token usage is tracked accurately
Prevents silent failures on repeated calls


___

### **PR Type**
Bug fix


___

### **Description**
- Fix double `openai/` prefix in embedding model names

- Prevent malformed model names like `openai/openai/text-embedding-3-large`

- Ensure proper routing of embedding requests


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Model Name Input"] --> B["Remove existing openai/ prefix"]
  B --> C["Add openai/ prefix"]
  C --> D["Clean Model Name"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>litellm.py</strong><dd><code>Fix duplicate prefix in model naming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/agents-api/agents_api/clients/litellm.py

<li>Modified model name handling to remove existing <code>openai/</code> prefix before <br>adding new one<br> <li> Prevents duplicate prefixes in embedding model names


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1520/files#diff-aabd22c1819fc1aefb5996dbdb9657f1b763eb1ca46d6a5f878eac02d2d0d724">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>