### PR TITLE
feat(agents-api): add secrets to task definition

### DIFF
--- a/changelog/dev/2025-07-31.md
+++ b/changelog/dev/2025-07-31.md
@@ -1,0 +1,8 @@
+---
+title: "Julep AI Changelog"
+date: 2025-07-31
+tags: [dev]
+---
+
+- Added secrets support to task definitions for secure access in task expressions
+- Removed support for claude-3-sonnet model from LLM proxy configuration

--- a/src/agents-api/agents_api/activities/task_steps/prompt_step.py
+++ b/src/agents-api/agents_api/activities/task_steps/prompt_step.py
@@ -70,6 +70,8 @@ async def prompt_step(context: StepContext) -> StepOutcome:
     passed_settings.update(passed_settings.pop("settings", {}) or {})
     passed_settings["user"] = str(context.execution_input.developer_id)
 
+    passed_settings = await base_evaluate(passed_settings, context)
+
     if get_feature_flag_value(
         "auto_tool_calls_prompt_step", developer_id=str(context.execution_input.developer_id)
     ):

--- a/src/agents-api/agents_api/common/protocol/tasks.py
+++ b/src/agents-api/agents_api/common/protocol/tasks.py
@@ -22,6 +22,7 @@ with workflow.unsafe.imports_passed_through():
         WorkflowStep,
     )
     from ...common.utils.expressions import evaluate_expressions
+    from ...common.utils.secrets import get_secrets_list
     from ...worker.codec import RemoteObject
 
 from ...activities.pg_query_step import pg_query_step
@@ -31,7 +32,6 @@ from ...queries.executions import (
     list_execution_inputs_data,
     list_execution_state_data,
 )
-from ...queries.secrets.list import list_secrets_query
 from ...queries.utils import serialize_model_data
 from .models import ExecutionInput
 
@@ -202,23 +202,7 @@ class StepContext(BaseModel):
         task_tools = []
         tools = task.tools if task else []
         inherit_tools = task.inherit_tools if task else False
-        try:
-            secrets_query_result = await workflow.execute_activity(
-                pg_query_step,
-                args=[
-                    "list_secrets_query",
-                    "secrets.list",
-                    {"developer_id": self.execution_input.developer_id, "decrypt": True},
-                ],
-                schedule_to_close_timeout=timedelta(days=31),
-                retry_policy=DEFAULT_RETRY_POLICY,
-                heartbeat_timeout=timedelta(seconds=temporal_heartbeat_timeout),
-            )
-        except _NotInWorkflowEventLoopError:
-            secrets_query_result = await list_secrets_query(
-                developer_id=self.execution_input.developer_id,
-                decrypt=True,
-            )
+        secrets_query_result = await get_secrets_list(self.execution_input.developer_id, True)
 
         if tools:
             secrets = {secret.name: secret.value for secret in secrets_query_result}
@@ -318,7 +302,7 @@ class StepContext(BaseModel):
 
     # AIDEV-NOTE: Prepares the step context by loading inputs and retrieving historical data for expression evaluation.
     async def prepare_for_step(
-        self, limit: int = max_steps_accessible_in_tasks, *args, **kwargs
+        self, limit: int = max_steps_accessible_in_tasks, connection_pool=None, *args, **kwargs
     ) -> dict[str, Any]:
         current_input = self.current_input
 
@@ -343,10 +327,18 @@ class StepContext(BaseModel):
 
             steps[i] = step
 
+        secrets_query_result = await get_secrets_list(
+            self.execution_input.developer_id, 
+            True, 
+            connection_pool=connection_pool
+        )
+        secrets = {secret.name: secret.value for secret in secrets_query_result}
+
         dump["state"] = state
         dump["steps"] = steps
         dump["inputs"] = {i: step["input"] for i, step in steps.items()}
         dump["outputs"] = {i: step["output"] for i, step in steps.items() if "output" in step}
+        dump["secrets"] = secrets
         return dump | {"_": current_input}
 
 

--- a/src/agents-api/agents_api/common/protocol/tasks.py
+++ b/src/agents-api/agents_api/common/protocol/tasks.py
@@ -1,10 +1,8 @@
-from datetime import timedelta
 from typing import Annotated, Any, Literal
 from uuid import UUID
 
 from temporalio import workflow
 from temporalio.exceptions import ApplicationError
-from temporalio.workflow import _NotInWorkflowEventLoopError
 
 with workflow.unsafe.imports_passed_through():
     from pydantic import BaseModel, Field, computed_field
@@ -25,9 +23,7 @@ with workflow.unsafe.imports_passed_through():
     from ...common.utils.secrets import get_secrets_list
     from ...worker.codec import RemoteObject
 
