### PR TITLE
fix(agents-api): remove agent participants from session_lookup on agent delete

### DIFF
--- a/src/agents-api/agents_api/queries/agents/delete_agent.py
+++ b/src/agents-api/agents_api/queries/agents/delete_agent.py
@@ -14,7 +14,13 @@ from ..utils import pg_query, rewrap_exceptions, wrap_in_class
 
 # Define the raw SQL query
 agent_query = """
-WITH deleted_file_owners AS (
+WITH deleted_session_lookup AS (
+    DELETE FROM session_lookup
+    WHERE developer_id = $1
+    AND participant_type = 'agent'
+    AND participant_id = $2
+),
+deleted_file_owners AS (
     DELETE FROM file_owners
     WHERE developer_id = $1
     AND owner_type = 'agent'


### PR DESCRIPTION
## Summary
When deleting an agent, `session_lookup` rows with that agent as participant were not removed.
This leaves orphan session-participant mappings and causes inconsistent session state.

## Changes
- Add `deleted_session_lookup` CTE in `delete_agent` query
- Delete rows where:
  - `participant_type = 'agent'`
  - `participant_id = agent_id`
  - `developer_id = developer_id`
- Keep existing delete flow intact (tools/files/docs/agent)

## Why
Issue #1550 reports orphan sessions after `delete_agent`.
This fix ensures participant references are cleaned up atomically in the same query.

Fixes #1550