### PR TITLE
fix(agents-api): fix sort by updated_at query in list docs

### DIFF
--- a/src/agents-api/agents_api/queries/docs/list_docs.py
+++ b/src/agents-api/agents_api/queries/docs/list_docs.py
@@ -141,9 +141,7 @@ async def list_docs(
     # Add sorting and pagination
     order_column = SORT_COLUMN_MAP[sort_by]
     direction_sql = "ASC" if direction == "asc" else "DESC"
-    query += (
-        f" ORDER BY {order_column} {direction_sql} LIMIT ${len(params) + 1} OFFSET ${len(params) + 2}"
-    )
+    query += f" ORDER BY {order_column} {direction_sql} LIMIT ${len(params) + 1} OFFSET ${len(params) + 2}"
     params.extend([limit, offset])
 
     return query, params


### PR DESCRIPTION
### **User description**
… functionality


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `updated_at` field to docs list query and sorting functionality

- Implement `SORT_COLUMN_MAP` to safely map sort keys to fully-qualified columns

- Use parameterized sort direction to prevent SQL injection vulnerabilities

- Add regression test for sorting by `updated_at` with descending order


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["list_docs query"] -->|"add updated_at column"| B["base_docs_query"]
  C["sort_by parameter"] -->|"map via SORT_COLUMN_MAP"| D["order_column"]
  D -->|"combined with direction_sql"| E["ORDER BY clause"]
  F["Test: create 2 docs"] -->|"sort by updated_at desc"| G["Verify correct order"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>list_docs.py</strong><dd><code>Add updated_at field and safe sort column mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/agents-api/agents_api/queries/docs/list_docs.py

<ul><li>Added <code>updated_at</code> field to the base docs SELECT query<br> <li> Introduced <code>SORT_COLUMN_MAP</code> dictionary to map exposed sort keys to <br>fully-qualified column names<br> <li> Updated query construction to use mapped column names and <br>parameterized direction SQL<br> <li> Prevents SQL injection and join ambiguity by using explicit column <br>references</ul>


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1587/files#diff-9b9acf39735b07e892717b53f383439c968197bbd193d1f2037dc71507e737ce">+13/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_docs_queries.py</strong><dd><code>Add regression test for updated_at sorting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/agents-api/tests/test_docs_queries.py

<ul><li>Added <code>asyncio</code> import for sleep functionality<br> <li> Created new regression test for sorting by <code>updated_at</code> field<br> <li> Test verifies that documents are correctly ordered by their latest <br>timestamps<br> <li> Uses metadata filter to isolate test documents and validates <br>descending sort order</ul>


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1587/files#diff-e4541eca6c87d4cd40fafdc4551c5c2abff61234b0b3f7c097b93d41ea050db6">+51/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance document listing by adding `updated_at` sorting and a regression test for safety and functionality.
> 
>   - **Enhancement**:
>     - Add `updated_at` field to `list_docs.py` for document sorting.
>     - Implement `SORT_COLUMN_MAP` to map sort keys to column names safely.
>     - Use parameterized sort direction to prevent SQL injection.
>   - **Tests**:
>     - Add regression test in `test_docs_queries.py` for sorting by `updated_at` in descending order.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 5514730033bbf47ba9e07cc626a6d606aae1bb7c. You can [customize](https://app.ellipsis.dev/julep-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->