### PR TITLE
fix: guard against empty/filtered LLM responses in CLI and API utils

### DIFF
--- a/src/agents-api/agents_api/common/utils/humanization_utils.py
+++ b/src/agents-api/agents_api/common/utils/humanization_utils.py
@@ -79,6 +79,8 @@ def humanize_llm(text: str) -> str:
             temperature=1.0,
             api_key=litellm_master_key,
         )
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return response.choices[0].message.content
     except Exception as e:
         msg = "Error humanizing text with an llm: "
@@ -98,6 +100,8 @@ def grammar(text: str):
             api_key=litellm_master_key,
             # extra_body={"min_p": 0.025},
         )
+        if not response.choices or response.choices[0].message is None:
+            return text
         return response.choices[0].message.content
     except Exception:
         return text

--- a/src/agents-api/agents_api/routers/utils/model_converters.py
+++ b/src/agents-api/agents_api/routers/utils/model_converters.py
@@ -382,6 +382,8 @@ def convert_chat_response_to_response(
             # TODO: Support system tool calls here
             pass
 
+    if not chat_response.choices or chat_response.choices[0].message is None:
+        raise ValueError("LLM returned empty or filtered response")
     output_text = chat_response.choices[0].message.content
     if output_text:
         output.append(

--- a/src/cli/src/julep_cli/chat.py
+++ b/src/cli/src/julep_cli/chat.py
@@ -73,6 +73,8 @@ def chat(
                 ],
             )
 
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         console.print(
             Panel(
                 Text(response.choices[0].message.content, style="bold blue"),


### PR DESCRIPTION
## What

Adds null checks before accessing `choices[0].message` in three files:

- `src/cli/src/julep_cli/chat.py` — CLI chat response display
- `src/agents-api/agents_api/common/utils/humanization_utils.py` — `humanize()` and `grammar()` (2 locations)
- `src/agents-api/agents_api/routers/utils/model_converters.py` — `chat_response_to_agent_output()`

Note: violations also exist in `src/agents-api/agents_api/autogen/Tasks.py` and `src/integrations-service/integrations/autogen/Tasks.py`, but those are auto-generated from the OpenAPI spec — fixing them here would be overwritten on next codegen.

## Why

Two silent failure modes crash at these lines:

1. **`IndexError`** — `choices` is an empty list (`[]`) when the provider returns no completions
2. **`AttributeError`** — `choices[0].message` is `None` when content is filtered (some providers return HTTP 200 with `PROHIBITED_CONTENT` finish reason)

## Fix

For functions that raise on failure:
```python
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
```

For `grammar()` which returns original text on failure:
```python
if not response.choices or response.choices[0].message is None:
    return text
```

Detected by [pact](https://github.com/qizwiz/pact) static analysis.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/julep-ai/julep/pull/1606">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->