### PR TITLE
[codex] route GPT-5.6 through Responses API

### DIFF
--- a/julep/execution/llm.py
+++ b/julep/execution/llm.py
@@ -58,6 +58,17 @@ from ..resilience import (
     is_auth_error,
 )
 from .llm_result import AttemptMeta, LlmCallMeta, LlmResult
+from .openai_responses import (
+    AnyResponses,
+    ResponsesModelBehaviorError,
+    ResponsesRefusalError,
+    call_openai_responses,
+    is_responses_result,
+    parse_responses_reply,
+    responses_cache_usage,
+    responses_usage,
+    uses_openai_responses,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -442,6 +453,8 @@ def _add_tokens(a: int | None, b: int | None) -> int | None:
 
 
 def _usage_of(completion: Any) -> tuple[int | None, int | None, int | None]:
+    if is_responses_result(completion):
+        return responses_usage(completion)
     usage = getattr(completion, "usage", None)
     if usage is None:
         return None, None, None
@@ -457,6 +470,8 @@ def _cache_usage_of(completion: Any) -> tuple[int | None, int | None]:
     """(cache_read, cache_creation) from either anthropic-style raw usage keys
     or the OpenAI-normalized ``prompt_tokens_details.cached_tokens`` (the only
     cache field any-llm surfaces on the anthropic *completion* path)."""
+    if is_responses_result(completion):
+        return responses_cache_usage(completion)
     usage = getattr(completion, "usage", None)
     if usage is None:
         return None, None
@@ -483,7 +498,8 @@ async def complete_reasoner(
     reasoner: Reasoner,
     value: Any,
     *,
-    acompletion: AnyCompletion,
+    acompletion: Optional[AnyCompletion] = None,
+    aresponses: Optional[AnyResponses] = None,
     default_provider: str = DEFAULT_PROVIDER,
     transcript: Optional[list[dict[str, Any]]] = None,
     dispatch: ReasonerDispatch = _DEFAULT_REASONER_DISPATCH,
@@ -512,6 +528,7 @@ async def complete_reasoner(
     reasoner = rendered_reasoner_for(reasoner, render_value)
     user_text = rendered_user_for(reasoner, render_value)
     provider, model = _split_model(reasoner.model, default_provider)
+    use_responses = uses_openai_responses(provider, model)
     schema = reasoner.reply_schema
     # mem-mcp's declarative json_object mode claims the kwarg only when no
     # reply schema does (the schema path wins; the call never carries both).
@@ -581,7 +598,20 @@ async def complete_reasoner(
             provider, reasoner.prompt_cache, messages, kwargs
         )
         pc_marker_placed = _has_cache_marker(messages)
-        return await acompletion(provider=provider, model=model, messages=messages, **kwargs)
+        if use_responses:
+            return await call_openai_responses(
+                _resolve_aresponses(aresponses),
+                provider=provider,
+                model=model,
+                messages=messages,
+                kwargs=kwargs,
+                tool_name_aliases={
+                    original: alias for alias, original in tool_name_reverse.items()
+                },
+            )
+        return await _resolve_acompletion(acompletion)(
+            provider=provider, model=model, messages=messages, **kwargs
+        )
 
     started = time.time()
     fallback_reason: Optional[str] = None
@@ -617,8 +647,10 @@ async def complete_reasoner(
     # Usage accumulates over every attempt — re-asks cost tokens too.
     pt, ct, tt = _usage_of(completion)
     cache_read, cache_creation = _cache_usage_of(completion)
-    reply, native_tool_calls = _parse_completion_reply(
-        completion, expect_json=schema is not None
+    reply, native_tool_calls = (
+        parse_responses_reply(completion, expect_json=schema is not None)
+        if is_responses_result(completion)
+        else _parse_completion_reply(completion, expect_json=schema is not None)
     )
     reply = _restore_tool_calls(reply)
     while (
@@ -642,7 +674,11 @@ async def complete_reasoner(
         rcr, rcc = _cache_usage_of(completion)
         cache_read = _add_tokens(cache_read, rcr)
         cache_creation = _add_tokens(cache_creation, rcc)
-        reply, native_tool_calls = _parse_completion_reply(completion, expect_json=True)
+        reply, native_tool_calls = (
+            parse_responses_reply(completion, expect_json=True)
+            if is_responses_result(completion)
+            else _parse_completion_reply(completion, expect_json=True)
+        )
         reply = _restore_tool_calls(reply)
     ended = time.time()
     pc = reasoner.prompt_cache
@@ -692,6 +728,20 @@ def _resolve_acompletion(acompletion: Optional[AnyCompletion]) -> AnyCompletion:
     return any_llm_acompletion
 
 
+def _resolve_aresponses(aresponses: Optional[AnyResponses]) -> AnyResponses:
+    if aresponses is not None:
+        return aresponses
+    try:
+        from any_llm import aresponses as any_llm_aresponses
+    except ImportError as exc:  # pragma: no cover - exercised only without any-llm
+        raise ImportError(
+            "any-llm is required for the GPT-5.6 Responses caller; install "
+            "julep[providers] plus the OpenAI provider extra "
+            "(e.g. pip install 'any-llm-sdk[openai]')."
+        ) from exc
+    return any_llm_aresponses
+
+
 # --------------------------------------------------------------------------- #
 # Seam factories.
 # --------------------------------------------------------------------------- #
@@ -699,6 +749,7 @@ def make_llm_caller(
     *,
     default_provider: str = DEFAULT_PROVIDER,
     acompletion: Optional[AnyCompletion] = None,
+    aresponses: Optional[AnyResponses] = None,
 ) -> Callable[..., Awaitable[Any]]:
     """Activity-seam ``LlmCaller``: ``(Reasoner, value, principal, transcript, dispatch)``.
 
@@ -720,7 +771,8 @@ def make_llm_caller(
     ) -> Any:
         return await complete_reasoner(
             reasoner, value,
-            acompletion=_resolve_acompletion(acompletion),
+            acompletion=acompletion,
+            aresponses=aresponses,
             default_provider=default_provider,
             transcript=transcript,
             dispatch=dispatch,
@@ -735,6 +787,7 @@ def make_local_reasoner(
     *,
     default_provider: str = DEFAULT_PROVIDER,
     acompletion: Optional[AnyCompletion] = None,
+    aresponses: Optional[AnyResponses] = None,
 ) -> Callable[[str, Any], Awaitable[Any]]:
     """Facade-seam llm: ``(reasoner_name, payload) -> reply``.
 
@@ -751,7 +804,8 @@ def make_local_reasoner(
         return await complete_reasoner(
             get_reasoner(reasoner_name),
             value,
-            acompletion=_resolve_acompletion(acompletion),
+            acompletion=acompletion,
+            aresponses=aresponses,
             default_provider=default_provider,
             tools=tools,
         )
@@ -796,6 +850,7 @@ def make_resilient_llm_caller(
     classifier: Callable[[BaseException], ErrorClass] = classify_error,
     default_provider: str = DEFAULT_PROVIDER,
     acompletion: Optional[AnyCompletion] = None,
+    aresponses: Optional[AnyResponses] = None,
     sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
 ) -> Callable[..., Awaitable[Any]]:
     """An ``LlmCaller`` that survives provider outages deterministically.
@@ -839,7 +894,6 @@ def make_resilient_llm_caller(
         tools: Optional[list[dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
     ) -> Any:
-        resolved = _resolve_acompletion(acompletion)
         attempts: list[AttemptRecord] = []
         last_exc: Optional[Exception] = None
 
@@ -862,13 +916,36 @@ def make_resilient_llm_caller(
                 try:
                     result = await complete_reasoner(
                         candidate, value,
-                        acompletion=resolved, default_provider=default_provider,
+                        acompletion=acompletion,
+                        aresponses=aresponses,
+                        default_provider=default_provider,
                         transcript=transcript,
                         dispatch=dispatch,
                         tools=tools,
                         parallel_tool_calls=parallel_tool_calls,
                     )
                     reply = result.reply
+                except ResponsesRefusalError as exc:
+                    record = AttemptRecord(
+                        model=model,
+                        provider=provider,
+                        outcome=ErrorClass.MODEL_BEHAVIOR.value,
+                        detail=str(exc),
+                    )
+                    attempts.append(record)
+                    _notify(record)
+                    raise
+                except ResponsesModelBehaviorError as exc:
+                    record = AttemptRecord(
+                        model=model,
+                        provider=provider,
+                        outcome=ErrorClass.MODEL_BEHAVIOR.value,
+                        detail=str(exc),
+                    )
+                    attempts.append(record)
+                    _notify(record)
+                    last_exc = exc
+                    break
                 except Exception as exc:
                     error_class = classifier(exc)
                     record = AttemptRecord(
@@ -931,6 +1008,7 @@ def make_resilient_llm_caller(
 
 __all__ = [
     "AnyCompletion",
+    "AnyResponses",
     "DEFAULT_PROVIDER",
     "complete_reasoner",
     "make_llm_caller",

--- a/julep/execution/llm.py
+++ b/julep/execution/llm.py
@@ -62,6 +62,7 @@ from .openai_responses import (
     AnyResponses,
     ResponsesModelBehaviorError,
     ResponsesRefusalError,
+    _strip_code_fence,
     call_openai_responses,
     is_responses_result,
     parse_responses_reply,
@@ -173,19 +174,6 @@ def provider_safe_tool_defs(
     if not needs_rewrite:
         return tools, {}
     return safe_tools, reverse
-
-
-def _strip_code_fence(text: str) -> str:
-    """Drop a leading ```` ```json ```` / ```` ``` ```` fence and its closer."""
-    stripped = text.strip()
-    if not stripped.startswith("```"):
-        return stripped
-    newline = stripped.find("\n")
-    if newline != -1:
-        stripped = stripped[newline + 1 :]
-    if stripped.rstrip().endswith("```"):
-        stripped = stripped.rstrip()[:-3]
-    return stripped.strip()
 
 
 def _response_format(schema: dict[str, Any]) -> dict[str, Any]:

--- a/julep/execution/openai_responses.py
+++ b/julep/execution/openai_responses.py
@@ -21,6 +21,19 @@ from typing import Any
 AnyResponses = Callable[..., Awaitable[Any]]
 
 
+def _strip_code_fence(text: str) -> str:
+    """Drop a leading JSON/plain Markdown fence and its closer."""
+    stripped = text.strip()
+    if not stripped.startswith("```"):
+        return stripped
+    newline = stripped.find("\n")
+    if newline != -1:
+        stripped = stripped[newline + 1 :]
+    if stripped.rstrip().endswith("```"):
+        stripped = stripped.rstrip()[:-3]
+    return stripped.strip()
+
+
 class ResponsesStatusError(RuntimeError):
     """The Responses API returned a non-completed operational status."""
 
@@ -252,7 +265,7 @@ def parse_responses_reply(result: Any, *, expect_json: bool) -> tuple[Any, int]:
     if not expect_json:
         return text, 0
     try:
-        return json.loads(text.strip()), 0
+        return json.loads(_strip_code_fence(text)), 0
     except (json.JSONDecodeError, TypeError, ValueError):
         return text, 0
 

--- a/julep/execution/openai_responses.py
+++ b/julep/execution/openai_responses.py
@@ -1,0 +1,291 @@
+"""OpenAI Responses API adapter for the GPT-5.6 model family.
+
+Julep's provider-neutral LLM seam speaks the Chat Completions-shaped dialect
+used by any-llm's ``acompletion`` API. GPT-5.6 tool-calling with reasoning must
+use the Responses API instead, whose request and response shapes differ. This
+module owns that translation so the agent loop, transcript model, and all
+execution backends keep one neutral contract.
+
+The adapter deliberately uses stateless requests (``store=False``) and
+``reasoning.context=current_turn``. Julep already carries durable, neutral
+agent state between controller rounds; provider-side conversation state would
+make replay and continue-as-new depend on retained remote objects.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+AnyResponses = Callable[..., Awaitable[Any]]
+
+
+class ResponsesStatusError(RuntimeError):
+    """The Responses API returned a non-completed operational status."""
+
+
+class ResponsesModelBehaviorError(RuntimeError):
+    """The model returned an incomplete response."""
+
+
+class ResponsesRefusalError(RuntimeError):
+    """The model refused the request; callers must fail closed."""
+
+
+def uses_openai_responses(provider: str, model: str) -> bool:
+    """Whether this provider/model must use the Responses transport."""
+    return provider == "openai" and (model == "gpt-5.6" or model.startswith("gpt-5.6-"))
+
+
+def _responses_tool_defs(
+    tools: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], set[str]]:
+    """Return flattened definitions plus tools whose scalar input was wrapped."""
+    out: list[dict[str, Any]] = []
+    scalar_tools: set[str] = set()
+    for tool in tools:
+        if tool.get("type") != "function" or not isinstance(tool.get("function"), dict):
+            raise ValueError("GPT-5.6 Responses transport only accepts function tools")
+        function = dict(tool["function"])
+        parameters = function.get("parameters")
+        if isinstance(parameters, dict) and parameters.get("type") != "object":
+            name = function.get("name")
+            if isinstance(name, str):
+                scalar_tools.add(name)
+            function["parameters"] = {
+                "type": "object",
+                "properties": {"value": parameters},
+                "required": ["value"],
+                "additionalProperties": False,
+            }
+        # Chat Completions defaults to non-strict tools. Responses may otherwise
+        # normalize a compatible schema into strict mode, so preserve Julep's
+        # existing semantics explicitly when the author did not choose a mode.
+        function.setdefault("strict", False)
+        out.append({"type": "function", **function})
+    return out, scalar_tools
+
+
+def responses_tool_defs(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Flatten Chat function tools and make every input schema an object."""
+    return _responses_tool_defs(tools)[0]
+
+
+def _unwrap_scalar_tool_arguments(result: Any, scalar_tools: set[str]) -> Any:
+    """Restore Julep's bare-value convention after provider object wrapping."""
+    if not scalar_tools:
+        return result
+    for item in getattr(result, "output", ()):
+        if getattr(item, "type", None) != "function_call":
+            continue
+        if getattr(item, "name", None) not in scalar_tools:
+            continue
+        arguments = getattr(item, "arguments", "")
+        try:
+            parsed = json.loads(arguments)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            continue
+        if isinstance(parsed, dict) and set(parsed) == {"value"}:
+            item.arguments = json.dumps(parsed["value"])
+    return result
+
+
+def responses_input(
+    messages: list[dict[str, Any]],
+    scalar_tools: set[str] | None = None,
+    tool_name_aliases: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """Translate Chat-style messages and tool history to Responses input items."""
+    out: list[dict[str, Any]] = []
+    scalar_tools = scalar_tools or set()
+    tool_name_aliases = tool_name_aliases or {}
+    for message in messages:
+        role = message.get("role")
+        tool_calls = message.get("tool_calls")
+        if role == "assistant" and isinstance(tool_calls, list):
+            for tool_call in tool_calls:
+                function = tool_call.get("function", {})
+                tool_name = function.get("name")
+                provider_tool_name = tool_name_aliases.get(tool_name, tool_name)
+                arguments = function.get("arguments") or "{}"
+                if provider_tool_name in scalar_tools:
+                    try:
+                        parsed_arguments = json.loads(arguments)
+                    except (json.JSONDecodeError, TypeError, ValueError):
+                        parsed_arguments = arguments
+                    if not (
+                        isinstance(parsed_arguments, dict)
+                        and set(parsed_arguments) == {"value"}
+                    ):
+                        arguments = json.dumps({"value": parsed_arguments})
+                out.append(
+                    {
+                        "type": "function_call",
+                        "call_id": tool_call.get("id"),
+                        "name": provider_tool_name,
+                        "arguments": arguments,
+                    }
+                )
+            continue
+        if role == "tool" and message.get("tool_call_id"):
+            content = message.get("content")
+            out.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": message["tool_call_id"],
+                    "output": content if isinstance(content, str) else json.dumps(content),
+                }
+            )
+            continue
+        if role in {"system", "developer", "user", "assistant"}:
+            out.append({"role": role, "content": message.get("content") or ""})
+            continue
+        out.append({"role": "user", "content": json.dumps(message, sort_keys=True)})
+    return out
+
+
+def responses_format(response_format: dict[str, Any]) -> dict[str, Any]:
+    """Translate Chat ``response_format`` to Responses ``text.format`` shape."""
+    if response_format.get("type") != "json_schema":
+        return response_format
+    schema = response_format.get("json_schema", {})
+    return {
+        "type": "json_schema",
+        "name": schema.get("name", "reply"),
+        "schema": schema.get("schema", {}),
+        "strict": bool(schema.get("strict", False)),
+    }
+
+
+async def call_openai_responses(
+    aresponses: AnyResponses,
+    *,
+    provider: str,
+    model: str,
+    messages: list[dict[str, Any]],
+    kwargs: dict[str, Any],
+    tool_name_aliases: dict[str, str] | None = None,
+) -> Any:
+    """Map Julep/acompletion kwargs onto any-llm's ``aresponses`` call."""
+    request: dict[str, Any] = {
+        "provider": provider,
+        "model": model,
+        "store": False,
+    }
+    tools = kwargs.get("tools")
+    scalar_tools: set[str] = set()
+    if tools:
+        request["tools"], scalar_tools = _responses_tool_defs(tools)
+    request["input_data"] = responses_input(
+        messages, scalar_tools, tool_name_aliases
+    )
+    if "parallel_tool_calls" in kwargs:
+        request["parallel_tool_calls"] = kwargs["parallel_tool_calls"]
+    effort = kwargs.get("reasoning_effort")
+    reasoning: dict[str, Any] = {"context": "current_turn"}
+    if effort is not None:
+        reasoning["effort"] = effort
+    request["reasoning"] = reasoning
+    if "temperature" in kwargs:
+        request["temperature"] = kwargs["temperature"]
+    if "max_tokens" in kwargs:
+        request["max_output_tokens"] = kwargs["max_tokens"]
+    if "response_format" in kwargs:
+        request["response_format"] = responses_format(kwargs["response_format"])
+    if "service_tier" in kwargs:
+        request["service_tier"] = kwargs["service_tier"]
+    result = await aresponses(**request)
+    return _unwrap_scalar_tool_arguments(result, scalar_tools)
+
+
+def is_responses_result(result: Any) -> bool:
+    """True for non-streaming Responses objects returned by any-llm."""
+    return hasattr(result, "output") and not hasattr(result, "choices")
+
+
+def parse_responses_reply(result: Any, *, expect_json: bool) -> tuple[Any, int]:
+    """Extract Julep's neutral tool-call or text reply from Responses output."""
+    status = getattr(result, "status", None)
+    error = getattr(result, "error", None)
+    incomplete = getattr(result, "incomplete_details", None)
+    if error is not None or status in {"failed", "cancelled"}:
+        raise ResponsesStatusError(
+            f"Responses API returned status={status!r}, error={error!r}"
+        )
+    if status == "incomplete" or incomplete is not None:
+        raise ResponsesModelBehaviorError(
+            f"Responses API returned an incomplete response: {incomplete!r}"
+        )
+    if status not in {None, "completed"}:
+        raise ResponsesStatusError(f"Responses API returned unexpected status={status!r}")
+    tool_calls: list[dict[str, Any]] = []
+    text_parts: list[str] = []
+    for item in getattr(result, "output", ()):
+        item_type = getattr(item, "type", None)
+        if item_type == "function_call":
+            arguments = getattr(item, "arguments", "")
+            try:
+                parsed_arguments = json.loads(arguments)
+            except (json.JSONDecodeError, TypeError, ValueError):
+                parsed_arguments = arguments
+            tool_calls.append(
+                {
+                    "id": getattr(item, "call_id", None),
+                    "tool": getattr(item, "name", None),
+                    "input": parsed_arguments,
+                }
+            )
+        elif item_type == "message":
+            for part in getattr(item, "content", ()):
+                if getattr(part, "type", None) == "output_text":
+                    text = getattr(part, "text", None)
+                    if isinstance(text, str):
+                        text_parts.append(text)
+                elif getattr(part, "type", None) == "refusal":
+                    raise ResponsesRefusalError(
+                        f"model refusal: {getattr(part, 'refusal', '')}"
+                    )
+    if tool_calls:
+        return {"tool_calls": tool_calls}, len(tool_calls)
+    text = "".join(text_parts)
+    if not expect_json:
+        return text, 0
+    try:
+        return json.loads(text.strip()), 0
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return text, 0
+
+
+def responses_usage(result: Any) -> tuple[int | None, int | None, int | None]:
+    usage = getattr(result, "usage", None)
+    if usage is None:
+        return None, None, None
+    return (
+        getattr(usage, "input_tokens", None),
+        getattr(usage, "output_tokens", None),
+        getattr(usage, "total_tokens", None),
+    )
+
+
+def responses_cache_usage(result: Any) -> tuple[int | None, int | None]:
+    usage = getattr(result, "usage", None)
+    details = getattr(usage, "input_tokens_details", None) if usage is not None else None
+    return getattr(details, "cached_tokens", None), getattr(details, "cache_write_tokens", None)
+
+
+__all__ = [
+    "AnyResponses",
+    "ResponsesModelBehaviorError",
+    "ResponsesRefusalError",
+    "ResponsesStatusError",
+    "call_openai_responses",
+    "is_responses_result",
+    "parse_responses_reply",
+    "responses_cache_usage",
+    "responses_format",
+    "responses_input",
+    "responses_tool_defs",
+    "responses_usage",
+    "uses_openai_responses",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "julep"
-version = "3.0.0rc1"
+version = "3.0.0rc2"
 description = "Julep — durable, composable AI agents on Temporal."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_openai_responses.py
+++ b/tests/test_openai_responses.py
@@ -1,0 +1,584 @@
+"""GPT-5.6 routing and OpenAI Responses adapter coverage."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from conftest import run
+from julep import Agent, tool
+from julep.dotctx import Reasoner
+from julep.execution.llm import (
+    complete_reasoner,
+    make_llm_caller,
+    make_local_reasoner,
+    make_resilient_llm_caller,
+)
+from julep.execution.openai_responses import (
+    ResponsesModelBehaviorError,
+    ResponsesRefusalError,
+    ResponsesStatusError,
+    responses_input,
+    responses_tool_defs,
+    uses_openai_responses,
+)
+from julep.resilience import AttemptRecord, ResiliencePolicy
+
+
+@dataclass
+class FakeFunctionCall:
+    call_id: str
+    name: str
+    arguments: str
+    type: str = "function_call"
+
+
+@dataclass
+class FakeText:
+    text: str
+    type: str = "output_text"
+
+
+@dataclass
+class FakeMessage:
+    content: list[Any]
+    type: str = "message"
+
+
+@dataclass
+class FakeRefusal:
+    refusal: str
+    type: str = "refusal"
+
+
+@dataclass
+class FakeInputDetails:
+    cached_tokens: int = 0
+
+
+@dataclass
+class FakeUsage:
+    input_tokens: int = 11
+    output_tokens: int = 7
+    total_tokens: int = 18
+    input_tokens_details: FakeInputDetails = field(default_factory=FakeInputDetails)
+
+
+@dataclass
+class FakeResponse:
+    output: list[Any]
+    model: str = "gpt-5.6-sol"
+    usage: FakeUsage = field(default_factory=FakeUsage)
+    status: str = "completed"
+    error: Any = None
+    incomplete_details: Any = None
+
+
+@dataclass
+class Recorder:
+    reply: Any
+    calls: list[dict[str, Any]] = field(default_factory=list)
+
+    async def __call__(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        return self.reply
+
+
+def _tools() -> list[dict[str, Any]]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "lookup_weather",
+                "description": "Look up weather for a city.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.6-sol-2026-07-10"],
+)
+def test_gpt_5_6_family_uses_responses(model: str) -> None:
+    assert uses_openai_responses("openai", model)
+
+
+def test_other_models_and_providers_keep_completion_transport() -> None:
+    assert not uses_openai_responses("openai", "gpt-5.5")
+    assert not uses_openai_responses("openai", "gpt-4o")
+    assert not uses_openai_responses("other", "gpt-5.6-sol")
+
+
+def test_complete_reasoner_routes_gpt_5_6_tools_to_responses() -> None:
+    async def unexpected_completion(**kwargs: Any) -> Any:
+        raise AssertionError(f"acompletion must not be called: {kwargs}")
+
+    responses = Recorder(
+        FakeResponse(
+            output=[
+                FakeFunctionCall(
+                    call_id="call-1",
+                    name="lookup_weather",
+                    arguments='{"city":"Paris"}',
+                )
+            ]
+        )
+    )
+    reasoner = Reasoner(
+        name="responses-tools",
+        model="openai:gpt-5.6-sol",
+        system="Use the weather tool.",
+        reasoning_effort="low",
+        max_tokens=64,
+    )
+
+    result = run(
+        complete_reasoner(
+            reasoner,
+            "Weather in Paris?",
+            acompletion=unexpected_completion,
+            aresponses=responses,
+            tools=_tools(),
+            parallel_tool_calls=False,
+        )
+    )
+
+    call = responses.calls[0]
+    assert call["provider"] == "openai" and call["model"] == "gpt-5.6-sol"
+    assert call["store"] is False
+    assert call["reasoning"] == {"context": "current_turn", "effort": "low"}
+    assert call["max_output_tokens"] == 64
+    assert call["parallel_tool_calls"] is False
+    assert call["tools"] == [
+        {
+            "type": "function",
+            "name": "lookup_weather",
+            "description": "Look up weather for a city.",
+            "parameters": _tools()[0]["function"]["parameters"],
+            "strict": False,
+        }
+    ]
+    assert call["input_data"] == [
+        {"role": "system", "content": "Use the weather tool."},
+        {"role": "user", "content": "Weather in Paris?"},
+    ]
+    assert result.reply == {
+        "tool_calls": [
+            {"id": "call-1", "tool": "lookup_weather", "input": {"city": "Paris"}}
+        ]
+    }
+    assert result.meta.native_tool_calls == 1
+    assert result.meta.input_tokens == 11
+    assert result.meta.output_tokens == 7
+
+
+def test_responses_transcript_maps_calls_and_outputs() -> None:
+    assert responses_input(
+        [
+            {"role": "user", "content": "Weather?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {
+                            "name": "lookup_weather",
+                            "arguments": '{"city":"Paris"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call-1", "content": '{"temp":25}'},
+        ]
+    ) == [
+        {"role": "user", "content": "Weather?"},
+        {
+            "type": "function_call",
+            "call_id": "call-1",
+            "name": "lookup_weather",
+            "arguments": '{"city":"Paris"}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call-1",
+            "output": '{"temp":25}',
+        },
+    ]
+
+
+def test_responses_transcript_uses_provider_safe_aliases_and_collision_suffixes() -> None:
+    tools = [
+        {
+            "type": "function",
+            "function": {"name": "srv/x", "parameters": {"type": "string"}},
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "srv_x",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+    ]
+    responses = Recorder(FakeResponse(output=[FakeMessage(content=[FakeText("ok")])]))
+    transcript = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "srv/x", "arguments": '"Paris"'},
+                },
+                {
+                    "id": "call-2",
+                    "type": "function",
+                    "function": {"name": "srv_x", "arguments": "{}"},
+                },
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call-1", "content": "first"},
+        {"role": "tool", "tool_call_id": "call-2", "content": "second"},
+    ]
+
+    result = run(
+        complete_reasoner(
+            Reasoner(name="responses-aliases", model="openai:gpt-5.6-sol"),
+            "continue",
+            aresponses=responses,
+            tools=tools,
+            transcript=transcript,
+        )
+    )
+
+    assert result.reply == "ok"
+    call = responses.calls[0]
+    assert [tool["name"] for tool in call["tools"]] == ["srv_x", "srv_x_2"]
+    replayed_calls = [
+        item for item in call["input_data"] if item.get("type") == "function_call"
+    ]
+    assert [(item["name"], item["arguments"]) for item in replayed_calls] == [
+        ("srv_x", '{"value": "Paris"}'),
+        ("srv_x_2", "{}"),
+    ]
+
+
+def test_responses_wraps_scalar_tool_schema_and_restores_bare_argument() -> None:
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "lookup_scalar",
+                "description": "Look up a city.",
+                "parameters": {"type": "string"},
+            },
+        }
+    ]
+    assert responses_tool_defs(tools) == [
+        {
+            "type": "function",
+            "name": "lookup_scalar",
+            "description": "Look up a city.",
+            "parameters": {
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+                "required": ["value"],
+                "additionalProperties": False,
+            },
+            "strict": False,
+        }
+    ]
+    responses = Recorder(
+        FakeResponse(
+            output=[
+                FakeFunctionCall(
+                    call_id="call-scalar",
+                    name="lookup_scalar",
+                    arguments='{"value":"Paris"}',
+                )
+            ]
+        )
+    )
+    result = run(
+        complete_reasoner(
+            Reasoner(name="responses-scalar", model="openai:gpt-5.6-sol"),
+            "Look up Paris.",
+            aresponses=responses,
+            tools=tools,
+        )
+    )
+    assert result.reply["tool_calls"][0]["input"] == "Paris"
+
+    assert responses_input(
+        [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call-scalar",
+                        "type": "function",
+                        "function": {"name": "lookup_scalar", "arguments": '"Paris"'},
+                    }
+                ],
+            }
+        ],
+        {"lookup_scalar"},
+    ) == [
+        {
+            "type": "function_call",
+            "call_id": "call-scalar",
+            "name": "lookup_scalar",
+            "arguments": '{"value": "Paris"}',
+        }
+    ]
+
+
+def test_responses_structured_text_and_format_are_normalized() -> None:
+    responses = Recorder(
+        FakeResponse(output=[FakeMessage(content=[FakeText('{"answer":"ok"}')])])
+    )
+    schema = {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+        "required": ["answer"],
+    }
+    result = run(
+        complete_reasoner(
+            Reasoner(name="responses-json", model="openai:gpt-5.6", reply=schema),
+            "Answer.",
+            aresponses=responses,
+        )
+    )
+
+    assert result.reply == {"answer": "ok"}
+    assert responses.calls[0]["response_format"] == {
+        "type": "json_schema",
+        "name": "reply",
+        "schema": schema,
+        "strict": False,
+    }
+
+
+def test_pre_5_6_openai_stays_on_acompletion() -> None:
+    completion = Recorder(
+        type(
+            "Completion",
+            (),
+            {
+                "choices": [
+                    type(
+                        "Choice",
+                        (),
+                        {"message": type("Message", (), {"content": "ok", "parsed": None})()},
+                    )()
+                ]
+            },
+        )()
+    )
+
+    async def unexpected_responses(**kwargs: Any) -> Any:
+        raise AssertionError(f"aresponses must not be called: {kwargs}")
+
+    result = run(
+        complete_reasoner(
+            Reasoner(name="chat", model="openai:gpt-5.5"),
+            "hi",
+            acompletion=completion,
+            aresponses=unexpected_responses,
+        )
+    )
+    assert result.reply == "ok"
+    assert completion.calls[0]["model"] == "gpt-5.5"
+
+
+def test_incomplete_failed_and_refused_responses_raise() -> None:
+    incomplete = Recorder(
+        FakeResponse(output=[], status="incomplete", incomplete_details={"reason": "max"})
+    )
+    with pytest.raises(ResponsesModelBehaviorError, match="incomplete"):
+        run(
+            complete_reasoner(
+                Reasoner(name="incomplete", model="openai:gpt-5.6-sol"),
+                "hi",
+                aresponses=incomplete,
+            )
+        )
+
+    failed = Recorder(FakeResponse(output=[], status="failed", error={"message": "down"}))
+    with pytest.raises(ResponsesStatusError, match="failed"):
+        run(
+            complete_reasoner(
+                Reasoner(name="failed", model="openai:gpt-5.6-sol"),
+                "hi",
+                aresponses=failed,
+            )
+        )
+
+    refused = Recorder(
+        FakeResponse(output=[FakeMessage(content=[FakeRefusal("not allowed")])])
+    )
+    with pytest.raises(ResponsesRefusalError, match="model refusal"):
+        run(
+            complete_reasoner(
+                Reasoner(name="refused", model="openai:gpt-5.6-sol"),
+                "hi",
+                aresponses=refused,
+            )
+        )
+
+
+def test_resilient_caller_advances_on_responses_model_behavior() -> None:
+    responses = Recorder(
+        FakeResponse(output=[], status="incomplete", incomplete_details={"reason": "max"})
+    )
+    completion = Recorder(
+        type(
+            "Completion",
+            (),
+            {
+                "choices": [
+                    type(
+                        "Choice",
+                        (),
+                        {"message": type("Message", (), {"content": "rescued", "parsed": None})()},
+                    )()
+                ]
+            },
+        )()
+    )
+    attempts: list[AttemptRecord] = []
+    caller = make_resilient_llm_caller(
+        policy=ResiliencePolicy(
+            fallbacks={"openai:gpt-5.6-sol": ("openai:gpt-5.5",)},
+            transient_attempts=3,
+        ),
+        acompletion=completion,
+        aresponses=responses,
+        on_attempt=attempts.append,
+    )
+
+    result = run(
+        caller(Reasoner(name="resilient-responses", model="openai:gpt-5.6-sol"), "hi")
+    )
+
+    assert result.reply == "rescued"
+    assert [(attempt.model, attempt.outcome) for attempt in attempts] == [
+        ("openai:gpt-5.6-sol", "model_behavior"),
+        ("openai:gpt-5.5", "ok"),
+    ]
+    assert len(responses.calls) == 1
+
+
+def test_resilient_caller_fails_closed_on_responses_refusal() -> None:
+    responses = Recorder(
+        FakeResponse(output=[FakeMessage(content=[FakeRefusal("not allowed")])])
+    )
+    completion = Recorder(
+        type(
+            "Completion",
+            (),
+            {
+                "choices": [
+                    type(
+                        "Choice",
+                        (),
+                        {"message": type("Message", (), {"content": "unsafe", "parsed": None})()},
+                    )()
+                ]
+            },
+        )()
+    )
+    attempts: list[AttemptRecord] = []
+    caller = make_resilient_llm_caller(
+        policy=ResiliencePolicy(
+            fallbacks={"openai:gpt-5.6-sol": ("openai:gpt-5.5",)},
+        ),
+        acompletion=completion,
+        aresponses=responses,
+        on_attempt=attempts.append,
+    )
+
+    with pytest.raises(ResponsesRefusalError, match="model refusal"):
+        run(
+            caller(
+                Reasoner(name="resilient-refusal", model="openai:gpt-5.6-sol"),
+                "hi",
+            )
+        )
+
+    assert [(attempt.model, attempt.outcome) for attempt in attempts] == [
+        ("openai:gpt-5.6-sol", "model_behavior"),
+    ]
+    assert completion.calls == []
+
+
+@pytest.mark.live
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"),
+    reason="OPENAI_API_KEY is required for the live GPT-5.6 Responses smoke",
+)
+def test_live_gpt_5_6_tool_call_through_julep_builder() -> None:
+    result = run(
+        make_llm_caller()(
+            Reasoner(
+                name="live-gpt-5.6-responses",
+                model="openai:gpt-5.6-sol",
+                system="Always call lookup_weather for the requested city.",
+                reasoning_effort="low",
+                max_tokens=64,
+            ),
+            "What is the weather in Paris?",
+            tools=_tools(),
+            parallel_tool_calls=False,
+        )
+    )
+    assert result.reply["tool_calls"][0]["tool"] == "lookup_weather"
+    assert result.reply["tool_calls"][0]["input"] == {"city": "Paris"}
+    assert result.meta.served_model == "gpt-5.6-sol"
+    assert result.meta.native_tool_calls == 1
+
+
+@pytest.mark.live
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"),
+    reason="OPENAI_API_KEY is required for the live GPT-5.6 agent smoke",
+)
+def test_live_gpt_5_6_native_agent_executes_tool_and_finishes() -> None:
+    @tool(effect="read", idempotent=True, name="live_responses_weather")
+    def weather(city: str) -> dict[str, Any]:
+        return {"city": city, "temperature": 25, "unit": "C"}
+
+    agent = Agent(
+        "openai:gpt-5.6-sol",
+        tools=[weather],
+        name="live_gpt_5_6_responses_agent",
+        instructions=(
+            "Call live_responses_weather exactly once for the requested city. "
+            "After receiving its result, finish with an object containing city, "
+            "temperature, and unit. Never call a tool already present in the trace."
+        ),
+        native_tools=True,
+        reasoning_effort="low",
+        max_tokens=128,
+        max_rounds=4,
+        llm=make_local_reasoner(),
+    )
+
+    result = run(agent.arun("What is the weather in Paris?"))
+
+    assert result.status == "done"
+    assert result.output == {"city": "Paris", "temperature": 25, "unit": "C"}
+    assert [entry["decision"] for entry in result.trace] == ["call"]

--- a/tests/test_openai_responses.py
+++ b/tests/test_openai_responses.py
@@ -372,6 +372,29 @@ def test_responses_structured_text_and_format_are_normalized() -> None:
     }
 
 
+def test_responses_schema_prompted_tool_round_strips_json_fences() -> None:
+    responses = Recorder(
+        FakeResponse(output=[FakeMessage(content=[FakeText('```json\n{"answer":"ok"}\n```')])])
+    )
+    schema = {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+        "required": ["answer"],
+    }
+
+    result = run(
+        complete_reasoner(
+            Reasoner(name="responses-fenced-json", model="openai:gpt-5.6", reply=schema),
+            "Answer without calling a tool.",
+            aresponses=responses,
+            tools=_tools(),
+        )
+    )
+
+    assert result.reply == {"answer": "ok"}
+    assert "response_format" not in responses.calls[0]
+
+
 def test_pre_5_6_openai_stays_on_acompletion() -> None:
     completion = Recorder(
         type(


### PR DESCRIPTION
## What changed

- route the `gpt-5.6` alias and all `gpt-5.6-*` OpenAI models through any-llm's Responses API
- translate Julep messages, function tools, transcripts, structured-output formats, reasoning settings, usage, and tool-call results across the Responses wire format
- keep pre-5.6 models on the existing Chat Completions transport
- preserve stateless durable execution with `store=False` and `reasoning.context=current_turn`
- support Julep scalar tools by wrapping provider schemas and restoring bare tool arguments
- fail loudly on failed/incomplete Responses and fail closed on model refusals without fallback shopping
- bump the PyPI package version from `3.0.0rc1` to `3.0.0rc2`

## Why

GPT-5.6 rejects Chat Completions requests that combine function tools with `reasoning_effort`. The prior shared `acompletion` path therefore returned HTTP 400 for native tool-using agents.

## Impact

GPT-5.6 Sol, Terra, Luna, aliases, and snapshots now work through the shared Julep engine across local and durable backends. Existing model transports remain unchanged.

## Validation

- independent Codex review completed; all findings addressed and final re-review found no blockers
- paid live GPT-5.6 tool-call smoke through Julep's builder
- paid live native `Agent` tool execution and finishing round
- paid live structured-output smoke
- `uv run python -m pytest` — 1761 passed, 37 skipped, 3 deselected
- `uv run ruff check julep tests`
- `uv run mypy --strict julep`
- `uv run pytest -q tests/test_openai_responses.py` — 15 passed
- `uv run pytest -q tests/test_version.py tests/test_ca_version.py` — 2 passed
- `uv build` — built `julep-3.0.0rc2` sdist and wheel with matching metadata
- `git diff --check`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/julep-ai/julep/pull/1613">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
