### PR TITLE
[codex] fix CLI auth invalid token error

### DIFF
--- a/src/cli/src/julep_cli/auth.py
+++ b/src/cli/src/julep_cli/auth.py
@@ -90,8 +90,12 @@ def auth(
                 progress.stop_task(verify_task)
                 progress.stop()
 
+                error_message = str(e)
+                if not is_valid_jwt(api_key):
+                    error_message = "invalid token format"
+
                 error_console.print(
-                    Text(f"Error verifying API key: {e}", style="bold red"),
+                    Text(f"Error verifying API key: {error_message}", style="bold red"),
                     highlight=True,
                 )
                 raise Exit(1)


### PR DESCRIPTION
## Summary

- preserve the existing verification flow for `julep auth`
- show `Error verifying API key: invalid token format` when verification fails for a non-JWT API key
- avoid leaking the current SDK internals error for malformed auth input

## Why

`julep auth --api-key not-a-jwt --environment production` currently exits with an obscure client construction error instead of the clearer invalid-token message already expected by the CLI auth tests. This makes a common user input mistake harder to diagnose.

## Validation

- `uv run poe test`
- `uv run poe lint`
- `uv run poe typecheck`
- `uv run ruff format --check src/julep_cli/auth.py tests/test_auth.py`
- `uv run julep auth --api-key not-a-jwt --environment production`
- `git diff --check`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/julep-ai/julep/pull/1605">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->