-from ...activities.pg_query_step import pg_query_step
-from ...common.retry_policies import DEFAULT_RETRY_POLICY
-from ...env import max_steps_accessible_in_tasks, temporal_heartbeat_timeout
+from ...env import max_steps_accessible_in_tasks
 from ...queries.executions import (
     list_execution_inputs_data,
     list_execution_state_data,
@@ -328,9 +324,7 @@ class StepContext(BaseModel):
             steps[i] = step
 
         secrets_query_result = await get_secrets_list(
-            self.execution_input.developer_id, 
-            True, 
-            connection_pool=connection_pool
+            self.execution_input.developer_id, True, connection_pool=connection_pool
         )
         secrets = {secret.name: secret.value for secret in secrets_query_result}
 

--- a/src/agents-api/agents_api/common/utils/secrets.py
+++ b/src/agents-api/agents_api/common/utils/secrets.py
@@ -44,11 +44,10 @@ async def get_secret_by_name(developer_id: UUID, name: str, decrypt: bool = Fals
 
     return secret
 
+
 @alru_cache(ttl=secrets_cache_ttl)
 async def get_secrets_list(
-    developer_id: UUID, 
-    decrypt: bool = False, 
-    connection_pool=None
+    developer_id: UUID, decrypt: bool = False, connection_pool=None
 ) -> list[Secret]:
     try:
         secrets_query_result = await workflow.execute_activity(

--- a/src/agents-api/agents_api/common/utils/secrets.py
+++ b/src/agents-api/agents_api/common/utils/secrets.py
@@ -9,6 +9,7 @@ from ...activities.pg_query_step import pg_query_step
 from ...autogen.openapi_model import Secret
 from ...env import secrets_cache_ttl, temporal_heartbeat_timeout
 from ...queries.secrets import get_secret_by_name as get_secret_by_name_query
+from ...queries.secrets.list import list_secrets_query
 from ..exceptions.secrets import (
     SecretNotFoundError,  # AIDEV-NOTE: use domain exception for missing secrets
 )
@@ -42,3 +43,30 @@ async def get_secret_by_name(developer_id: UUID, name: str, decrypt: bool = Fals
         raise SecretNotFoundError(developer_id, name)
 
     return secret
+
+@alru_cache(ttl=secrets_cache_ttl)
+async def get_secrets_list(
+    developer_id: UUID, 
+    decrypt: bool = False, 
+    connection_pool=None
+) -> list[Secret]:
+    try:
+        secrets_query_result = await workflow.execute_activity(
+            pg_query_step,
+            args=[
+                "list_secrets_query",
+                "secrets.list",
+                {"developer_id": developer_id, "decrypt": decrypt},
+            ],
+            schedule_to_close_timeout=timedelta(days=31),
+            retry_policy=DEFAULT_RETRY_POLICY,
+            heartbeat_timeout=timedelta(seconds=temporal_heartbeat_timeout),
+        )
+    except _NotInWorkflowEventLoopError:
+        secrets_query_result = await list_secrets_query(
+            developer_id=developer_id,
+            decrypt=decrypt,
+            connection_pool=connection_pool,
+        )
+
+    return secrets_query_result

--- a/src/agents-api/tests/test_prepare_for_step.py
+++ b/src/agents-api/tests/test_prepare_for_step.py
@@ -10,19 +10,20 @@ from agents_api.autogen.openapi_model import (
     TransitionTarget,
     Workflow,
 )
+from agents_api.clients.pg import create_db_pool
 from agents_api.common.protocol.tasks import (
     ExecutionInput,
     StepContext,
 )
 from agents_api.common.utils.datetime import utcnow
+from agents_api.common.utils.expressions import evaluate_expressions
 from agents_api.common.utils.workflows import get_workflow_name
 from uuid_extensions import uuid7
 from ward import raises, test
 
-from tests.utils import generate_transition
 from tests.fixtures import pg_dsn
-from agents_api.clients.pg import create_db_pool
-from agents_api.web import app
+from tests.utils import generate_transition
+
 
 async def base_evaluate_with_pool(
     exprs,
@@ -43,11 +44,11 @@ async def base_evaluate_with_pool(
 
     return evaluate_expressions(exprs, values=values, extra_lambda_strs=extra_lambda_strs)
 
+
 @test("utility: prepare_for_step - underscore")
 async def _(dsn=pg_dsn):  # Add dsn parameter
-    
     pool = await create_db_pool(dsn=dsn)
-    
+
     with patch(
         "agents_api.common.protocol.tasks.StepContext.get_inputs",
         return_value=(
@@ -88,7 +89,7 @@ async def _(dsn=pg_dsn):  # Add dsn parameter
 @test("utility: prepare_for_step - label lookup in step")
 async def _(dsn=pg_dsn):
     pool = await create_db_pool(dsn=dsn)
-    
+
     with patch(
         "agents_api.common.protocol.tasks.StepContext.get_inputs",
         return_value=(
@@ -133,7 +134,7 @@ async def _(dsn=pg_dsn):
 @test("utility: prepare_for_step - global state")
 async def _(dsn=pg_dsn):
     pool = await create_db_pool(dsn=dsn)
-    
+
     with patch(
         "agents_api.common.protocol.tasks.StepContext.get_inputs",
         return_value=([], [], {"user_name": "John", "count": 10, "has_data": True}),
@@ -171,8 +172,8 @@ async def _(dsn=pg_dsn):
 
 @test("utility: get_workflow_name")
 async def _(dsn=pg_dsn):
-    pool = await create_db_pool(dsn=dsn)
-    
+    await create_db_pool(dsn=dsn)
+
     transition = Transition(
         id=uuid.uuid4(),
         execution_id=uuid.uuid4(),
@@ -231,8 +232,8 @@ async def _(dsn=pg_dsn):
 
 @test("utility: get_workflow_name - raises")
 async def _(dsn=pg_dsn):
-    pool = await create_db_pool(dsn=dsn)
-    
+    await create_db_pool(dsn=dsn)
+
     transition = Transition(
         id=uuid.uuid4(),
         execution_id=uuid.uuid4(),
@@ -271,8 +272,8 @@ async def _(dsn=pg_dsn):
 
 @test("utility: get_inputs - 2 parallel subworkflows")
 async def _(dsn=pg_dsn):
-    pool = await create_db_pool(dsn=dsn)
-    
+    await create_db_pool(dsn=dsn)
+
     uuid7()
     subworkflow1_scope_id = uuid7()
     subworkflow2_scope_id = uuid7()

--- a/src/agents-api/tests/test_prompt_step_auto_tools.py
+++ b/src/agents-api/tests/test_prompt_step_auto_tools.py
@@ -22,9 +22,8 @@ def mock_base_evaluate(value, context):
     if isinstance(value, dict):
         # For passed_settings, return the dict unchanged
         return value
-    else:
-        # For prompt strings, return the string
-        return "Test prompt"
+    # For prompt strings, return the string
+    return "Test prompt"
 
 
 @test("prompt_step uses auto tool calls when feature flag is enabled")
@@ -39,141 +38,143 @@ async def _():
     )
 
     # Mock feature flag to be enabled
-    with patch(
-        "agents_api.activities.task_steps.prompt_step.get_feature_flag_value"
-    ) as mock_flag:
+    with (
+        patch(
+            "agents_api.activities.task_steps.prompt_step.get_feature_flag_value"
+        ) as mock_flag,
+        patch(
+            "agents_api.activities.task_steps.prompt_step.base_evaluate",
+            side_effect=mock_base_evaluate,
+        ),
+        patch(
+            "agents_api.activities.task_steps.prompt_step.run_llm_with_tools",
+            new_callable=AsyncMock,
+        ) as mock_run_llm,
+    ):
         mock_flag.return_value = True
+        mock_run_llm.return_value = [
+            {"role": "user", "content": "Test prompt"},
+            {"role": "assistant", "content": "Test response"},
+        ]
 
-        # Use the shared mock function
-        with patch("agents_api.activities.task_steps.prompt_step.base_evaluate", side_effect=mock_base_evaluate) as mock_eval:
-            # Mock run_llm_with_tools
-            with patch(
-                "agents_api.activities.task_steps.prompt_step.run_llm_with_tools",
-                new_callable=AsyncMock,
-            ) as mock_run_llm:
-                mock_run_llm.return_value = [
-                    {"role": "user", "content": "Test prompt"},
-                    {"role": "assistant", "content": "Test response"},
-                ]
+        # Create proper StepContext with real objects
+        # Note: auto_run_tools defaults to False now, so we need to explicitly set it to True
+        step = PromptStep(prompt="Test prompt", unwrap=False, auto_run_tools=True)
+        execution_input = ExecutionInput(
+            developer_id=uuid4(),
+            agent=Agent(
+                id=uuid4(),
+                name="test_agent",
+                model="gpt-4",
+                default_settings={"temperature": 0.7},
+                created_at=utcnow(),
+                updated_at=utcnow(),
+            ),
+            agent_tools=[],
+            arguments={},
+            task=TaskSpecDef(
+                name="test_task",
+                tools=[],
+                workflows=[Workflow(name="main", steps=[step])],
+            ),
+        )
 
-                # Create proper StepContext with real objects
-                # Note: auto_run_tools defaults to False now, so we need to explicitly set it to True
-                step = PromptStep(prompt="Test prompt", unwrap=False, auto_run_tools=True)
-                execution_input = ExecutionInput(
-                    developer_id=uuid4(),
-                    agent=Agent(
-                        id=uuid4(),
-                        name="test_agent",
-                        model="gpt-4",
-                        default_settings={"temperature": 0.7},
-                        created_at=utcnow(),
-                        updated_at=utcnow(),
-                    ),
-                    agent_tools=[],
-                    arguments={},
-                    task=TaskSpecDef(
-                        name="test_task",
-                        tools=[],
-                        workflows=[Workflow(name="main", steps=[step])],
-                    ),
-                )
+        context = StepContext(
+            execution_input=execution_input,
+            current_input="test input",
+            cursor=TransitionTarget(
+                workflow="main",
+                step=0,
+                scope_id=uuid4(),
+            ),
+        )
 
-                context = StepContext(
-                    execution_input=execution_input,
-                    current_input="test input",
-                    cursor=TransitionTarget(
-                        workflow="main",
-                        step=0,
-                        scope_id=uuid4(),
-                    ),
-                )
+        # Mock the tools method on the StepContext class - need to accept self parameter
+        async def mock_tools_method(self):
+            return [tool]
 
-                # Mock the tools method on the StepContext class - need to accept self parameter
-                async def mock_tools_method(self):
-                    return [tool]
+        with patch.object(StepContext, "tools", mock_tools_method):
+            # Run the activity
+            result = await prompt_step(context)
 
-                with patch.object(StepContext, "tools", mock_tools_method):
-                    # Run the activity
-                    result = await prompt_step(context)
+            # Verify run_llm_with_tools was called
+            mock_run_llm.assert_called_once()
+            call_args = mock_run_llm.call_args
+            assert call_args[1]["messages"] == [{"role": "user", "content": "Test prompt"}]
+            assert len(call_args[1]["tools"]) == 1
+            assert call_args[1]["tools"][0].name == "test_tool"
 
-                    # Verify run_llm_with_tools was called
-                    mock_run_llm.assert_called_once()
-                    call_args = mock_run_llm.call_args
-                    assert call_args[1]["messages"] == [
-                        {"role": "user", "content": "Test prompt"}
-                    ]
-                    assert len(call_args[1]["tools"]) == 1
-                    assert call_args[1]["tools"][0].name == "test_tool"
-
-                    # Check result
-                    assert result.output == [
-                        {"role": "user", "content": "Test prompt"},
-                        {"role": "assistant", "content": "Test response"},
-                    ]
+            # Check result
+            assert result.output == [
+                {"role": "user", "content": "Test prompt"},
+                {"role": "assistant", "content": "Test response"},
+            ]
 
 
 @test("prompt_step with auto tools handles unwrap correctly")
 async def _():
     # Mock feature flag to be enabled
-    with patch(
-        "agents_api.activities.task_steps.prompt_step.get_feature_flag_value"
-    ) as mock_flag:
+    with (
+        patch(
+            "agents_api.activities.task_steps.prompt_step.get_feature_flag_value"
+        ) as mock_flag,
+        patch(
+            "agents_api.activities.task_steps.prompt_step.base_evaluate",
+            side_effect=mock_base_evaluate,
+        ),
+        patch(
+            "agents_api.activities.task_steps.prompt_step.run_llm_with_tools",
+            new_callable=AsyncMock,
+        ) as mock_run_llm,
+    ):
         mock_flag.return_value = True
+        mock_run_llm.return_value = [
+            {"role": "user", "content": "Test prompt"},
+            {"role": "assistant", "content": "Unwrapped response", "tool_calls": None},
+        ]
 
-        # Use the shared mock function
-        with patch("agents_api.activities.task_steps.prompt_step.base_evaluate", side_effect=mock_base_evaluate) as mock_eval:
-            # Mock run_llm_with_tools to return unwrappable response
-            with patch(
-                "agents_api.activities.task_steps.prompt_step.run_llm_with_tools",
-                new_callable=AsyncMock,
-            ) as mock_run_llm:
-                mock_run_llm.return_value = [
-                    {"role": "user", "content": "Test prompt"},
-                    {"role": "assistant", "content": "Unwrapped response", "tool_calls": None},
-                ]
+        # Create proper StepContext with real objects
+        # Note: auto_run_tools defaults to False now, so we need to explicitly set it to True for this test
+        step = PromptStep(prompt="Test prompt", unwrap=True, auto_run_tools=True)
+        execution_input = ExecutionInput(
+            developer_id=uuid4(),
+            agent=Agent(
+                id=uuid4(),
+                name="test_agent",
+                model="gpt-4",
+                default_settings={},
+                created_at=utcnow(),
+                updated_at=utcnow(),
+            ),
+            agent_tools=[],
+            arguments={},
+            task=TaskSpecDef(
+                name="test_task",
+                tools=[],
+                workflows=[Workflow(name="main", steps=[step])],
+            ),
+        )
 
-                # Create proper StepContext with real objects
-                # Note: auto_run_tools defaults to False now, so we need to explicitly set it to True for this test
-                step = PromptStep(prompt="Test prompt", unwrap=True, auto_run_tools=True)
-                execution_input = ExecutionInput(
-                    developer_id=uuid4(),
-                    agent=Agent(
-                        id=uuid4(),
-                        name="test_agent",
-                        model="gpt-4",
-                        default_settings={},
-                        created_at=utcnow(),
-                        updated_at=utcnow(),
-                    ),
-                    agent_tools=[],
-                    arguments={},
-                    task=TaskSpecDef(
-                        name="test_task",
-                        tools=[],
-                        workflows=[Workflow(name="main", steps=[step])],
-                    ),
-                )
+        context = StepContext(
+            execution_input=execution_input,
+            current_input="test input",
+            cursor=TransitionTarget(
+                workflow="main",
+                step=0,
+                scope_id=uuid4(),
+            ),
+        )
 
-                context = StepContext(
-                    execution_input=execution_input,
-                    current_input="test input",
-                    cursor=TransitionTarget(
-                        workflow="main",
-                        step=0,
-                        scope_id=uuid4(),
-                    ),
-                )
+        # Mock the tools method on the StepContext class - need to accept self parameter
+        async def mock_tools_method(self):
+            return []
 
-                # Mock the tools method on the StepContext class - need to accept self parameter
-                async def mock_tools_method(self):
-                    return []
+        with patch.object(StepContext, "tools", mock_tools_method):
+            # Run the activity
+            result = await prompt_step(context)
 
-                with patch.object(StepContext, "tools", mock_tools_method):
-                    # Run the activity
-                    result = await prompt_step(context)
-
-                    # Check that output is unwrapped
-                    assert result.output == "Unwrapped response"
+            # Check that output is unwrapped
+            assert result.output == "Unwrapped response"
 
 
 @test("prompt_step with auto_run_tools=False passes empty tools list")
@@ -188,76 +189,76 @@ async def _():
     )
 
     # Mock feature flag to be enabled
-    with patch(
-        "agents_api.activities.task_steps.prompt_step.get_feature_flag_value"
-    ) as mock_flag:
+    with (
+        patch(
+            "agents_api.activities.task_steps.prompt_step.get_feature_flag_value"
+        ) as mock_flag,
+        patch(
+            "agents_api.activities.task_steps.prompt_step.base_evaluate",
+            side_effect=mock_base_evaluate,
+        ),
+        patch(
+            "agents_api.activities.task_steps.prompt_step.run_llm_with_tools",
+            new_callable=AsyncMock,
+        ) as mock_run_llm,
+    ):
         mock_flag.return_value = True
+        mock_run_llm.return_value = [
+            {"role": "user", "content": "Test prompt"},
+            {"role": "assistant", "content": "Test response without tools"},
+        ]
 
-        # Use the shared mock function
-        with patch("agents_api.activities.task_steps.prompt_step.base_evaluate", side_effect=mock_base_evaluate) as mock_eval:
-            # Mock run_llm_with_tools
-            with patch(
-                "agents_api.activities.task_steps.prompt_step.run_llm_with_tools",
-                new_callable=AsyncMock,
-            ) as mock_run_llm:
-                mock_run_llm.return_value = [
-                    {"role": "user", "content": "Test prompt"},
-                    {"role": "assistant", "content": "Test response without tools"},
-                ]
+        # Create prompt step with auto_run_tools=False
+        step = PromptStep(prompt="Test prompt", unwrap=False, auto_run_tools=False)
+        execution_input = ExecutionInput(
+            developer_id=uuid4(),
+            agent=Agent(
+                id=uuid4(),
+                name="test_agent",
+                model="gpt-4",
+                default_settings={"temperature": 0.7},
+                created_at=utcnow(),
+                updated_at=utcnow(),
+            ),
+            agent_tools=[],
+            arguments={},
+            task=TaskSpecDef(
+                name="test_task",
+                tools=[],
+                workflows=[Workflow(name="main", steps=[step])],
+            ),
+        )
 
-                # Create prompt step with auto_run_tools=False
-                step = PromptStep(prompt="Test prompt", unwrap=False, auto_run_tools=False)
-                execution_input = ExecutionInput(
-                    developer_id=uuid4(),
-                    agent=Agent(
-                        id=uuid4(),
-                        name="test_agent",
-                        model="gpt-4",
-                        default_settings={"temperature": 0.7},
-                        created_at=utcnow(),
-                        updated_at=utcnow(),
-                    ),
-                    agent_tools=[],
-                    arguments={},
-                    task=TaskSpecDef(
-                        name="test_task",
-                        tools=[],
-                        workflows=[Workflow(name="main", steps=[step])],
-                    ),
-                )
+        context = StepContext(
+            execution_input=execution_input,
+            current_input="test input",
+            cursor=TransitionTarget(
+                workflow="main",
+                step=0,
+                scope_id=uuid4(),
+            ),
+        )
 
-                context = StepContext(
-                    execution_input=execution_input,
-                    current_input="test input",
-                    cursor=TransitionTarget(
-                        workflow="main",
-                        step=0,
-                        scope_id=uuid4(),
-                    ),
-                )
+        # Mock the tools method to return a tool
+        async def mock_tools_method(self):
+            return [tool]
 
-                # Mock the tools method to return a tool
-                async def mock_tools_method(self):
-                    return [tool]
+        with patch.object(StepContext, "tools", mock_tools_method):
+            # Run the activity
+            result = await prompt_step(context)
 
-                with patch.object(StepContext, "tools", mock_tools_method):
-                    # Run the activity
-                    result = await prompt_step(context)
+            # Verify run_llm_with_tools was called with empty tools list
+            mock_run_llm.assert_called_once()
+            call_args = mock_run_llm.call_args
+            assert call_args[1]["messages"] == [{"role": "user", "content": "Test prompt"}]
+            # IMPORTANT: Verify empty tools list was passed
+            assert call_args[1]["tools"] == []
 
-                    # Verify run_llm_with_tools was called with empty tools list
-                    mock_run_llm.assert_called_once()
-                    call_args = mock_run_llm.call_args
-                    assert call_args[1]["messages"] == [
-                        {"role": "user", "content": "Test prompt"}
-                    ]
-                    # IMPORTANT: Verify empty tools list was passed
-                    assert call_args[1]["tools"] == []
-
-                    # Check result
-                    assert result.output == [
-                        {"role": "user", "content": "Test prompt"},
-                        {"role": "assistant", "content": "Test response without tools"},
-                    ]
+            # Check result
+            assert result.output == [
+                {"role": "user", "content": "Test prompt"},
+                {"role": "assistant", "content": "Test response without tools"},
+            ]
 
 
 @test("prompt_step with auto_run_tools=True passes all available tools")
@@ -280,75 +281,75 @@ async def _():
     )
 
     # Mock feature flag to be enabled
-    with patch(
-        "agents_api.activities.task_steps.prompt_step.get_feature_flag_value"
-    ) as mock_flag:
+    with (
+        patch(
+            "agents_api.activities.task_steps.prompt_step.get_feature_flag_value"
+        ) as mock_flag,
+        patch(
+            "agents_api.activities.task_steps.prompt_step.base_evaluate",
+            side_effect=mock_base_evaluate,
+        ),
+        patch(
+            "agents_api.activities.task_steps.prompt_step.run_llm_with_tools",
+            new_callable=AsyncMock,
+        ) as mock_run_llm,
+    ):
         mock_flag.return_value = True
+        mock_run_llm.return_value = [
+            {"role": "user", "content": "Test prompt"},
+            {"role": "assistant", "content": "Test response with tools"},
+        ]
 
-        # Use the shared mock function
-        with patch("agents_api.activities.task_steps.prompt_step.base_evaluate", side_effect=mock_base_evaluate) as mock_eval:
-            # Mock run_llm_with_tools
-            with patch(
-                "agents_api.activities.task_steps.prompt_step.run_llm_with_tools",
-                new_callable=AsyncMock,
-            ) as mock_run_llm:
-                mock_run_llm.return_value = [
-                    {"role": "user", "content": "Test prompt"},
-                    {"role": "assistant", "content": "Test response with tools"},
-                ]
+        # Create prompt step with auto_run_tools=True (default)
+        step = PromptStep(prompt="Test prompt", unwrap=False, auto_run_tools=True)
+        execution_input = ExecutionInput(
+            developer_id=uuid4(),
+            agent=Agent(
+                id=uuid4(),
+                name="test_agent",
+                model="gpt-4",
+                default_settings={"temperature": 0.7},
+                created_at=utcnow(),
+                updated_at=utcnow(),
+            ),
+            agent_tools=[],
+            arguments={},
+            task=TaskSpecDef(
+                name="test_task",
+                tools=[],
+                workflows=[Workflow(name="main", steps=[step])],
+            ),
+        )
 
-                # Create prompt step with auto_run_tools=True (default)
-                step = PromptStep(prompt="Test prompt", unwrap=False, auto_run_tools=True)
-                execution_input = ExecutionInput(
-                    developer_id=uuid4(),
-                    agent=Agent(
-                        id=uuid4(),
-                        name="test_agent",
-                        model="gpt-4",
-                        default_settings={"temperature": 0.7},
-                        created_at=utcnow(),
-                        updated_at=utcnow(),
-                    ),
-                    agent_tools=[],
-                    arguments={},
-                    task=TaskSpecDef(
-                        name="test_task",
-                        tools=[],
-                        workflows=[Workflow(name="main", steps=[step])],
-                    ),
-                )
+        context = StepContext(
+            execution_input=execution_input,
+            current_input="test input",
+            cursor=TransitionTarget(
+                workflow="main",
+                step=0,
+                scope_id=uuid4(),
+            ),
+        )
 
-                context = StepContext(
-                    execution_input=execution_input,
-                    current_input="test input",
-                    cursor=TransitionTarget(
-                        workflow="main",
-                        step=0,
-                        scope_id=uuid4(),
-                    ),
-                )
+        # Mock the tools method to return multiple tools
+        async def mock_tools_method(self):
+            return [tool1, tool2]
 
-                # Mock the tools method to return multiple tools
-                async def mock_tools_method(self):
-                    return [tool1, tool2]
+        with patch.object(StepContext, "tools", mock_tools_method):
+            # Run the activity
+            result = await prompt_step(context)
 
-                with patch.object(StepContext, "tools", mock_tools_method):
-                    # Run the activity
-                    result = await prompt_step(context)
+            # Verify run_llm_with_tools was called with all tools
+            mock_run_llm.assert_called_once()
+            call_args = mock_run_llm.call_args
+            assert call_args[1]["messages"] == [{"role": "user", "content": "Test prompt"}]
+            # IMPORTANT: Verify all tools were passed
+            assert len(call_args[1]["tools"]) == 2
+            assert call_args[1]["tools"][0].name == "tool1"
+            assert call_args[1]["tools"][1].name == "tool2"
 
-                    # Verify run_llm_with_tools was called with all tools
-                    mock_run_llm.assert_called_once()
-                    call_args = mock_run_llm.call_args
-                    assert call_args[1]["messages"] == [
-                        {"role": "user", "content": "Test prompt"}
-                    ]
-                    # IMPORTANT: Verify all tools were passed
-                    assert len(call_args[1]["tools"]) == 2
-                    assert call_args[1]["tools"][0].name == "tool1"
-                    assert call_args[1]["tools"][1].name == "tool2"
-
-                    # Check result
-                    assert result.output == [
-                        {"role": "user", "content": "Test prompt"},
-                        {"role": "assistant", "content": "Test response with tools"},
-                    ]
+            # Check result
+            assert result.output == [
+                {"role": "user", "content": "Test prompt"},
+                {"role": "assistant", "content": "Test response with tools"},
+            ]

--- a/src/agents-api/tests/test_prompt_step_auto_tools.py
+++ b/src/agents-api/tests/test_prompt_step_auto_tools.py
@@ -16,6 +16,17 @@ from agents_api.common.utils.datetime import utcnow
 from ward import test
 
 
+# Define the mock function once at module level
+def mock_base_evaluate(value, context):
+    """Mock base_evaluate to return appropriate types based on input"""
+    if isinstance(value, dict):
+        # For passed_settings, return the dict unchanged
+        return value
+    else:
+        # For prompt strings, return the string
+        return "Test prompt"
+
+
 @test("prompt_step uses auto tool calls when feature flag is enabled")
 async def _():
     tool = CreateToolRequest(
@@ -33,10 +44,8 @@ async def _():
     ) as mock_flag:
         mock_flag.return_value = True
 
-        # Mock base_evaluate to just return the prompt unchanged
-        with patch("agents_api.activities.task_steps.prompt_step.base_evaluate") as mock_eval:
-            mock_eval.return_value = "Test prompt"
-
+        # Use the shared mock function
+        with patch("agents_api.activities.task_steps.prompt_step.base_evaluate", side_effect=mock_base_evaluate) as mock_eval:
             # Mock run_llm_with_tools
             with patch(
                 "agents_api.activities.task_steps.prompt_step.run_llm_with_tools",
@@ -111,10 +120,8 @@ async def _():
     ) as mock_flag:
         mock_flag.return_value = True
 
-        # Mock base_evaluate
-        with patch("agents_api.activities.task_steps.prompt_step.base_evaluate") as mock_eval:
-            mock_eval.return_value = "Test prompt"
-
+        # Use the shared mock function
+        with patch("agents_api.activities.task_steps.prompt_step.base_evaluate", side_effect=mock_base_evaluate) as mock_eval:
             # Mock run_llm_with_tools to return unwrappable response
             with patch(
                 "agents_api.activities.task_steps.prompt_step.run_llm_with_tools",
@@ -186,10 +193,8 @@ async def _():
     ) as mock_flag:
         mock_flag.return_value = True
 
-        # Mock base_evaluate to just return the prompt unchanged
-        with patch("agents_api.activities.task_steps.prompt_step.base_evaluate") as mock_eval:
-            mock_eval.return_value = "Test prompt"
-
+        # Use the shared mock function
+        with patch("agents_api.activities.task_steps.prompt_step.base_evaluate", side_effect=mock_base_evaluate) as mock_eval:
             # Mock run_llm_with_tools
             with patch(
                 "agents_api.activities.task_steps.prompt_step.run_llm_with_tools",
@@ -280,10 +285,8 @@ async def _():
     ) as mock_flag:
         mock_flag.return_value = True
 
-        # Mock base_evaluate to just return the prompt unchanged
-        with patch("agents_api.activities.task_steps.prompt_step.base_evaluate") as mock_eval:
-            mock_eval.return_value = "Test prompt"
-
+        # Use the shared mock function
+        with patch("agents_api.activities.task_steps.prompt_step.base_evaluate", side_effect=mock_base_evaluate) as mock_eval:
             # Mock run_llm_with_tools
             with patch(
                 "agents_api.activities.task_steps.prompt_step.run_llm_with_tools",

--- a/src/agents-api/tests/test_task_execution_workflow.py
+++ b/src/agents-api/tests/test_task_execution_workflow.py
@@ -1,5 +1,5 @@
-import uuid
 import functools
+import uuid
 from base64 import b64decode
 from datetime import timedelta
 from unittest.mock import Mock, call, patch
@@ -9,7 +9,6 @@ from agents_api.activities import task_steps
 from agents_api.activities.execute_api_call import execute_api_call
 from agents_api.activities.execute_integration import execute_integration
 from agents_api.activities.execute_system import execute_system
-from agents_api.activities.task_steps.base_evaluate import base_evaluate
 from agents_api.autogen.openapi_model import (
     Agent,
     ApiCallDef,
@@ -39,6 +38,7 @@ from agents_api.autogen.openapi_model import (
     Workflow,
     YieldStep,
 )
+from agents_api.clients.pg import create_db_pool
 from agents_api.common.protocol.tasks import (
     ExecutionInput,
     PartialTransition,
@@ -48,6 +48,7 @@ from agents_api.common.protocol.tasks import (
 )
 from agents_api.common.retry_policies import DEFAULT_RETRY_POLICY
 from agents_api.common.utils.datetime import utcnow
+from agents_api.common.utils.expressions import evaluate_expressions
 from agents_api.env import (
     debug,
     temporal_heartbeat_timeout,
@@ -59,8 +60,7 @@ from aiohttp import test_utils
 from temporalio.exceptions import ApplicationError
 from temporalio.workflow import _NotInWorkflowEventLoopError
 from ward import raises, test
-from agents_api.common.utils.expressions import evaluate_expressions
-from agents_api.clients.pg import create_db_pool
+
 from tests.fixtures import pg_dsn
 
 
@@ -1015,10 +1015,7 @@ async def _():
 async def _(dsn=pg_dsn):
     pool = await create_db_pool(dsn=dsn)
 
-    base_evaluate_patched = functools.partial(
-        base_evaluate_with_pool,
-        connection_pool=pool
-    )
+    base_evaluate_patched = functools.partial(base_evaluate_with_pool, connection_pool=pool)
 
     wf = TaskExecutionWorkflow()
     step = PromptStep(prompt=[PromptItem(content="hi there", role="user")])
@@ -1100,10 +1097,7 @@ async def _(dsn=pg_dsn):
 async def _(dsn=pg_dsn):
     pool = await create_db_pool(dsn=dsn)
 
-    base_evaluate_patched = functools.partial(
-        base_evaluate_with_pool,
-        connection_pool=pool
-    )
+    base_evaluate_patched = functools.partial(base_evaluate_with_pool, connection_pool=pool)
 
     wf = TaskExecutionWorkflow()
     step = PromptStep(prompt=[PromptItem(content="hi there", role="user")])
@@ -1185,10 +1179,7 @@ async def _(dsn=pg_dsn):
 async def _(dsn=pg_dsn):
     pool = await create_db_pool(dsn=dsn)
 
-    base_evaluate_patched = functools.partial(
-        base_evaluate_with_pool,
-        connection_pool=pool
-    )
+    base_evaluate_patched = functools.partial(base_evaluate_with_pool, connection_pool=pool)
 
     wf = TaskExecutionWorkflow()
     step = PromptStep(prompt=[PromptItem(content="hi there", role="user")])
@@ -1270,10 +1261,7 @@ async def _(dsn=pg_dsn):
 async def _(dsn=pg_dsn):
     pool = await create_db_pool(dsn=dsn)
 
-    base_evaluate_patched = functools.partial(
-        base_evaluate_with_pool,
-        connection_pool=pool
-    )
+    base_evaluate_patched = functools.partial(base_evaluate_with_pool, connection_pool=pool)
 
     wf = TaskExecutionWorkflow()
     step = PromptStep(prompt=[PromptItem(content="hi there", role="user")])
@@ -1355,10 +1343,7 @@ async def _(dsn=pg_dsn):
 async def _(dsn=pg_dsn):
     pool = await create_db_pool(dsn=dsn)
 
-    base_evaluate_patched = functools.partial(
-        base_evaluate_with_pool,
-        connection_pool=pool
-    )
+    base_evaluate_patched = functools.partial(base_evaluate_with_pool, connection_pool=pool)
 
     wf = TaskExecutionWorkflow()
     step = PromptStep(prompt=[PromptItem(content="hi there", role="user")])
@@ -1440,10 +1425,7 @@ async def _(dsn=pg_dsn):
 async def _(dsn=pg_dsn):
     pool = await create_db_pool(dsn=dsn)
 
-    base_evaluate_patched = functools.partial(
-        base_evaluate_with_pool,
-        connection_pool=pool
-    )
+    base_evaluate_patched = functools.partial(base_evaluate_with_pool, connection_pool=pool)
 
     wf = TaskExecutionWorkflow()
     step = PromptStep(prompt=[PromptItem(content="hi there", role="user")])
@@ -1525,10 +1507,7 @@ async def _(dsn=pg_dsn):
 async def _(dsn=pg_dsn):
     pool = await create_db_pool(dsn=dsn)
 
-    base_evaluate_patched = functools.partial(
-        base_evaluate_with_pool,
-        connection_pool=pool
-    )
+    base_evaluate_patched = functools.partial(base_evaluate_with_pool, connection_pool=pool)
 
     wf = TaskExecutionWorkflow()
     step = PromptStep(prompt=[PromptItem(content="hi there", role="user")])
@@ -1608,10 +1587,7 @@ async def _(dsn=pg_dsn):
 async def _(dsn=pg_dsn):
     pool = await create_db_pool(dsn=dsn)
 
-    base_evaluate_patched = functools.partial(
-        base_evaluate_with_pool,
-        connection_pool=pool
-    )
+    base_evaluate_patched = functools.partial(base_evaluate_with_pool, connection_pool=pool)
 
     wf = TaskExecutionWorkflow()
     step = PromptStep(prompt=[PromptItem(content="hi there", role="user")])
@@ -1691,10 +1667,7 @@ async def _(dsn=pg_dsn):
 async def _(dsn=pg_dsn):
     pool = await create_db_pool(dsn=dsn)
 
-    base_evaluate_patched = functools.partial(
-        base_evaluate_with_pool,
-        connection_pool=pool
-    )
+    base_evaluate_patched = functools.partial(base_evaluate_with_pool, connection_pool=pool)
 
     wf = TaskExecutionWorkflow()
     step = PromptStep(prompt=[PromptItem(content="hi there", role="user")])
@@ -1781,10 +1754,7 @@ async def _(dsn=pg_dsn):
 async def _(dsn=pg_dsn):
     pool = await create_db_pool(dsn=dsn)
 
-    base_evaluate_patched = functools.partial(
-        base_evaluate_with_pool,
-        connection_pool=pool
-    )
+    base_evaluate_patched = functools.partial(base_evaluate_with_pool, connection_pool=pool)
 
     wf = TaskExecutionWorkflow()
     step = ToolCallStep(tool="tool1", arguments={"x": "$ 1 + 2"})
@@ -1887,10 +1857,7 @@ async def _(dsn=pg_dsn):
 async def _(dsn=pg_dsn):
     pool = await create_db_pool(dsn=dsn)
 
-    base_evaluate_patched = functools.partial(
-        base_evaluate_with_pool,
-        connection_pool=pool
-    )
+    base_evaluate_patched = functools.partial(base_evaluate_with_pool, connection_pool=pool)
 
     wf = TaskExecutionWorkflow()
     step = YieldStep(arguments={"x": "$ 1 + 2"}, workflow="main")
@@ -1980,10 +1947,7 @@ async def _(dsn=pg_dsn):
 async def _(dsn=pg_dsn):
     pool = await create_db_pool(dsn=dsn)
 
-    base_evaluate_patched = functools.partial(
-        base_evaluate_with_pool,
-        connection_pool=pool
-    )
+    base_evaluate_patched = functools.partial(base_evaluate_with_pool, connection_pool=pool)
 
     wf = TaskExecutionWorkflow()
     step = ToolCallStep(tool="tool1", arguments={"x": "$ 1 + 2"})

--- a/src/llm-proxy/litellm-config.yaml
+++ b/src/llm-proxy/litellm-config.yaml
@@ -142,11 +142,11 @@ model_list:
     tags: ["paid"]
     api_key: os.environ/ANTHROPIC_API_KEY
 
-- model_name: "claude-3-sonnet"
-  litellm_params:
-    model: "claude-3-sonnet-20240229"
-    tags: ["paid"]
-    api_key: os.environ/ANTHROPIC_API_KEY
+# - model_name: "claude-3-sonnet" # Litellm/Anthropic removed support for this model
+#   litellm_params:
+#     model: "claude-3-sonnet-20240229"
+#     tags: ["paid"]
+#     api_key: os.environ/ANTHROPIC_API_KEY
 
 - model_name: "claude-3-haiku"
   litellm_params:


### PR DESCRIPTION
### **User description**
- **feat(agents-api): add secrets to task definition**
- **chore(llm-proxy): remove support for claude-3-sonnet model**


___

### **PR Type**
Enhancement, Other


___

### **Description**
- Add secrets support to task execution context

- Refactor secrets handling with centralized utility function

- Remove deprecated claude-3-sonnet model from LLM proxy

- Update tests to support database connection pooling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Task Context"] --> B["Secrets Utility"]
  B --> C["Database Pool"]
  C --> D["Secrets in Context"]
  E["Prompt Step"] --> F["Base Evaluate"]
  F --> D
  G["LLM Config"] --> H["Remove Claude-3-Sonnet"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prompt_step.py</strong><dd><code>Evaluate settings in prompt step</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/agents-api/agents_api/activities/task_steps/prompt_step.py

<ul><li>Add <code>base_evaluate</code> call to process <code>passed_settings</code> before LLM execution</ul>


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1534/files#diff-59f7933f84e18162334518f016cb3ef9d5130b8e0839d3de220dab496a863eca">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tasks.py</strong><dd><code>Integrate secrets into task context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/agents-api/agents_api/common/protocol/tasks.py

<ul><li>Replace direct secrets query with centralized <code>get_secrets_list</code> utility<br> <li> Add secrets to task context in <code>prepare_for_step</code> method<br> <li> Remove duplicate secrets handling code from tools method<br> <li> Add connection_pool parameter support</ul>


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1534/files#diff-07f6720f25e665428aa073028b7d67a272b684b043c619c521424da0ce1fcd0a">+11/-19</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>secrets.py</strong><dd><code>Add centralized secrets list utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/agents-api/agents_api/common/utils/secrets.py

<ul><li>Add new <code>get_secrets_list</code> function with caching support<br> <li> Handle both workflow and non-workflow execution contexts<br> <li> Support optional connection_pool parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1534/files#diff-8b9d2d49b5f0817b038314779eabb0adbbbccf74e76025e0694c1fe408df8a5e">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_prepare_for_step.py</strong><dd><code>Update tests for database pooling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/agents-api/tests/test_prepare_for_step.py

<ul><li>Add database connection pool support to all test functions<br> <li> Create custom <code>base_evaluate_with_pool</code> function for testing<br> <li> Update test signatures to accept <code>dsn</code> parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1534/files#diff-81fe974a69b9c47ab480777c66295e35dd997f14d986a8051516a9f1b5774b30">+45/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_prompt_step_auto_tools.py</strong><dd><code>Refactor prompt step test mocking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/agents-api/tests/test_prompt_step_auto_tools.py

<ul><li>Replace individual mock functions with shared <code>mock_base_evaluate</code><br> <li> Update mocking to use <code>side_effect</code> for proper type handling</ul>


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1534/files#diff-117fa3817793bcc9b970006aed370c42b73292b0e9aef0e968cc92550f901809">+19/-16</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_task_execution_workflow.py</strong><dd><code>Update workflow tests for pooling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/agents-api/tests/test_task_execution_workflow.py

<ul><li>Add database connection pool support across all workflow tests<br> <li> Create <code>base_evaluate_with_pool</code> helper function<br> <li> Update mock patches to use connection pool-aware evaluation<br> <li> Replace <code>list_secrets_query</code> mocks with <code>get_secrets_list</code></ul>


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1534/files#diff-907e4cfd013dfdc161609caeff4a1bc73c5946ac294edd1dcdda51fa38bb61d9">+137/-29</a></td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>litellm-config.yaml</strong><dd><code>Remove deprecated claude-3-sonnet model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/llm-proxy/litellm-config.yaml

<ul><li>Comment out claude-3-sonnet model configuration<br> <li> Add note about Litellm/Anthropic removing support</ul>


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1534/files#diff-187500284f35d2ee3a053f38284d719e37c5172dab3cb4886308378a183dcc9c">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add secrets support to task definitions and remove deprecated model from LLM proxy configuration, with refactored secrets handling and updated tests for connection pooling.
> 
>   - **Behavior**:
>     - Add secrets to task execution context in `tasks.py` using `get_secrets_list` utility.
>     - Remove `claude-3-sonnet` model from `litellm-config.yaml`.
>   - **Utilities**:
>     - Add `get_secrets_list` function in `secrets.py` with caching and connection pool support.
>   - **Tests**:
>     - Update tests in `test_prepare_for_step.py` and `test_task_execution_workflow.py` for database connection pooling.
>     - Refactor test mocking in `test_prompt_step_auto_tools.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for a270d3bc708ea34273edd19575dbe6fd4443c6cf. You can [customize](https://app.ellipsis.dev/julep-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->