### PR TITLE
fix: P4-2

### DIFF
--- a/julep/registry.py
+++ b/julep/registry.py
@@ -112,6 +112,27 @@ def _source_hash(fn: PureFn) -> str:
     return _text_hash(src)
 
 
+def _has_module_top_pep723_block(module_source: str) -> bool:
+    """Return ``True`` when the module header looks like a PEP 723 block.
+
+    We only inspect the preamble before the first top-level decorator or ``def``.
+    That catches a module-top block, which ``inspect.getsource(fn)`` would miss,
+    while still allowing the supported placement between ``@pure(...)`` and ``def``.
+    """
+    lines = module_source.splitlines()
+    first_defn = len(lines)
+    for idx, line in enumerate(lines):
+        if line.startswith(("@", "def ", "async def ")):
+            first_defn = idx
+            break
+    preamble = "\n".join(lines[:first_defn])
+    try:
+        deps, requires_python = parse_pep723(preamble)
+    except ValueError:
+        return True
+    return bool(deps) or requires_python is not None
+
+
 class Registry:
     """An explicit registry for named reasoners and deterministic pure functions."""
 
@@ -136,10 +157,6 @@ class Registry:
     def list_reasoners(self) -> list[str]:
         return sorted(self.reasoners)
 
-    # FIXME(P4-2/P4-6): inspect.getsource(fn) drops a module-top `# /// script` block
-    # (the idiomatic PEP 723 placement) => a dep-declaring baked pure registers as no-dep
-    # and `import <dep>` fails OPEN late in wasm. Reject pures that import an undeclared
-    # third-party module, or support module-top metadata. See TODOS.md (P4 follow-ups).
     def register_pure(self, name: str, fn: PureFn) -> PureEntry:
         if name in self.pures and self.pures[name].fn is not fn:
             raise ValueError(f"pure name already registered to a different fn: {name!r}")
@@ -151,6 +168,20 @@ class Registry:
             pass
         else:
             deps, requires_python = parse_pep723(source)
+            if not deps:
+                module = inspect.getmodule(fn)
+                module_source = None
+                if module is not None:
+                    try:
+                        module_source = inspect.getsource(module)
+                    except (OSError, TypeError):
+                        module_source = None
+                if module_source is not None and _has_module_top_pep723_block(module_source):
+                    raise ValueError(
+                        f"pure {name!r}: a PEP 723 `# /// script` block is placed at module "
+                        "top, where register_pure cannot see it. Move it between the "
+                        "`@pure(...)` decorator and `def`."
+                    )
         entry = PureEntry(
             name=name,
             fn=fn,

--- a/tests/test_register_pure_pep723_placement.py
+++ b/tests/test_register_pure_pep723_placement.py
@@ -1,0 +1,126 @@
+"""P4-2: register_pure must reject a module-top PEP 723 block instead of
+silently dropping it (which fails OPEN on `import <dep>` late in the wasm tier).
+
+`inspect.getsource(fn)` spans only the decorator-to-body range, so a block placed
+above the first decorator/def is invisible. The correct, documented placement is
+between `@pure(...)` and `def` -- that path must keep working.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from julep.registry import Registry, _has_module_top_pep723_block
+
+MODULE_TOP = textwrap.dedent(
+    """\
+    # /// script
+    # dependencies = ["regex==2024.11.6"]
+    # ///
+    def extract(record):
+        import regex
+        return record
+    """
+)
+
+BETWEEN_DECORATOR = textwrap.dedent(
+    """\
+    def deco(fn):
+        return fn
+
+    @deco
+    # /// script
+    # dependencies = ["regex==2024.11.6"]
+    # ///
+    def extract(record):
+        import regex
+        return record
+    """
+)
+
+NO_BLOCK = textwrap.dedent(
+    """\
+    def merge(record):
+        return record
+    """
+)
+
+DOCSTRING_EXAMPLE = textwrap.dedent(
+    '''\
+    """Example module.
+
+    Declare deps with a PEP 723 block::
+
+        # /// script
+        # dependencies = ["regex==2024.11.6"]
+        # ///
+    """
+    def merge(record):
+        return record
+    '''
+)
+UNTERMINATED = textwrap.dedent(
+    """\
+    # /// script
+    # dependencies = ["regex==2024.11.6"]
+    def extract(record):
+        import regex
+        return record
+    """
+)
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        (MODULE_TOP, True),
+        (BETWEEN_DECORATOR, False),
+        (NO_BLOCK, False),
+        (DOCSTRING_EXAMPLE, False),
+        (UNTERMINATED, True),
+    ],
+)
+def test_detector_flags_only_module_top_placement(source: str, expected: bool) -> None:
+    assert _has_module_top_pep723_block(source) is expected
+
+
+def _load_pure_from_source(tmp_path: Path, name: str, source: str):
+    """Write `source` to an importable module and return its `extract`/`merge` fn."""
+    module_name = f"_p4_2_fixture_{name}"
+    path = tmp_path / f"{module_name}.py"
+    path.write_text(source, encoding="utf-8")
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return getattr(module, "extract", None) or module.merge
+
+
+def test_register_pure_rejects_module_top_block(tmp_path: Path) -> None:
+    fn = _load_pure_from_source(tmp_path, "moduletop", MODULE_TOP)
+    with pytest.raises(ValueError, match="module top"):
+        Registry().register_pure("cad.test.moduletop.v1", fn)
+
+
+def test_register_pure_accepts_between_decorator_block(tmp_path: Path) -> None:
+    fn = _load_pure_from_source(tmp_path, "between", BETWEEN_DECORATOR)
+    entry = Registry().register_pure("cad.test.between.v1", fn)
+    assert entry.deps == ("regex==2024.11.6",)
+
+
+def test_register_pure_accepts_dep_free_pure(tmp_path: Path) -> None:
+    fn = _load_pure_from_source(tmp_path, "noblock", NO_BLOCK)
+    entry = Registry().register_pure("cad.test.noblock.v1", fn)
+    assert entry.deps == ()
+
+
+def test_register_pure_accepts_pure_with_docstring_pep723_example(tmp_path: Path) -> None:
+    fn = _load_pure_from_source(tmp_path, "docexample", DOCSTRING_EXAMPLE)
+    entry = Registry().register_pure("cad.test.docexample.v1", fn)
+    assert entry.deps == ()


### PR DESCRIPTION
From TODOS.md

- **FIXME(P4-2) major — module-top PEP 723 dropped (fail-OPEN).** `register_pure` /
  bundle source use `inspect.getsource(fn)`, which omits a module-top `# /// script`
  block, so a dep'd baked pure publishes as no-dep and imports fail late in wasm. Reject
  pures importing an undeclared third-party module, or support module-top metadata; fix
  `examples/regex_extract_flow.py` to the documented placement.



<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/julep-ai/julep/pull/1612">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->