### PR TITLE
fix(agents-api): Remove caching from secret retrieval functions

### DIFF
--- a/src/agents-api/agents_api/common/utils/secrets.py
+++ b/src/agents-api/agents_api/common/utils/secrets.py
@@ -1,13 +1,12 @@
 from datetime import timedelta
 from uuid import UUID
 
-from async_lru import alru_cache
 from temporalio import workflow
 from temporalio.workflow import _NotInWorkflowEventLoopError
 
 from ...activities.pg_query_step import pg_query_step
 from ...autogen.openapi_model import Secret
-from ...env import secrets_cache_ttl, temporal_heartbeat_timeout
+from ...env import temporal_heartbeat_timeout
 from ...queries.secrets import get_secret_by_name as get_secret_by_name_query
 from ...queries.secrets.list import list_secrets_query
 from ..exceptions.secrets import (
@@ -16,9 +15,8 @@ from ..exceptions.secrets import (
 from ..retry_policies import DEFAULT_RETRY_POLICY
 
 
-@alru_cache(ttl=secrets_cache_ttl)
 async def get_secret_by_name(developer_id: UUID, name: str, decrypt: bool = False) -> Secret:
-    # FIXME: Should use workflow.in_workflow() instead ?
+    """Fetch a developer secret by name without caching to avoid cross-loop futures."""
     try:
         secret = await workflow.execute_activity(
             pg_query_step,
@@ -38,17 +36,18 @@ async def get_secret_by_name(developer_id: UUID, name: str, decrypt: bool = Fals
             decrypt=decrypt,
         )
 
-    # AIDEV-NOTE: use domain-specific exception instead of HTTPException
     if secret is None:
         raise SecretNotFoundError(developer_id, name)
 
     return secret
 
 
-@alru_cache(ttl=secrets_cache_ttl)
 async def get_secrets_list(
-    developer_id: UUID, decrypt: bool = False, connection_pool=None
+    developer_id: UUID,
+    decrypt: bool = False,
+    connection_pool=None,
 ) -> list[Secret]:
+    """Return the full secret list without shared caching (avoids loop mismatches)."""
     try:
         secrets_query_result = await workflow.execute_activity(
             pg_query_step,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove async LRU caching from secret retrieval functions

- Prevent cross-loop futures issues in workflow execution

- Add docstrings explaining caching removal rationale

- Clean up unused imports and environment variables


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Secret Retrieval Functions"] -->|Remove @alru_cache| B["Uncached Functions"]
  B -->|Prevent| C["Cross-Loop Futures"]
  D["Imports"] -->|Remove async_lru| E["Cleaned Dependencies"]
  F["Docstrings"] -->|Add| G["Explain Caching Removal"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>secrets.py</strong><dd><code>Remove caching decorators and add explanatory docstrings</code>&nbsp; </dd></summary>
<hr>

src/agents-api/agents_api/common/utils/secrets.py

<ul><li>Removed <code>@alru_cache</code> decorator from <code>get_secret_by_name()</code> and <br><code>get_secrets_list()</code> functions<br> <li> Removed <code>async_lru</code> import and <code>secrets_cache_ttl</code> environment variable <br>reference<br> <li> Added docstrings to both functions explaining caching removal to avoid <br>cross-loop futures<br> <li> Reformatted <code>get_secrets_list()</code> function signature for better <br>readability<br> <li> Removed outdated FIXME and AIDEV-NOTE comments</ul>


</details>


  </td>
  <td><a href="https://github.com/julep-ai/julep/pull/1590/files#diff-8b9d2d49b5f0817b038314779eabb0adbbbccf74e76025e0694c1fe408df8a5e">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove caching from `get_secret_by_name` and `get_secrets_list` in `secrets.py` to prevent cross-loop future issues.
> 
>   - **Caching Removal**:
>     - Remove `alru_cache` from `get_secret_by_name` and `get_secrets_list` in `secrets.py` to prevent cross-loop future issues.
>   - **Docstring Updates**:
>     - Update docstrings in `get_secret_by_name` and `get_secrets_list` to indicate no caching is used.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fjulep&utm_source=github&utm_medium=referral)<sup> for 3991ab9555589d61fc0519d16d6b0383487fad40. You can [customize](https://app.ellipsis.dev/julep-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->