### PR TITLE
[codex] Add local execution and adoption APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.12"]
-        temporal: ["off", "on"]
+        temporal: ["off", "minimum", "on"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -58,8 +58,11 @@ jobs:
       - name: Install package with dev extras
         if: matrix.temporal == 'on'
         run: python -m pip install -e '.[dev]'
+      - name: Install package at the minimum supported Temporal version
+        if: matrix.temporal == 'minimum'
+        run: python -m pip install -e '.[dev]' 'temporalio==1.20.0'
       - name: Assert Temporal is present
-        if: matrix.temporal == 'on'
+        if: matrix.temporal != 'off'
         run: python -c "import julep as c; assert c.HAVE_TEMPORAL is True"
       - name: Pytest
         run: python -m pytest -q

--- a/docs-site/content/docs/deploy/control-plane.md
+++ b/docs-site/content/docs/deploy/control-plane.md
@@ -399,6 +399,8 @@ with JulepClient("https://julep.example", api_key) as client:
 `JulepRunFailed` covers `failed`, `canceled`, `terminated`, and
 `start_failed`. `JulepRunTimeout` is a caller deadline, not a request to cancel
 the durable run. Async callers use the same method and contract with `await`.
+The admin-only `mcp_preflight` override is deliberately available on
+`start_and_wait(...)`, not the ordinary `run_and_wait(...)` convenience.
 
 For terminal CLI reads:
 

--- a/docs-site/content/docs/deploy/control-plane.md
+++ b/docs-site/content/docs/deploy/control-plane.md
@@ -20,6 +20,10 @@ The `server` extra installs FastAPI, Uvicorn, sse-starlette,
 builds `ServerSettings.from_env()`, optionally applies the Postgres migrations,
 constructs the app, and runs Uvicorn.
 
+The supported Temporal SDK floor is `temporalio>=1.20`. For a supervised
+single-machine stack that also publishes the release and launches its workers,
+see [`julep dev up`](/docs/deploy/local#run-the-durable-stack-on-one-machine).
+
 ## Configuration
 
 Environment variables override `[server]` in `julep.toml`, which overrides
@@ -227,7 +231,11 @@ in more than one deployment return `409`.
 The workflow id is `run-<run_id>`. Without `runId`, `run_id` is a UUIDv5 of the
 idempotency key. A fresh submission returns `201`. A duplicate returns its
 existing run with `200` for its owner; reuse by a different owner returns
-`409`.
+`409`. Reusing an idempotency key for a different pipeline or effective release
+also returns structured `409` detail with `error: "idempotency_conflict"` and
+`field: "pipeline" | "release"`; the server never silently returns the other
+pipeline's run. An identical pipeline/release retry keeps the existing `200`
+response, and explicit same-`runId` resubmission semantics are unchanged.
 
 `secrets` supplies run-scoped values for whole-string `secret://name` references
 in MCP headers. Values travel only in AES-GCM-encrypted Temporal payloads and are
@@ -362,8 +370,37 @@ best-effort view, not workflow durability. See the repository's
 
 ## Clients
 
-`julep.client.JulepClient` is a small synchronous httpx client installed by
-`julep[http]`. For terminal reads:
+`julep.client.JulepClient` and `AsyncJulepClient` provide matching synchronous
+and asynchronous httpx surfaces for releases, runs, controls, result waits, and
+projection events. Install `julep[http]` (or `julep[server]`). Both accept an
+injected httpx client for in-process tests and own their client otherwise.
+
+For the common submit-and-wait path, `run_and_wait(...)` requires an
+`idempotency_key` or explicit `run_id`, uses bounded server-side result polls,
+and returns the unwrapped result payload:
+
+```python
+from julep.client import JulepClient, JulepRunFailed, JulepRunTimeout
+
+with JulepClient("https://julep.example", api_key) as client:
+    try:
+        result = client.run_and_wait(
+            pipeline="episode-summary",
+            input={"episode_id": "42"},
+            idempotency_key="summary:42:v3",
+            deadline_s=120,
+        )
+    except JulepRunFailed as exc:
+        print(exc.run_id, exc.status, exc.error)
+    except JulepRunTimeout as exc:
+        print(exc.run_id, exc.deadline_s)
+```
+
+`JulepRunFailed` covers `failed`, `canceled`, `terminated`, and
+`start_failed`. `JulepRunTimeout` is a caller deadline, not a request to cancel
+the durable run. Async callers use the same method and contract with `await`.
+
+For terminal CLI reads:
 
 ```bash
 julep status --remote --api-url https://julep.example --api-key "$JULEP_API_KEY"

--- a/docs-site/content/docs/deploy/local.md
+++ b/docs-site/content/docs/deploy/local.md
@@ -9,6 +9,7 @@ matches what you need to test:
 | Mode | Best for | Services required |
 |---|---|---|
 | `julep run` | Fast source-level iteration from the CLI | None |
+| `prepare_local_pipeline(...).run/arun` | Configured production-like foreground calls | Effect dependencies only |
 | `Deployment.dry_run(...)` | Unit tests with injected tools and reasoners | None |
 | `TestClient(create_local_app(...))` | In-process control-plane and execution tests | None |
 | `julep serve api --local` | Interactive API and client development | None |
@@ -18,7 +19,7 @@ The local API modes use an in-memory execution store, a local artifact
 directory, and interpreter-backed execution. They do not require PostgreSQL or
 Temporal. SQLite is not involved.
 
-The first four modes are **foreground** execution: they return in the caller or
+The first five modes are **foreground** execution: they return in the caller or
 API process, favor low latency, and deliberately omit crash recovery. Use them
 for unit tests, prompt iteration, and foreground request paths. `julep dev up`
 is the **durable** path: it exercises release publication, API persistence,
@@ -37,6 +38,54 @@ The default `local` environment resolves live source and runs the in-memory
 interpreter with deterministic echo effects. It prints the trace tree and final
 output directly. Use this mode when you do not need to exercise the HTTP API,
 release records, or deployment activation.
+
+## Run a configured pipeline in-process
+
+`prepare_local_pipeline(...)` is the first-class foreground seam for an
+application declared in `pyproject.toml` or `julep.toml`. It resolves the
+selected environment, compiles only the named pipeline with its normal env,
+policy, reasoner, freeze, and snapshot gates, and returns a reusable
+`LocalPipeline` with a stable `artifact_hash`:
+
+```python
+from julep import WorkerContext, prepare_local_pipeline
+from julep.llm import litellm_caller
+
+summary = prepare_local_pipeline("episode_summary", env="local")
+context = WorkerContext(llm=litellm_caller())
+
+result = await summary.arun(
+    {"episode_id": "42"},
+    context=context,
+    principal={"tenant": "acme"},
+)
+```
+
+Prepare once when a foreground service will call the pipeline repeatedly.
+`LocalPipeline.arun(...)` executes in the current event loop;
+`LocalPipeline.run(...)` is the synchronous wrapper and rejects an already
+running event loop. `arun_local_pipeline(...)` and `run_local_pipeline(...)`
+are one-shot compile-and-run conveniences. All four execution methods return
+the interpreter value directly rather than a control-plane result envelope.
+
+The model seam is the canonical `LlmCaller(reasoner, value, principal,
+transcript, dispatch)`. An explicit `llm=` wins over `WorkerContext.llm`.
+`principal=` is forwarded to both model and MCP calls. MCP execution is never
+inferred from ambient configuration: inject `WorkerContext(mcp_call=...)`.
+QoS resolution and registry verification are also reused. A context registry
+may contain the same compiled reasoner declaration, but a differing override is
+rejected. Tool-calling agents additionally require a caller that accepts
+Julep's optional `tools=` keyword extension.
+
+This path deliberately has no HTTP/control-plane hop, PostgreSQL, Temporal,
+release lifecycle, or durable retry boundary. It rejects session `LOOP`
+artifacts, transcript-scoped `APP` agents, staged plans, subflows, and the
+reserved human-gate, sleep, recv, and emit effects with typed
+`LocalExecutionUnsupported`. Ordinary business input may still contain a field
+named `transcript`; only the agent runtime protocol is unsupported. Batch QoS
+is clamped to foreground `FLEX`, and run-scoped control-plane secrets are not
+an argument. Use `serve api --local` or a durable worker for those orchestration
+surfaces.
 
 ## Unit-test a deployment
 
@@ -141,8 +190,8 @@ idempotent submission, PostgreSQL run records, Temporal retry/replay, payload
 encryption, or worker queue routing.
 
 Install the server/store/Temporal dependencies, a local PostgreSQL server, and
-the Temporal CLI. Generate independent development-only API, payload-codec,
-vault, and signing keys once, then load the same values into every process:
+the Temporal CLI. Generate independent development-only admin API, worker API,
+payload-codec, vault, and signing keys, then load the file into the supervisor:
 
 ```bash
 pip install --pre 'julep[server,store]'
@@ -158,6 +207,14 @@ export JULEP_EXECUTION_STORE_DSN='postgresql://postgres:postgres@127.0.0.1:5432/
 omitted. Use `--format json` when feeding a secret manager instead of a shell.
 The generated values are local credentials; Julep does not persist them for
 you and they should not be committed.
+
+The supervisor partitions that input by process. Publication receives the
+private signing seed; the API receives the static API keyring and vault keys;
+workers receive the shared payload codec, public signer allow-list, and only
+the worker-role token as `JULEP_API_KEY`. Workers never receive
+`JULEP_API_KEYS`, vault decryption keys, the admin token, or the private signing
+seed. `JULEP_WORKER_API_KEY` exists only as the supervisor's handoff name; it is
+used for authenticated vault reads through `JULEP_API_URL`.
 
 Configure a local file release store, the worker context factory that supplies
 real effects, and the lane queues in `julep.toml`:
@@ -190,7 +247,8 @@ frontend, `--no-publish --no-worker` to bring up infrastructure only, and
 `--dry-run` to inspect the redacted process plan. `--api-url` defaults to
 `JULEP_API_URL`, then `http://127.0.0.1:8080`; `--api-key` defaults to
 `JULEP_API_KEY`. The selected key must match an admin entry in
-`JULEP_API_KEYS`.
+`JULEP_API_KEYS`; the generated `JULEP_WORKER_API_KEY` must match its separate
+worker-role entry.
 
 This mode still uses PostgreSQL and Temporal intentionally. If a test only
 needs the HTTP surface, use `create_local_app(...)` or `serve api --local`

--- a/docs-site/content/docs/deploy/local.md
+++ b/docs-site/content/docs/deploy/local.md
@@ -1,0 +1,143 @@
+---
+title: "Local development"
+description: "Choose a service-free execution path or run the complete control-plane API locally."
+---
+
+Julep provides several local execution modes. Choose the smallest surface that
+matches what you need to test:
+
+| Mode | Best for | Services required |
+|---|---|---|
+| `julep run` | Fast source-level iteration from the CLI | None |
+| `Deployment.dry_run(...)` | Unit tests with injected tools and reasoners | None |
+| `TestClient(create_local_app(...))` | In-process control-plane and execution tests | None |
+| `julep serve api --local` | Interactive API and client development | None |
+
+The local API modes use an in-memory execution store, a local artifact
+directory, and interpreter-backed execution. They do not require PostgreSQL or
+Temporal. SQLite is not involved.
+
+## Run source from the CLI
+
+`julep run` is the quickest feedback loop for an agent or dotctx package:
+
+```bash
+julep run triage --input '{"ticket":"TICKET-42"}'
+```
+
+The default `local` environment resolves live source and runs the in-memory
+interpreter with deterministic echo effects. It prints the trace tree and final
+output directly. Use this mode when you do not need to exercise the HTTP API,
+release records, or deployment activation.
+
+## Unit-test a deployment
+
+`Deployment.dry_run(...)` runs a compiled deployment in-process. Inject native
+tool and reasoner implementations to test real application logic without a
+worker or control plane:
+
+```python
+deployment = deploy(flow, tools=[lookup_ticket])
+
+result = deployment.dry_run(
+    {"ticket": "TICKET-42"},
+    tools={"lookup_ticket": fake_lookup_ticket},
+    reasoners={"triage": fake_triage},
+)
+
+assert result.value == {"priority": "high"}
+```
+
+For an MCP-backed deployment, pass `mcp_call=...` or an injected implementation
+through `tools`. This is the most focused option for unit tests; it does not
+exercise the release or run API.
+
+## Test the API in-process
+
+Use `create_local_app(...)` with Starlette's `TestClient` to exercise the same
+HTTP routes without opening a port:
+
+```python
+from starlette.testclient import TestClient
+
+from julep.server import create_local_app
+
+
+app = create_local_app(project_root=tmp_path)
+
+with TestClient(app) as client:
+    response = client.get(
+        "/v1/ready",
+        headers={"Authorization": "Bearer local-dev"},
+    )
+    assert response.status_code == 200
+```
+
+The factory stores artifacts under `<project>/.julep/artifacts`. Runs, release
+records, deployment records, projections, gates, and vault rows otherwise live
+only in the process and disappear when the application exits.
+
+With no configured API keys, local mode provides the admin token `local-dev`
+when bound to a loopback host. It refuses to provide that fallback for a
+non-loopback bind. Configure explicit keys before exposing the server on another
+interface.
+
+## Serve the local API
+
+Run the same application under Uvicorn for interactive testing or development
+against an HTTP client:
+
+```bash
+pip install --pre 'julep[server]'
+julep serve api --local --host 127.0.0.1 --port 8080
+```
+
+`--local` cannot be combined with `--migrate`: the local execution store has no
+database schema to migrate.
+
+By default, the server uses deterministic echo effects. Supply a zero-argument
+sync or async factory returning a `WorkerContext` to call configured tools and
+reasoners instead:
+
+```bash
+julep serve api --local \
+  --context-factory my_project.worker:build_context
+```
+
+Configured-context execution uses the normal effect implementations, including
+real MCP discovery, binding validation, and preflight. Echo execution makes no
+network calls: it simulates an MCP surface equal to the tools frozen into the
+release. Because echo mode has no real secret transport or binding to validate,
+it rejects runs that submit run-scoped secrets.
+
+## Exercise the release lifecycle
+
+The local server preserves the normal control-plane sequence:
+
+1. Upload referenced blobs with `PUT /v1/artifacts/{sha256}`.
+2. Publish the immutable application release with `POST /v1/releases`.
+3. Activate it on a lane with `POST /v1/deployments`.
+4. Start a pipeline with `POST /v1/runs`.
+5. Read events, open gates, signals, status, and the terminal result through the
+   ordinary `/v1/runs/{run_id}/...` endpoints.
+
+This means an HTTP client can use the same artifact, release, deployment, and
+run flow locally before it targets a durable control plane. Queue names remain
+part of release metadata, but the process-local gateway does not dispatch work
+to external queues.
+
+## Limitations
+
+Local API mode is an early-iteration and testing surface, not a deployment
+backend:
+
+- State is process-local and is not recovered after exit or a crash.
+- It does not provide Temporal replay durability or multi-process execution.
+- Configured effects run locally without Temporal's activity retry, QoS, or
+  timeout scheduling semantics.
+- It does not run Helm reconciliation or production workers.
+- Session `LOOP` artifacts are not supported; use a finite flow.
+- Use the PostgreSQL and Temporal control plane for durable, distributed runs.
+
+See [Control plane](/docs/deploy/control-plane) for production configuration and
+[Temporal](/docs/deploy/temporal) for durable workflow execution.

--- a/docs-site/content/docs/deploy/local.md
+++ b/docs-site/content/docs/deploy/local.md
@@ -134,10 +134,16 @@ The factory stores artifacts under `<project>/.julep/artifacts`. Runs, release
 records, deployment records, projections, gates, and vault rows otherwise live
 only in the process and disappear when the application exits.
 
-With no configured API keys, local mode provides the admin token `local-dev`
-when bound to a loopback host. It refuses to provide that fallback for a
-non-loopback bind. Configure explicit keys before exposing the server on another
-interface.
+With no configured API keys, echo-only local mode provides the admin token
+`local-dev` when bound to a loopback host. It refuses to provide that fallback
+for a non-loopback bind. Configured-context mode can invoke real effects and
+therefore requires explicit API keys even on loopback.
+
+Only one local-app lifespan may be active in a process at a time. Local mode
+temporarily owns process-wide effect and artifact resolution; an overlapping
+`TestClient` lifespan fails immediately instead of risking cross-app context or
+credential leakage. Use one shared app in a test process or put independent
+local apps in separate processes.
 
 ## Serve the local API
 
@@ -157,6 +163,8 @@ sync or async factory returning a `WorkerContext` to call configured tools and
 reasoners instead:
 
 ```bash
+LOCAL_JULEP_TOKEN="$(openssl rand -hex 32)"
+export JULEP_API_KEYS="local-admin:${LOCAL_JULEP_TOKEN}:admin"
 julep serve api --local \
   --context-factory my_project.worker:build_context
 ```

--- a/docs-site/content/docs/deploy/local.md
+++ b/docs-site/content/docs/deploy/local.md
@@ -12,10 +12,18 @@ matches what you need to test:
 | `Deployment.dry_run(...)` | Unit tests with injected tools and reasoners | None |
 | `TestClient(create_local_app(...))` | In-process control-plane and execution tests | None |
 | `julep serve api --local` | Interactive API and client development | None |
+| `julep dev up` | Durable single-machine acceptance tests | PostgreSQL, Temporal CLI, worker effects |
 
 The local API modes use an in-memory execution store, a local artifact
 directory, and interpreter-backed execution. They do not require PostgreSQL or
 Temporal. SQLite is not involved.
+
+The first four modes are **foreground** execution: they return in the caller or
+API process, favor low latency, and deliberately omit crash recovery. Use them
+for unit tests, prompt iteration, and foreground request paths. `julep dev up`
+is the **durable** path: it exercises release publication, API persistence,
+Temporal dispatch/replay, and release-scoped workers on one machine. Choosing a
+local mode is a test-scope decision, not a different flow definition.
 
 ## Run source from the CLI
 
@@ -126,6 +134,68 @@ run flow locally before it targets a durable control plane. Queue names remain
 part of release metadata, but the process-local gateway does not dispatch work
 to external queues.
 
+## Run the durable stack on one machine
+
+Use the supervised development stack when the behavior under test includes
+idempotent submission, PostgreSQL run records, Temporal retry/replay, payload
+encryption, or worker queue routing.
+
+Install the server/store/Temporal dependencies, a local PostgreSQL server, and
+the Temporal CLI. Generate independent development-only API, payload-codec,
+vault, and signing keys once, then load the same values into every process:
+
+```bash
+pip install --pre 'julep[server,store]'
+mkdir -p .julep
+julep keygen --output .julep/dev.env
+source .julep/dev.env
+
+export JULEP_EXECUTION_STORE_DSN='postgresql://postgres:postgres@127.0.0.1:5432/julep'
+```
+
+`julep keygen` writes mode `0600`, refuses to replace an existing file unless
+`--force` is supplied, and prints shell exports to stdout when `--output` is
+omitted. Use `--format json` when feeding a secret manager instead of a shell.
+The generated values are local credentials; Julep does not persist them for
+you and they should not be committed.
+
+Configure a local file release store, the worker context factory that supplies
+real effects, and the lane queues in `julep.toml`:
+
+```toml
+[env.local]
+temporal_address = "127.0.0.1:7233"
+release_store = "file:///absolute/path/to/project/.julep/releases"
+worker_context_factory = "my_project.worker:build_context"
+
+[env.local.queues]
+default = "julep-local"
+reasoner = "julep-local-reasoner"
+```
+
+Start the complete stack in the foreground:
+
+```bash
+julep dev up --env local
+```
+
+The supervisor starts Temporal's local dev server, migrates and starts the
+durable API, publishes and registers the configured application through the
+Python API, and starts one worker for every release-scoped lane queue. It waits
+for dependency readiness and tears down all child processes on exit. The API
+is loopback-only in this mode.
+
+Use `--no-start-temporal` to connect to an already-running local Temporal
+frontend, `--no-publish --no-worker` to bring up infrastructure only, and
+`--dry-run` to inspect the redacted process plan. `--api-url` defaults to
+`JULEP_API_URL`, then `http://127.0.0.1:8080`; `--api-key` defaults to
+`JULEP_API_KEY`. The selected key must match an admin entry in
+`JULEP_API_KEYS`.
+
+This mode still uses PostgreSQL and Temporal intentionally. If a test only
+needs the HTTP surface, use `create_local_app(...)` or `serve api --local`
+instead of replacing PostgreSQL with another database.
+
 ## Limitations
 
 Local API mode is an early-iteration and testing surface, not a deployment
@@ -138,6 +208,10 @@ backend:
 - It does not run Helm reconciliation or production workers.
 - Session `LOOP` artifacts are not supported; use a finite flow.
 - Use the PostgreSQL and Temporal control plane for durable, distributed runs.
+
+The foreground limitations above do not apply to `julep dev up`; that command
+runs the real durable components, but remains a single-machine development
+supervisor rather than a production process manager.
 
 See [Control plane](/docs/deploy/control-plane) for production configuration and
 [Temporal](/docs/deploy/temporal) for durable workflow execution.

--- a/docs-site/content/docs/deploy/local.md
+++ b/docs-site/content/docs/deploy/local.md
@@ -77,6 +77,12 @@ may contain the same compiled reasoner declaration, but a differing override is
 rejected. Tool-calling agents additionally require a caller that accepts
 Julep's optional `tools=` keyword extension.
 
+The MCP surface is snapshotted and frozen when the pipeline is prepared, and
+frozen input schemas are enforced before dispatch. This foreground seam does
+not perform the control plane's per-run MCP preflight or re-snapshot drift
+check; call `prepare_local_pipeline(...)` again to refresh a live surface, or
+use the local/durable API when per-run preflight behavior is under test.
+
 This path deliberately has no HTTP/control-plane hop, PostgreSQL, Temporal,
 release lifecycle, or durable retry boundary. It rejects session `LOOP`
 artifacts, transcript-scoped `APP` agents, staged plans, subflows, and the

--- a/docs-site/content/docs/deploy/meta.json
+++ b/docs-site/content/docs/deploy/meta.json
@@ -2,6 +2,7 @@
   "title": "Deploy & Scale",
   "pages": [
     "index",
+    "local",
     "temporal",
     "control-plane",
     "kubernetes",

--- a/docs-site/content/docs/guides/using-the-cli.md
+++ b/docs-site/content/docs/guides/using-the-cli.md
@@ -99,7 +99,7 @@ keys are rejected with a close-match suggestion.
 | `julep apply --env <name> [--mcp-snapshot] [--publish-only] [--api-url --api-key]` | Publish a signed schema-v2 release, optionally register it with a control plane, and optionally reconcile lane workers. |
 | `julep status [SEL] --env <name>` | Aggregate application state or inspect the legacy ledger; `--remote --api-url --api-key --limit` reads control-plane runs. |
 | `julep worker [--smoke-test-seconds N]` | Run the environment-configured Temporal worker continuously (`0`) or verify/poll/drain for a positive `N`. |
-| `julep keygen [--format env|json] [--output PATH]` | Generate independent local API, payload, vault, and signing credentials; output files are mode `0600`. |
+| `julep keygen [--format env|json] [--output PATH]` | Generate independent local admin/worker API, payload, vault, and signing credentials; output files are mode `0600`. |
 | `julep dev up [--env local] [--dry-run]` | Supervise the PostgreSQL/Temporal durable development stack and one worker per release lane. |
 | `julep serve api [--host --port --migrate --local --context-factory]` | Run the durable or service-free local FastAPI control plane. |
 | `julep db migrate [--dsn]` | Apply projection-store migrations. |

--- a/docs-site/content/docs/guides/using-the-cli.md
+++ b/docs-site/content/docs/guides/using-the-cli.md
@@ -99,6 +99,8 @@ keys are rejected with a close-match suggestion.
 | `julep apply --env <name> [--mcp-snapshot] [--publish-only] [--api-url --api-key]` | Publish a signed schema-v2 release, optionally register it with a control plane, and optionally reconcile lane workers. |
 | `julep status [SEL] --env <name>` | Aggregate application state or inspect the legacy ledger; `--remote --api-url --api-key --limit` reads control-plane runs. |
 | `julep worker [--smoke-test-seconds N]` | Run the environment-configured Temporal worker continuously (`0`) or verify/poll/drain for a positive `N`. |
+| `julep keygen [--format env|json] [--output PATH]` | Generate independent local API, payload, vault, and signing credentials; output files are mode `0600`. |
+| `julep dev up [--env local] [--dry-run]` | Supervise the PostgreSQL/Temporal durable development stack and one worker per release lane. |
 | `julep serve api [--host --port --migrate --local --context-factory]` | Run the durable or service-free local FastAPI control plane. |
 | `julep db migrate [--dsn]` | Apply projection-store migrations. |
 | `julep db sweep --older-than N [--dsn]` | Apply operator-controlled projection retention. |
@@ -142,7 +144,7 @@ julep run triage --input '"TICKET-42"'
 └─ seq#12 [ok]
    └─ seq#9 [ok]
       ├─ call#0 [ok] $1.0000      ← a @tool call
-      └─ think#3 [ok] $2.0000     ← a think() reasoner, with cost
+      └─ think#3 [ok] cost=unknown ← no provider price was reported
 
 output: {"reply": "..."}
 ```
@@ -154,6 +156,9 @@ output: {"reply": "..."}
 > reasoners (see [Your First Flow](/docs/start/first-flow)). Registered `@pure`
 > functions run for real in both.
 
+Julep renders a dollar cost only when the effect reports one. Usage or model
+metadata without a price is `cost=unknown`, never a placeholder estimate.
+
 The tree renders directly from in-memory projection events — fully offline. Runs are cached under `.julep/runs/` so `julep trace <run-id>` can re-render them and `result:fail` can select the failures.
 
 `julep run prompts/summary.ctx --input '{"episode":"42"}'` is a separate
@@ -162,9 +167,23 @@ the local eval harness, and prints `artifact <hash>` plus `output: <json>`.
 Configured `[pipeline.<name>]` packages are also appended during `plan` and
 `apply`; a collision with a code pipeline is an error.
 
+For HTTP-level foreground tests, `julep serve api --local` runs the same routes
+with an in-memory store and interpreter, without PostgreSQL or Temporal. For a
+durable single-machine acceptance environment, generate shared credentials
+with `julep keygen`, configure a local release store and worker context factory,
+then run `julep dev up`. The latter uses real PostgreSQL persistence, Temporal
+replay, encrypted payloads, release registration, and release-scoped queues.
+See [Local development](/docs/deploy/local) for the decision guide and setup.
+
 ## Gates
 
-`julep lint` lowers each selected agent to IR and runs the structural validator, reporting named diagnostics (`CYCLE`, `UNFROZEN_CALL`, `UNKNOWN_PURE`, …) at `error`/`warning`. `--fail-severity` decouples *what is reported* from *what fails the build*:
+`julep lint` lowers each selected code agent and configured dotctx pipeline to
+IR and runs the structural validator, reporting named diagnostics (`CYCLE`,
+`UNFROZEN_CALL`, `UNKNOWN_PURE`, …) at `error`/`warning`. It validates configured
+ctx env/policy/tool bindings without contacting MCP servers. Missing
+`schema.pyi:Output` produces `CTX_OUTPUT_SCHEMA_MISSING`, because replies would
+otherwise be unvalidated. `--fail-severity` decouples *what is reported* from
+*what fails the build*:
 
 - exit `0` — clean (or all findings below the threshold)
 - exit `1` — findings at/above `--fail-severity`

--- a/docs-site/content/docs/guides/using-the-cli.md
+++ b/docs-site/content/docs/guides/using-the-cli.md
@@ -96,10 +96,10 @@ keys are rejected with a close-match suggestion.
 | `julep doctor` | Preflight: discovery, dangling `secret://` refs, git, Langfuse, Temporal. |
 | `julep deploy [SEL] --env <name>` | Freeze → publish bundle to the env artifact store → record in the deploy ledger. |
 | `julep plan --env <name> [--mcp-snapshot]` | Compile code plus configured dotctx pipelines and report drift; optionally fetch configured MCP schemas. |
-| `julep apply --env <name> [--mcp-snapshot] [--publish-only]` | Publish a signed schema-v2 release and optionally reconcile lane workers. |
+| `julep apply --env <name> [--mcp-snapshot] [--publish-only] [--api-url --api-key]` | Publish a signed schema-v2 release, optionally register it with a control plane, and optionally reconcile lane workers. |
 | `julep status [SEL] --env <name>` | Aggregate application state or inspect the legacy ledger; `--remote --api-url --api-key --limit` reads control-plane runs. |
 | `julep worker [--smoke-test-seconds N]` | Run the environment-configured Temporal worker continuously (`0`) or verify/poll/drain for a positive `N`. |
-| `julep serve api [--host --port --migrate]` | Run the FastAPI control plane. |
+| `julep serve api [--host --port --migrate --local --context-factory]` | Run the durable or service-free local FastAPI control plane. |
 | `julep db migrate [--dsn]` | Apply projection-store migrations. |
 | `julep db sweep --older-than N [--dsn]` | Apply operator-controlled projection retention. |
 | `julep db reencrypt-secrets [--dsn]` | Maintenance-only vault key rotation sweep. |

--- a/docs-site/content/docs/reference/julep-cli.md
+++ b/docs-site/content/docs/reference/julep-cli.md
@@ -104,6 +104,13 @@ lane = "summaries"
 
 [tool.julep.pipeline.episode_summary.env]
 MODEL = "anthropic:claude-haiku-4-5-20251001"
+
+[tool.julep.pipeline.episode_summary.tools]
+search = "memory:search"
+
+[tool.julep.pipeline.episode_summary.policy]
+reasoner_max_attempts = 1
+reasoner_timeout_s = 300
 ```
 
 Reserved top-level sections are `mcp`, `pipeline`, `server`, and `redaction`;
@@ -113,8 +120,10 @@ and `[redaction]`.
 
 MCP server keys are `url`, `auth`, `headers`, and `version`. URLs must be
 absolute HTTP(S) endpoints without embedded credentials and form the live
-snapshot allow-list. Pipeline keys are `ctx`, `lane`, and nested `env` string
-values. Server settings are documented under
+snapshot allow-list. Pipeline keys are `ctx`, `lane`, and nested `env`, `tools`,
+and `policy` tables. Tool bindings map prompt-visible aliases to
+`server:tool`; policy keys use the snake-case `ExecutionPolicy` field names.
+Server settings are documented under
 [Control plane](/docs/deploy/control-plane). Redaction keys are
 `key_patterns`, `path_patterns`, and `disable_default`; worker-side file loading
 uses `[tool.julep.redaction]` in `pyproject.toml`.
@@ -139,7 +148,7 @@ the error includes a close-match suggestion, such as `lan` to `lane` or
 | `env.<name>.artifacts` | `None` | Deploy artifact store; implicit `local` defaults to `.julep/artifacts`. |
 | `env.<name>.langfuse_host` | `None` | Parsed, but current trace links read `LANGFUSE_HOST`. |
 | `env.<name>.release_store` | `None` | Application release artifact store (`s3://...` or `file://...`). |
-| `env.<name>.worker_image` | `None` | Immutable `repository@sha256:...` image required by application `apply`. |
+| `env.<name>.worker_image` | `None` | Immutable `repository@sha256:...` image required for lane reconciliation; optional with `apply --publish-only`. |
 | `env.<name>.helm_chart` | `infra/helm/julep-worker` | Local chart path or digest-pinned OCI chart. |
 | `env.<name>.kubernetes_namespace` | `julep` | Namespace for application lane releases. |
 | `env.<name>.worker_context_factory` | `None` | Required `module:attribute` worker context factory. |
@@ -384,7 +393,7 @@ and does not change plan's success exit code.
 
 ## `julep apply`
 
-Synopsis: `julep apply --env ENV [--publish-only] [--mcp-snapshot]`
+Synopsis: `julep apply --env ENV [--publish-only] [--mcp-snapshot] [--api-url URL] [--api-key KEY]`
 
 Compile and publish a signed, immutable application release. By default it then
 reconciles one digest-pinned Helm release and release-specific Temporal task
@@ -396,6 +405,8 @@ applied state. It never switches application traffic.
 | `--env ENV` | required | Configured application environment. |
 | `--publish-only` | false | Publish release artifacts without Helm reconciliation or local applied-state recording. |
 | `--mcp-snapshot` | false | Fetch configured MCP `tools/list` schemas before publishing. Requires `julep[mcp]`. |
+| `--api-url URL` | unset | Register the release manifest with this control-plane API after publishing. |
+| `--api-key KEY` | unset | Admin bearer key for release registration. |
 
 An explicit `snapshot=` in application code remains authoritative. The CLI
 flag applies the configured server snapshot to pipelines without native tools.
@@ -408,9 +419,10 @@ and renderer declarations, so generic workers can execute them.
 64-hex public keys must include the publishing key. An omitted allow-list is
 derived from the publishing key and injected into the worker configuration.
 
-Exit/errors: unknown env exits `2`; compile, signing, artifact store, configuration, or
-reconciliation failures exit `1`; success exits `0` and prints the release,
-artifact, lane releases/queues, and `traffic unchanged`.
+Exit/errors: unknown env exits `2`; compile, signing, artifact store,
+configuration, reconciliation, or registration failures exit `1`; success
+exits `0` and prints the release, artifact, every release-scoped lane queue,
+optional `registered <release-hash>`, and `traffic unchanged`.
 
 ## `julep status`
 
@@ -457,7 +469,7 @@ errors exit `1`; missing API URL or httpx exits `2`.
 
 ## `julep serve api`
 
-Synopsis: `julep serve api [--host HOST] [--port PORT] [--migrate]`
+Synopsis: `julep serve api [--host HOST] [--port PORT] [--migrate] [--local] [--context-factory MODULE:ATTR]`
 
 Build and run the FastAPI control plane from `ServerSettings.from_env()`.
 
@@ -466,9 +478,12 @@ Build and run the FastAPI control plane from `ServerSettings.from_env()`.
 | `--host HOST` | `JULEP_SERVER_HOST` or `127.0.0.1` | Uvicorn listen host. |
 | `--port PORT` | `JULEP_SERVER_PORT` or `8080` | Uvicorn listen port. |
 | `--migrate` | false | Apply the execution-store schema before serving. |
+| `--local` | false | Use the service-free in-memory control plane and interpreter. Cannot be combined with `--migrate`. |
+| `--context-factory MODULE:ATTR` | unset | In local mode, load a zero-argument sync or async factory returning `WorkerContext`. |
 
-Requires `julep[server]` and `JULEP_EXECUTION_STORE_DSN`. Configuration or
-optional-dependency failures exit `2`. See
+Durable mode requires `julep[server]` and `JULEP_EXECUTION_STORE_DSN`. Local
+mode needs no PostgreSQL or Temporal. Configuration or optional-dependency
+failures exit `2`. See [Local development](/docs/deploy/local) and
 [Control plane](/docs/deploy/control-plane).
 
 ## `julep db migrate`

--- a/docs-site/content/docs/reference/julep-cli.md
+++ b/docs-site/content/docs/reference/julep-cli.md
@@ -485,9 +485,13 @@ the generated values on its own.
 | `--force` | false | Replace an existing output file; without it, overwrite is refused. |
 
 The env form includes `TEMPORAL_PAYLOAD_KEYS`, `JULEP_VAULT_KEYS`, the bundle
-signing seed and allowed public signer, `JULEP_API_KEYS`, and the matching
-`JULEP_API_KEY`. Load the same output into the API and worker processes. Treat
-it as secret local configuration and do not commit it.
+signing seed and allowed public signer, and a two-role `JULEP_API_KEYS` keyring.
+`JULEP_API_KEY` is its admin token; `JULEP_WORKER_API_KEY` is an independent
+worker token. Source the output into `julep dev up`, which partitions the
+credentials by child process: workers receive the payload codec, public signer,
+and worker token, but not the static API keyring, vault keyring, admin token, or
+private signing seed. Treat the complete generated output as secret local
+configuration and do not commit it.
 
 ## `julep dev up`
 
@@ -512,7 +516,10 @@ stopped on exit or startup failure.
 
 Durable dev requires `JULEP_EXECUTION_STORE_DSN`, a local `file://` release
 store, a worker context factory, payload encryption keys, an admin API key, and
-the server/store/Temporal dependencies. It uses real PostgreSQL and Temporal;
+the server/store/Temporal dependencies. When workers need operator-vault
+values, `JULEP_WORKER_API_KEY` must match a separate worker-role keyring entry;
+the supervisor exposes it to workers as `JULEP_API_KEY` alongside
+`JULEP_API_URL`. It uses real PostgreSQL and Temporal;
 for a service-free HTTP test surface, use `julep serve api --local` instead.
 See [Local development](/docs/deploy/local) for setup.
 

--- a/docs-site/content/docs/reference/julep-cli.md
+++ b/docs-site/content/docs/reference/julep-cli.md
@@ -538,8 +538,10 @@ Build and run the FastAPI control plane from `ServerSettings.from_env()`.
 | `--context-factory MODULE:ATTR` | unset | In local mode, load a zero-argument sync or async factory returning `WorkerContext`. |
 
 Durable mode requires `julep[server]` and `JULEP_EXECUTION_STORE_DSN`. Local
-mode needs no PostgreSQL or Temporal. Configuration or optional-dependency
-failures exit `2`. See [Local development](/docs/deploy/local) and
+echo mode needs no PostgreSQL or Temporal and supplies the fixed `local-dev`
+admin token only on loopback. Because configured-context mode can invoke real
+effects, it requires explicit `JULEP_API_KEYS` even on loopback. Configuration
+or optional-dependency failures exit `2`. See [Local development](/docs/deploy/local) and
 [Control plane](/docs/deploy/control-plane).
 
 ## `julep db migrate`

--- a/docs-site/content/docs/reference/julep-cli.md
+++ b/docs-site/content/docs/reference/julep-cli.md
@@ -184,6 +184,9 @@ pipeline-specific extras. Application reconciliation/observation shells out to
 authenticated `helm`, `kubectl`, and `temporal` CLIs (`apply --publish-only`
 skips Helm reconciliation).
 
+The Temporal-facing extras support `temporalio>=1.20`, including the minimum
+version used by the compatibility CI lane.
+
 ## `julep ls`
 
 Synopsis: `julep ls [SELECTOR] [--exclude EXPR]`
@@ -467,6 +470,52 @@ backlog, and running counts.
 Remote output prints run id, status, pipeline, and application. Remote API
 errors exit `1`; missing API URL or httpx exits `2`.
 
+## `julep keygen`
+
+Synopsis: `julep keygen [--format env|json] [--output PATH] [--force]`
+
+Generate mutually independent development API, Temporal payload-codec, vault,
+and Ed25519 bundle-signing keys for the durable local stack. Julep never stores
+the generated values on its own.
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--format FORMAT` | `env` | Render shell `export` statements or a JSON object. |
+| `--output PATH` | stdout | Write the rendered values to a mode-`0600` file. |
+| `--force` | false | Replace an existing output file; without it, overwrite is refused. |
+
+The env form includes `TEMPORAL_PAYLOAD_KEYS`, `JULEP_VAULT_KEYS`, the bundle
+signing seed and allowed public signer, `JULEP_API_KEYS`, and the matching
+`JULEP_API_KEY`. Load the same output into the API and worker processes. Treat
+it as secret local configuration and do not commit it.
+
+## `julep dev up`
+
+Synopsis: `julep dev up [--env ENV] [--api-url URL] [--api-key KEY] [--start-temporal/--no-start-temporal] [--publish/--no-publish] [--worker/--no-worker] [--startup-timeout SECONDS] [--dry-run]`
+
+Supervise the durable single-machine development stack. It optionally starts
+Temporal's dev server, migrates and starts the PostgreSQL-backed API, publishes
+and registers the configured application directly through Python APIs, then
+starts one worker per release-scoped lane queue. All child processes are
+stopped on exit or startup failure.
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--env ENV` | `local` | Application environment to compile and publish. |
+| `--api-url URL` | `JULEP_API_URL`, then `http://127.0.0.1:8080` | Loopback durable API URL. Paths, queries, fragments, HTTPS, and non-loopback hosts are rejected. |
+| `--api-key KEY` | `JULEP_API_KEY` | Admin key that must match `JULEP_API_KEYS`. |
+| `--start-temporal/--no-start-temporal` | start | Start a loopback `temporal server start-dev`, or connect to an existing frontend. |
+| `--publish/--no-publish` | publish | Publish and register the release before workers start. |
+| `--worker/--no-worker` | worker | Start one generic worker per published lane queue. Workers require publication. |
+| `--startup-timeout SECONDS` | `30` | Positive readiness deadline for each supervised dependency. |
+| `--dry-run` | false | Validate configuration and print a credential-redacted command plan without starting processes. |
+
+Durable dev requires `JULEP_EXECUTION_STORE_DSN`, a local `file://` release
+store, a worker context factory, payload encryption keys, an admin API key, and
+the server/store/Temporal dependencies. It uses real PostgreSQL and Temporal;
+for a service-free HTTP test surface, use `julep serve api --local` instead.
+See [Local development](/docs/deploy/local) for setup.
+
 ## `julep serve api`
 
 Synopsis: `julep serve api [--host HOST] [--port PORT] [--migrate] [--local] [--context-factory MODULE:ATTR]`
@@ -545,7 +594,11 @@ positive smoke mode on a release-specific empty queue before `apply` succeeds.
 
 Synopsis: `julep lint [SELECTOR] [--exclude EXPR] [--fail-severity LEVEL]`
 
-Resolve selected agents to IR and run structural validation.
+Resolve selected agents and configured `[pipeline.<name>]` dotctx packages to
+IR and run structural validation. Configured pipelines participate in the same
+selector namespace and tags as code agents. Lint loads their package, env,
+policy, and tool bindings without fetching MCP schemas, publishing artifacts,
+or contacting configured services.
 
 | Arg/flag | Default | Meaning |
 |---|---|---|
@@ -569,6 +622,11 @@ WARNING triage: SOME_CODE — diagnostic message
 Exit/errors: clean or below-threshold findings exit `0`; findings at or above
 the threshold exit `1`; resolver errors return `RESOLVE` and exit `2`; no
 matched agents prints `clean` and exits `0`.
+
+A dotctx pipeline whose `schema.pyi` does not define `class Output` produces
+`CTX_OUTPUT_SCHEMA_MISSING` at warning severity: the package can still run, but
+model replies are not schema-validated. Use `--fail-severity warning` to make
+that compatibility degradation fail CI.
 
 ## `julep test`
 
@@ -620,6 +678,10 @@ julep trace r-cmd-1
    ├─ call#0 [ok]
    └─ think#3 [ok] $1.0000
 ```
+
+When a model event carries usage/model metadata but no provider-reported price,
+the node renders `cost=unknown`. It is intentionally not assigned a placeholder
+dollar amount.
 
 ```text
 run 'r-err' status=error (no trace events captured)

--- a/docs-site/content/docs/reference/python-api.md
+++ b/docs-site/content/docs/reference/python-api.md
@@ -321,6 +321,37 @@ are derived from the resolved frozen tool set when `capabilities` is omitted.
 `InMemoryEnv` also accepts `mcp_call=`, so an MCP-only deployment needs no
 native `tools=` map for local execution.
 
+## Configured foreground execution
+
+These package-root exports load one configured application pipeline and execute
+its frozen deployment in the caller's process. They return the unwrapped
+interpreter value and perform no HTTP, PostgreSQL, Temporal, release, or durable
+retry work.
+
+| Symbol | Signature | Behavior | Raises |
+|---|---|---|---|
+| `prepare_local_pipeline` | `prepare_local_pipeline(pipeline: str, *, project_root: str | Path = ".", config: JulepConfig | None = None, env: str = "local") -> LocalPipeline` | resolve config/application, compile only the selected pipeline, and return a reusable object with `.artifact_hash`, `.name`, and `.environment` | `LocalPipelineNotFound`, compilation/freeze/snapshot errors |
+| `LocalPipeline.arun` | `async arun(input=None, *, llm: LlmCaller | None = None, context: WorkerContext | None = None, principal: RunPrincipal | None = None) -> Any` | execute in the current event loop and return the unwrapped value | local configuration/effect/interpreter errors |
+| `LocalPipeline.run` | `run(input=None, *, llm=None, context=None, principal=None) -> Any` | synchronous wrapper over `arun`; prepare once and reuse across calls | `LocalExecutionConfigurationError` in an active event loop |
+| `arun_local_pipeline` | `async arun_local_pipeline(pipeline, input=None, *, project_root=".", config=None, env="local", llm=None, context=None, principal=None) -> Any` | one-shot prepare and async run | same as prepare + `arun` |
+| `run_local_pipeline` | `run_local_pipeline(pipeline, input=None, *, project_root=".", config=None, env="local", llm=None, context=None, principal=None) -> Any` | one-shot prepare and sync run | same as prepare + `run` |
+| `LocalPipelineError` | subclass of `JulepError` | base class for configured foreground failures | n/a |
+| `LocalPipelineNotFound` | `LocalPipelineNotFound(kind, name, available)` | typed unknown environment/pipeline error with `.kind`, `.name`, and `.available` | n/a |
+| `LocalExecutionConfigurationError` | subclass of `LocalPipelineError` | missing/mismatched LLM, MCP, registry, or sync-loop configuration | n/a |
+| `LocalExecutionUnsupported` | subclass of `LocalPipelineError` | direct-foreground artifact requires a runtime-owned orchestration boundary | n/a |
+
+An explicit `llm=` takes precedence over `context.llm`; it uses the canonical
+five-argument `LlmCaller`. Tool-calling agents require the optional `tools=`
+keyword extension. `WorkerContext` supplies MCP calls plus QoS and registry
+hooks, while `principal` is forwarded to both LLM and MCP calls. A differing
+reasoner declaration in `context.registry` is rejected rather than overriding
+the compiled artifact.
+
+Direct foreground execution rejects session `LOOP`, transcript-scoped `APP`
+agents, staged plans, subflows, and human-gate/sleep/recv/emit reserved effects.
+It also has no run-secret input; use the local API or durable worker when the
+runtime must own those boundaries.
+
 ## Control-plane clients
 
 Import the HTTP clients and their typed run errors from `julep.client`. Install
@@ -636,6 +667,8 @@ Environment knobs verified in source:
 | `WORKER_MAX_CONCURRENT_WORKFLOW_TASKS` | worker host | SDK workflow-task slots |
 | `WORKER_HEALTH_PORT` | worker host | probe port serving `/healthz` and `/readyz` |
 | `JULEP_ARTIFACT_STORE_URL` | bundle worker/verification | artifact store URL for bundle resolution |
+| `JULEP_API_KEY` | CLI/client or worker | client/admin token in the invoking shell; `dev up` gives workers only their separate worker-role token under this name |
+| `JULEP_WORKER_API_KEY` | `julep dev up` supervisor | worker-role handoff token; validated against `JULEP_API_KEYS` and never forwarded under this name |
 | `JULEP_BUNDLE_SIGNING_KEY` | bundle publish | signing seed or path |
 | `JULEP_BUNDLE_ALLOWED_SIGNERS` | bundle resolution | comma-separated signer allow-list |
 | `JULEP_BUNDLES` | bundle worker | bundle refs to load from `JULEP_ARTIFACT_STORE_URL` |

--- a/docs-site/content/docs/reference/python-api.md
+++ b/docs-site/content/docs/reference/python-api.md
@@ -534,9 +534,9 @@ CLI entry points:
 | `run` | `julep run <name-or-path.ctx> [--input JSON] [--run-id id] [--env name]` |
 | `deploy` | `julep deploy [selector] [--exclude expr] [--env name]` |
 | `plan` | `julep plan [--env name] [--json] [--mcp-snapshot]` |
-| `apply` | `julep apply --env name [--publish-only] [--mcp-snapshot]` |
+| `apply` | `julep apply --env name [--publish-only] [--mcp-snapshot] [--api-url URL] [--api-key KEY]` |
 | `status` | `julep status [selector] [--exclude expr] [--env name] [--remote] [--api-url URL] [--api-key KEY] [--limit N]` |
-| `serve api` | `julep serve api [--host HOST] [--port PORT] [--migrate]` |
+| `serve api` | `julep serve api [--host HOST] [--port PORT] [--migrate] [--local] [--context-factory module:attr]` |
 | `db migrate` | `julep db migrate [--dsn DSN]` |
 | `db sweep` | `julep db sweep --older-than SECONDS [--dsn DSN]` |
 | `db reencrypt-secrets` | `julep db reencrypt-secrets [--dsn DSN]` |

--- a/docs-site/content/docs/reference/python-api.md
+++ b/docs-site/content/docs/reference/python-api.md
@@ -64,9 +64,14 @@ report optional runtime availability.
 | `server` | FastAPI control plane, Postgres store, SSE, Temporal gateway | `pip install --pre 'julep[server]'` |
 | `dotctx` | rich dotctx prompt packages with Jinja2 | `pip install --pre 'julep[dotctx]'` |
 | `providers` | `any-llm` provider caller | `pip install --pre 'julep[providers]'` |
+| `litellm` | public LiteLLM `LlmCaller` adapter | `pip install --pre 'julep[litellm]'` |
 | `otel`, `langfuse` | projection span export | `pip install --pre 'julep[otel]'` |
 | `store` | artifact store bundle storage/signing helpers | `pip install --pre 'julep[store]'` |
 | `wasm` | wasm-tier bundle-sourced pures | `pip install --pre 'julep[wasm]'` |
+
+The `temporal`, `server`, and development extras accept `temporalio>=1.20`.
+This keeps Julep co-installable with current pydantic-ai stacks that still cap
+the Temporal SDK below 1.21; the minimum-SDK CI lane exercises 1.20 directly.
 
 ## Core enums and constants
 
@@ -127,7 +132,8 @@ flow parameters or JSON captures.
 | `get_pure` | `get_pure(name: str) -> PureFn` | registered pure name | callable | `KeyError` if unknown | `get_pure("prompt")({"summary": "x"})` |
 | `is_registered` | `is_registered(name: str) -> bool` | pure name | bool | none | `is_registered("prompt")` |
 | `diff_pure_hashes` | `diff_pure_hashes(pinned: dict[str,str], registered: dict[str,str]) -> list[dict[str,str|None]]` | pinned and actual hash maps | drift list | none | `diff_pure_hashes({}, {})` |
-| `Reasoner` | `Reasoner(name, model, system="", tools=(), temperature=None, max_rounds=None, is_agent=False, sub_contract=None, context_scope=ContextScope.LOCAL, system_render=None, user_render=None, max_tokens=None, *, reply=_UNSET)` | model-call config; `reply` accepts TypedDict, Pydantic v2 model, or raw schema dict | reasoner config | `TypeError` for unsupported `reply` | `Reasoner("r", "anthropic:claude-haiku-4-5", reply=Reply)` |
+| `Reasoner` | `Reasoner(name, model, system="", tools=(), temperature=None, max_rounds=None, is_agent=False, sub_contract=None, context_scope=ContextScope.LOCAL, system_render=None, user_render=None, max_tokens=None, *, reply=_UNSET, reasoning_effort=None, output_retries=0, require_tool_call=False, response_format=None, prompt_cache=None)` | model-call config; `reply` accepts TypedDict, Pydantic v2 model, or raw schema dict | reasoner config | `TypeError` for unsupported `reply`; `ValueError` for bad cache TTL | `Reasoner("r", "anthropic:claude-haiku-4-5", reply=Reply)` |
+| `Reasoner.replace` | `replace(*, name=_KEEP, model=_KEEP, system=_KEEP, reply=_KEEP, tools=_KEEP, temperature=_KEEP, max_rounds=_KEEP, is_agent=_KEEP, sub_contract=_KEEP, context_scope=_KEEP, system_render=_KEEP, user_render=_KEEP, max_tokens=_KEEP, reasoning_effort=_KEEP, output_retries=_KEEP, require_tool_call=_KEEP, response_format=_KEEP, prompt_cache=_KEEP) -> Reasoner` | immutable copy-with updates; omitted `reply` preserves its materialized schema and explicit `reply=None` clears it | new reasoner | constructor validation for replaced values | `fast = base.replace(model="openai:gpt-5-mini")` |
 | `get_reasoner` | `get_reasoner(name: str) -> Reasoner` | reasoner name | config | `KeyError` if unknown | `get_reasoner("support_reply").model` |
 | `load_dotctx` | `load_dotctx(path: str) -> Reasoner` | dotctx directory | registered reasoner | `FileNotFoundError`, `RuntimeError`, rich-layout import errors | `load_dotctx("reasoners/planner")` |
 | `reasoner_from_settings` | `reasoner_from_settings(settings: dict[str, Any], *, name=None, base_dir=None) -> Reasoner` | settings mapping and optional path | registered reasoner | `ValueError` if no name | `reasoner_from_settings({"name":"r","model":"m"})` |
@@ -135,6 +141,12 @@ flow parameters or JSON captures.
 | `dotctx_flow` | `dotctx_flow(path: str, *, ctx=None) -> Node` | dotctx path | lowered node | same as `load_dotctx` | `dotctx_flow("reasoners/r")` |
 | `CtxPipelineConfig` | `CtxPipelineConfig(name, ctx, lane="default", env={})` | zero-code pipeline declaration | config value | config validation occurs in `load_config` | `CtxPipelineConfig("summary", "prompts/summary.ctx")` |
 | `pipeline_spec_from_ctx` | `pipeline_spec_from_ctx(config, *, root, env_vars=None) -> PipelineSpec` | load dotctx, merge env, and lower with `reasoner_to_flow` | pipeline spec | dotctx/config errors | `pipeline_spec_from_ctx(cfg, root=Path("."))` |
+
+Rich dotctx packages whose `schema.pyi` omits `class Output` emit
+`MissingOutputSchemaWarning`: loading remains compatible, but the returned
+reasoner has no reply schema and model output is not schema-validated. The CLI
+exposes the same condition as `CTX_OUTPUT_SCHEMA_MISSING` during configured
+pipeline lint.
 
 ## `@flow` control helpers
 
@@ -196,6 +208,23 @@ All functions return `Node` unless noted. They do no IO; `freeze(...)`,
 | `is_continuation` | `is_continuation(value: Any) -> bool` | value | bool | none | `is_continuation(continue_with(1))` |
 | `continuation_value` | `continuation_value(value: dict[str, Any]) -> Any` | sentinel dict | wrapped value | `KeyError` if missing key | `continuation_value(continue_with(1))` |
 | `run_chained` | `async run_chained(run_segment, input, *, max_segments=1000) -> Any` | async segment runner and initial input | final non-continuation value | `JulepError` when max segments exhausted | `await run_chained(lambda x: one_segment(x), 0)` |
+
+## Durable dispatch primitives
+
+Import these dispatch-boundary helpers from `julep.dispatch`. They decide how
+work starts; they are not frozen flow IR. Stable ids and batch-window evaluation
+are pure and import without Temporal. Materializing or executing the built-in
+debounce request requires `julep[temporal]`.
+
+| Symbol | Signature | Use | Returns | Raises |
+|---|---|---|---|---|
+| `dedup_workflow_id` | `dedup_workflow_id(namespace: str, *identity: Any, max_length=255) -> str` | opaque deterministic Temporal id for one logical dispatch; canonical finite JSON identity is hashed rather than exposed in listings | bounded workflow id | `TypeError` for non-finite/non-JSON identity; `ValueError` for invalid namespace/limit |
+| `BatchWindow` | `BatchWindow(quiet_s: float, max_items: int | None = None, max_wait_s: float | None = None)` | shared debounce/batch trigger policy | immutable window | `ValueError` for negative, non-finite, or invalid limits |
+| `BatchWindow.evaluate` | `evaluate(*, item_count, opened_at, last_arrival_at, now) -> BatchWindowDecision` | deterministic trigger selection using caller-supplied time | `fire`, `trigger`, `deadline`, `wait_s` | `ValueError` for inconsistent state |
+| `SignalWithStartRequest` | `SignalWithStartRequest(workflow, input, workflow_id, task_queue, signal, signal_args=(), start_options={})` | backend-neutral atomic signal-with-start description with `USE_EXISTING` conflict and `ALLOW_DUPLICATE` reuse policies | request; `await request.start(client)` returns a workflow handle | `ValueError`, missing Temporal extra at execution |
+| `build_debounce_request` | `build_debounce_request(flow_json, manifest_json, *, key, item, window, task_queue="julep", ..., scope=None, workflow_id=None, start_options=None) -> SignalWithStartRequest` | build an atomic keyed collector request; item values join the compatible open collector but are excluded from identity | request | config errors; missing Temporal extra |
+| `dispatch_debounced` | `async dispatch_debounced(client, flow_json, manifest_json, *, key, item, window, ...) -> Any` | build and execute a debounce signal-with-start | Temporal workflow handle | config/Temporal errors |
+| `signal_with_start` | `async signal_with_start(client, request) -> Any` | execute a pre-built request | Temporal workflow handle | Temporal errors |
 
 ## Sessions
 
@@ -291,6 +320,29 @@ keyword calls synthesize a compiler-owned `std.record` node. Capability defaults
 are derived from the resolved frozen tool set when `capabilities` is omitted.
 `InMemoryEnv` also accepts `mcp_call=`, so an MCP-only deployment needs no
 native `tools=` map for local execution.
+
+## Control-plane clients
+
+Import the HTTP clients and their typed run errors from `julep.client`. Install
+`julep[http]` (or `julep[server]`) for httpx. `AsyncJulepClient` mirrors the
+sync client's complete release, run, result, control, and projection-event
+surface and owns an `httpx.AsyncClient` when one is not injected.
+
+| Symbol | Signature | Behavior |
+|---|---|---|
+| `JulepClient` | `JulepClient(base_url=None, api_key=None, *, client: httpx.Client | None = None, timeout=30.0)` | synchronous client; supports context-manager cleanup |
+| `AsyncJulepClient` | `AsyncJulepClient(base_url=None, api_key=None, *, client: httpx.AsyncClient | None = None, timeout=30.0)` | async method parity; supports `async with` and `aclose()` |
+| `run_and_wait` | `run_and_wait(*, pipeline, input=None, release=None, session_id=None, principal=None, secrets=None, queue_lanes=None, idempotency_key=None, run_id=None, deadline_s=300.0, poll_wait_s=20.0) -> Any` | idempotent submit, bounded `GET .../result` long polls, and the unwrapped `result` payload on `completed`; async on `AsyncJulepClient` |
+| `wait_for_run` | `wait_for_run(run_id, *, deadline_s=300.0, poll_wait_s=20.0) -> Any` | wait for an already-submitted run and unwrap success; async on `AsyncJulepClient` |
+| `JulepClientError` | `JulepClientError(status_code, detail)` | non-success HTTP response with parsed `.detail` |
+| `JulepRunFailed` | `JulepRunFailed(run_id, status, error=None)` | typed terminal error for `failed`, `canceled`, `terminated`, or `start_failed`; exposes `.run_id`, `.status`, `.error`, and `.detail` |
+| `JulepRunTimeout` | `JulepRunTimeout(run_id, deadline_s)` | caller deadline expired; exposes `.run_id` and `.deadline_s` |
+| `JulepRunProtocolError` | `JulepRunProtocolError(message, *, run_id)` | malformed or mismatched start/result envelope |
+
+`start_run` and the wait helpers require either `idempotency_key` or `run_id`.
+Reuse of an idempotency key is safe only for the same pipeline and release; a
+different pipeline or release produces an HTTP `409 idempotency_conflict`
+instead of returning an unrelated existing run.
 
 ## MCP authentication
 
@@ -465,7 +517,15 @@ durability.
 | `SpanData` | `SpanData(name, cid, node, start_ts, end_ts, status, parents, error=None, attrs={}, cost=None, value_ref=None, planned_event_id=None, terminal_event_id=None)` | OTel-ready span data | span record | none | `to_otel_spans(store.events())` |
 | `to_otel_spans` | `to_otel_spans(events: list[ProjectionEvent]) -> list[SpanData]` | projection events | span data | none | `to_otel_spans(store.events())` |
 
+Cost is reported only when an effect supplies an actual cost. Model spans that
+carry model or usage metadata without a price have `cost=None` and render as
+`cost=unknown`; Julep does not substitute a synthetic dollar estimate.
+
 ## Provider resilience and QoS
+
+The LiteLLM helpers below live in `julep.llm`; installing `julep[litellm]` is
+needed only when `litellm_caller()` imports its default backend. Injecting
+`acompletion=` keeps unit tests provider-free.
 
 | Symbol | Signature | Parameters | Returns | Raises | Example |
 |---|---|---|---|---|---|
@@ -481,6 +541,9 @@ durability.
 | `make_llm_caller` | `make_llm_caller(*, default_provider="anthropic", acompletion=None) -> Callable[..., Awaitable[Any]]` | provider and optional test completion fn | worker `LlmCaller` | lazy `ImportError`, provider errors | `WorkerContext(llm=make_llm_caller())` |
 | `make_local_reasoner` | `make_local_reasoner(*, default_provider="anthropic", acompletion=None) -> Callable[[str, Any], Awaitable[Any]]` | provider/test seam | facade `llm` callable | lazy `ImportError`, provider errors | `Agent("anthropic:m", llm=make_local_reasoner())` |
 | `make_resilient_llm_caller` | `make_resilient_llm_caller(*, policy, breaker=None, on_attempt=None, classifier=classify_error, default_provider="anthropic", acompletion=None, sleep=asyncio.sleep) -> Callable[..., Awaitable[Any]]` | fallback policy and hooks | resilient `LlmCaller` | `ResilienceExhausted`, config/provider errors | `make_resilient_llm_caller(policy=ResiliencePolicy())` |
+| `prepare_litellm_payload` | `prepare_litellm_payload(payload: Mapping[str, Any]) -> dict[str, Any]` | pure translation of Julep model slugs and reasoning controls, including Fireworks, OpenRouter, Anthropic, and GPT-5 provider requirements | LiteLLM request mapping | malformed consumer data may raise normal mapping/value errors | `prepare_litellm_payload({"model":"openai:gpt-5@low"})` |
+| `litellm_caller` | `litellm_caller(*, request_timeout_s=None, acompletion=None) -> LlmCaller` | canonical five-argument worker caller backed by LiteLLM | async caller | lazy `ImportError`, provider errors | `WorkerContext(llm=litellm_caller())` |
+| `with_model_ladder` | `with_model_ladder(caller, *, models: Sequence[str], classify=classify_error, on_attempt=None) -> LlmCaller` | primary reasoner model followed by stable de-duplicated fallbacks; advances only on transient/timeout failures and records attempt provenance on `LlmResult` | wrapped caller | non-transient original error or `ResilienceExhausted` | `llm = with_model_ladder(litellm_caller(), models=["openai:gpt-5-mini"])` |
 
 ## Errors and exceptions
 
@@ -536,6 +599,8 @@ CLI entry points:
 | `plan` | `julep plan [--env name] [--json] [--mcp-snapshot]` |
 | `apply` | `julep apply --env name [--publish-only] [--mcp-snapshot] [--api-url URL] [--api-key KEY]` |
 | `status` | `julep status [selector] [--exclude expr] [--env name] [--remote] [--api-url URL] [--api-key KEY] [--limit N]` |
+| `keygen` | `julep keygen [--format env|json] [--output PATH] [--force]` |
+| `dev up` | `julep dev up [--env name] [--api-url URL] [--api-key KEY] [--start-temporal/--no-start-temporal] [--publish/--no-publish] [--worker/--no-worker] [--startup-timeout SECONDS] [--dry-run]` |
 | `serve api` | `julep serve api [--host HOST] [--port PORT] [--migrate] [--local] [--context-factory module:attr]` |
 | `db migrate` | `julep db migrate [--dsn DSN]` |
 | `db sweep` | `julep db sweep --older-than SECONDS [--dsn DSN]` |

--- a/docs-site/content/docs/reference/python-api.md
+++ b/docs-site/content/docs/reference/python-api.md
@@ -135,12 +135,12 @@ flow parameters or JSON captures.
 | `Reasoner` | `Reasoner(name, model, system="", tools=(), temperature=None, max_rounds=None, is_agent=False, sub_contract=None, context_scope=ContextScope.LOCAL, system_render=None, user_render=None, max_tokens=None, *, reply=_UNSET, reasoning_effort=None, output_retries=0, require_tool_call=False, response_format=None, prompt_cache=None)` | model-call config; `reply` accepts TypedDict, Pydantic v2 model, or raw schema dict | reasoner config | `TypeError` for unsupported `reply`; `ValueError` for bad cache TTL | `Reasoner("r", "anthropic:claude-haiku-4-5", reply=Reply)` |
 | `Reasoner.replace` | `replace(*, name=_KEEP, model=_KEEP, system=_KEEP, reply=_KEEP, tools=_KEEP, temperature=_KEEP, max_rounds=_KEEP, is_agent=_KEEP, sub_contract=_KEEP, context_scope=_KEEP, system_render=_KEEP, user_render=_KEEP, max_tokens=_KEEP, reasoning_effort=_KEEP, output_retries=_KEEP, require_tool_call=_KEEP, response_format=_KEEP, prompt_cache=_KEEP) -> Reasoner` | immutable copy-with updates; omitted `reply` preserves its materialized schema and explicit `reply=None` clears it | new reasoner | constructor validation for replaced values | `fast = base.replace(model="openai:gpt-5-mini")` |
 | `get_reasoner` | `get_reasoner(name: str) -> Reasoner` | reasoner name | config | `KeyError` if unknown | `get_reasoner("support_reply").model` |
-| `load_dotctx` | `load_dotctx(path: str) -> Reasoner` | dotctx directory | registered reasoner | `FileNotFoundError`, `RuntimeError`, rich-layout import errors | `load_dotctx("reasoners/planner")` |
+| `load_dotctx` | `load_dotctx(path: str, *, env=None) -> Reasoner` | dotctx directory or file and explicit render environment | registered reasoner | `FileNotFoundError`, `RuntimeError`, rich-layout import errors | `load_dotctx("reasoners/planner")` |
 | `reasoner_from_settings` | `reasoner_from_settings(settings: dict[str, Any], *, name=None, base_dir=None) -> Reasoner` | settings mapping and optional path | registered reasoner | `ValueError` if no name | `reasoner_from_settings({"name":"r","model":"m"})` |
 | `reasoner_to_flow` | `reasoner_to_flow(reasoner: Reasoner, *, ctx=None) -> Node` | reasoner and optional context | `think`, `iter_up_to`, `app`, or `sub` node | none | `reasoner_to_flow(get_reasoner("r"))` |
 | `dotctx_flow` | `dotctx_flow(path: str, *, ctx=None) -> Node` | dotctx path | lowered node | same as `load_dotctx` | `dotctx_flow("reasoners/r")` |
 | `CtxPipelineConfig` | `CtxPipelineConfig(name, ctx, lane="default", env={})` | zero-code pipeline declaration | config value | config validation occurs in `load_config` | `CtxPipelineConfig("summary", "prompts/summary.ctx")` |
-| `pipeline_spec_from_ctx` | `pipeline_spec_from_ctx(config, *, root, env_vars=None) -> PipelineSpec` | load dotctx, merge env, and lower with `reasoner_to_flow` | pipeline spec | dotctx/config errors | `pipeline_spec_from_ctx(cfg, root=Path("."))` |
+| `pipeline_spec_from_ctx` | `pipeline_spec_from_ctx(config, *, root, env_vars=None, agent_round_cap=32, mcp_servers=None) -> PipelineSpec` | load dotctx, merge env, bind configured MCP servers, and lower with `reasoner_to_flow` | pipeline spec | dotctx/config errors | `pipeline_spec_from_ctx(cfg, root=Path("."))` |
 
 Rich dotctx packages whose `schema.pyi` omits `class Output` emit
 `MissingOutputSchemaWarning`: loading remains compatible, but the returned
@@ -374,6 +374,11 @@ surface and owns an `httpx.AsyncClient` when one is not injected.
 Reuse of an idempotency key is safe only for the same pipeline and release; a
 different pipeline or release produces an HTTP `409 idempotency_conflict`
 instead of returning an unrelated existing run.
+
+`run_and_wait` intentionally exposes the ordinary client submission contract.
+The admin-only `mcp_preflight` override remains on `start_run` and
+`start_and_wait`; use the latter when an operator explicitly needs that
+override plus a bounded wait.
 
 ## MCP authentication
 

--- a/julep/__init__.py
+++ b/julep/__init__.py
@@ -306,6 +306,16 @@ from .execution import (
     WorkerContext as WorkerContext,
     interpret as interpret,
 )
+from .local import (
+    LocalExecutionConfigurationError as LocalExecutionConfigurationError,
+    LocalExecutionUnsupported as LocalExecutionUnsupported,
+    LocalPipeline as LocalPipeline,
+    LocalPipelineError as LocalPipelineError,
+    LocalPipelineNotFound as LocalPipelineNotFound,
+    arun_local_pipeline as arun_local_pipeline,
+    prepare_local_pipeline as prepare_local_pipeline,
+    run_local_pipeline as run_local_pipeline,
+)
 
 
 class _CallableApplicationModule(_ModuleType):
@@ -387,6 +397,10 @@ _BASE_EXPORTS = [
     # execution (pure)
     "Env", "ExecutionPolicy", "InMemoryEnv", "Result", "RunPrincipal", "WorkerContext", "interpret",
     "HAVE_DBOS", "HAVE_TEMPORAL",
+    # foreground configured execution
+    "LocalPipeline", "LocalPipelineError", "LocalPipelineNotFound",
+    "LocalExecutionConfigurationError", "LocalExecutionUnsupported",
+    "prepare_local_pipeline", "run_local_pipeline", "arun_local_pipeline",
     "__version__",
 ]
 

--- a/julep/agent_loop.py
+++ b/julep/agent_loop.py
@@ -605,15 +605,23 @@ def charge_tool_call(
     state: AgentState,
     tool: str,
     contracts: Optional[AgentContractMap],
+    *,
+    count_key: Optional[str] = None,
 ) -> Optional[CallDenial]:
-    """Increment the deterministic per-tool call counter, or return a denial."""
+    """Increment one deterministic tool budget counter, or return a denial.
+
+    ``tool`` is the provider-visible name used for contracts and diagnostics.
+    ``count_key`` is its canonical capability identity when multiple provider
+    aliases dispatch to the same wire tool.
+    """
     limit = max_calls_for_tool(tool, contracts)
     if limit is None:
         return None
-    count = state.call_counts.get(tool, 0)
+    key = tool if count_key is None else count_key
+    count = state.call_counts.get(key, 0)
     if count >= limit:
         return CallDenial(reason=f"tool {tool!r} exceeded maxCalls={limit}")
-    state.call_counts[tool] = count + 1
+    state.call_counts[key] = count + 1
     return None
 
 
@@ -669,12 +677,16 @@ def manifest_contracts_for_agent(
 
 def max_call_limits_from_contracts(
     contracts: Optional[dict[str, dict[str, Any]]],
+    tool_aliases: Optional[Mapping[str, str]] = None,
 ) -> Optional[dict[str, int]]:
+    """Extract limits, optionally canonicalized to wire-tool identities."""
     limits: dict[str, int] = {}
     for tool, raw in (contracts or {}).items():
         limit = raw.get("maxCalls", raw.get("max_calls"))
         if limit is not None:
-            limits[tool] = int(limit)
+            key = (tool_aliases or {}).get(tool, tool)
+            value = int(limit)
+            limits[key] = min(limits.get(key, value), value)
     return limits or None
 
 
@@ -688,6 +700,7 @@ async def drive_agent_loop(
     granted: Optional[set[str]] = None,
     granted_subflows: Optional[set[str]] = None,
     contracts: Optional[AgentContractMap] = None,
+    tool_count_keys: Optional[Mapping[str, str]] = None,
     tool_schemas: Optional[Mapping[str, dict[str, Any]]] = None,
     state: Optional[AgentState] = None,
     get_pure: Optional[Callable[[str], Callable[..., Any]]] = None,
@@ -701,7 +714,8 @@ async def drive_agent_loop(
     step = controller_turn(
         cfg=cfg, invoke_controller=invoke_controller, call_tool=call_tool,
         run_subflow=run_subflow, granted=granted, granted_subflows=granted_subflows,
-        contracts=contracts, mode=mode, prod_gap=prod_gap, run_input=input,
+        contracts=contracts, tool_count_keys=tool_count_keys, mode=mode,
+        prod_gap=prod_gap, run_input=input,
         get_pure=get_pure, tool_schemas=tool_schemas,
     )
     return await drive(step, state, halt=pre_round(cfg), finalize=make_finalize(prod_gap))

--- a/julep/cli/dev.py
+++ b/julep/cli/dev.py
@@ -1,0 +1,391 @@
+"""One-command supervisor for Julep's durable local development stack."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional, Protocol
+from urllib.parse import urlsplit
+
+from julep.cli.config import EnvConfig, JulepConfig
+
+
+class DevStackError(RuntimeError):
+    """The durable local stack is misconfigured or a child process failed."""
+
+
+@dataclass(frozen=True)
+class DevCommand:
+    name: str
+    argv: tuple[str, ...]
+    environment: Mapping[str, str] = field(default_factory=dict, repr=False)
+
+
+@dataclass(frozen=True)
+class DevStackPlan:
+    root: Path
+    env_name: str
+    api_url: str
+    api_key: str = field(repr=False)
+    temporal_address: str
+    temporal: Optional[DevCommand]
+    api: DevCommand
+    worker: DevCommand
+    publish_release: bool = True
+    start_workers: bool = True
+    startup_timeout_s: float = 30.0
+
+
+class ChildProcess(Protocol):
+    def poll(self) -> Optional[int]: ...
+    def terminate(self) -> None: ...
+    def kill(self) -> None: ...
+    def wait(self, timeout: Optional[float] = None) -> int: ...
+
+
+PopenFactory = Callable[..., ChildProcess]
+ReleasePublisher = Callable[[DevStackPlan], tuple[tuple[str, str], ...]]
+
+
+def _server_endpoint(api_url: str) -> tuple[str, int]:
+    parsed = urlsplit(api_url)
+    if parsed.scheme != "http" or not parsed.hostname:
+        raise DevStackError("julep dev up requires an http:// API URL with a host")
+    if parsed.path not in ("", "/") or parsed.query or parsed.fragment:
+        raise DevStackError("julep dev up API URL must not contain a path, query, or fragment")
+    return parsed.hostname, parsed.port or 80
+
+
+def _temporal_endpoint(address: str) -> tuple[str, int]:
+    raw = address.removeprefix("http://").removeprefix("https://")
+    host, separator, port_text = raw.rpartition(":")
+    if not separator or not host:
+        raise DevStackError("TEMPORAL_ADDRESS must use host:port for julep dev up")
+    try:
+        port = int(port_text)
+    except ValueError as exc:
+        raise DevStackError("TEMPORAL_ADDRESS port must be an integer") from exc
+    if not 1 <= port <= 65535:
+        raise DevStackError("TEMPORAL_ADDRESS port must be between 1 and 65535")
+    return host, port
+
+
+def build_dev_stack_plan(
+    cfg: JulepConfig,
+    env: EnvConfig,
+    *,
+    api_url: str,
+    api_key: str,
+    source_env: Mapping[str, str],
+    start_temporal: bool = True,
+    publish_release: bool = True,
+    start_workers: bool = True,
+    startup_timeout_s: float = 30.0,
+    python: str = sys.executable,
+) -> DevStackPlan:
+    """Validate configuration and construct the exact supervised commands."""
+
+    if startup_timeout_s <= 0:
+        raise DevStackError("startup timeout must be positive")
+    if start_workers and not publish_release:
+        raise DevStackError("workers require release publication; also pass --no-worker")
+    if not api_key.strip():
+        raise DevStackError("--api-key or JULEP_API_KEY is required")
+    if env.release_store is None:
+        raise DevStackError(f"env {env.name!r} requires release_store")
+    host, port = _server_endpoint(api_url)
+    if host not in {"127.0.0.1", "localhost", "::1"}:
+        raise DevStackError("julep dev up only supervises a loopback API")
+
+    effective = dict(source_env)
+    # JULEP_API_KEY is a client credential, not server configuration. Keep it
+    # out of child environments so worker secret resolution never receives an
+    # admin token by accident. A separately generated worker-role token is
+    # installed below only for the worker processes.
+    worker_api_key = effective.pop("JULEP_WORKER_API_KEY", None)
+    effective.pop("JULEP_API_KEY", None)
+    effective.pop("JULEP_API_URL", None)
+    effective["JULEP_ARTIFACT_STORE_URL"] = env.release_store
+    effective["JULEP_SERVER_HOST"] = host
+    effective["JULEP_SERVER_PORT"] = str(port)
+    temporal_address = env.temporal_address or effective.get("TEMPORAL_ADDRESS") or "localhost:7233"
+    effective["TEMPORAL_ADDRESS"] = temporal_address
+    effective["TEMPORAL_NAMESPACE"] = env.temporal_namespace
+
+    context_factory = env.worker_context_factory or effective.get("WORKER_CONTEXT_FACTORY")
+    if not context_factory:
+        raise DevStackError(
+            "durable local workers require WORKER_CONTEXT_FACTORY or "
+            f"env.{env.name}.worker_context_factory"
+        )
+    effective["WORKER_CONTEXT_FACTORY"] = context_factory
+
+    try:
+        from julep.server.auth import KeyRing
+        from julep.server.settings import ServerSettings
+
+        settings = ServerSettings.from_env(effective, root=cfg.root)
+    except (ImportError, ValueError) as exc:
+        raise DevStackError(str(exc)) from exc
+    if settings.execution_store_dsn is None:
+        raise DevStackError("JULEP_EXECUTION_STORE_DSN is required")
+    keyring = KeyRing(settings.api_keys)
+    authenticated = keyring.authenticate(api_key)
+    if authenticated is None or authenticated.role != "admin":
+        raise DevStackError("the dev API key must match an admin entry in JULEP_API_KEYS")
+    if worker_api_key:
+        worker_identity = keyring.authenticate(worker_api_key)
+        if worker_identity is None or worker_identity.role != "worker":
+            raise DevStackError("JULEP_WORKER_API_KEY must match a worker entry in JULEP_API_KEYS")
+    if settings.payload_encryption_required and settings.payload_keys is None:
+        raise DevStackError("durable dev requires Temporal payload encryption keys")
+
+    temporal_host, temporal_port = _temporal_endpoint(temporal_address)
+    temporal: Optional[DevCommand] = None
+    if start_temporal:
+        if temporal_host not in {"127.0.0.1", "localhost", "::1"}:
+            raise DevStackError("--start-temporal requires a loopback TEMPORAL_ADDRESS")
+        temporal = DevCommand(
+            "temporal",
+            (
+                "temporal",
+                "server",
+                "start-dev",
+                "--headless",
+                "--port",
+                str(temporal_port),
+            ),
+            effective,
+        )
+
+    base = (python, "-m", "julep.cli.main")
+    api_environment = dict(effective)
+    worker_environment = dict(effective)
+    if worker_api_key:
+        worker_environment["JULEP_API_URL"] = api_url
+        worker_environment["JULEP_API_KEY"] = worker_api_key
+    api = DevCommand(
+        "api",
+        (*base, "serve", "api", "--migrate", "--host", host, "--port", str(port)),
+        api_environment,
+    )
+    worker = DevCommand("worker", (*base, "worker"), worker_environment)
+    return DevStackPlan(
+        root=cfg.root,
+        env_name=env.name,
+        api_url=api_url,
+        api_key=api_key,
+        temporal_address=temporal_address,
+        temporal=temporal,
+        api=api,
+        worker=worker,
+        publish_release=publish_release,
+        start_workers=start_workers,
+        startup_timeout_s=startup_timeout_s,
+    )
+
+
+def render_dev_stack_plan(plan: DevStackPlan) -> str:
+    """Human-readable command plan with credentials redacted."""
+
+    commands = [item for item in (plan.temporal, plan.api) if item is not None]
+    lines = [f"{item.name:8} {' '.join(item.argv)}" for item in commands]
+    if plan.publish_release:
+        lines.append(f"publish  env={plan.env_name} publish-only register={plan.api_url}")
+    if plan.start_workers:
+        lines.append(f"worker   {' '.join(plan.worker.argv)}  # one per published queue")
+    return "\n".join(lines) + "\n"
+
+
+def _publish_and_register(plan: DevStackPlan) -> tuple[tuple[str, str], ...]:
+    """Publish once through Python APIs, register, and return exact queue names."""
+
+    from julep.cli.application import (
+        apply_configured_application,
+        release_queue_lines,
+    )
+    from julep.cli.config import load_config
+    from julep.client import JulepClient
+
+    with _temporary_environment(plan.api.environment):
+        cfg = load_config(plan.root)
+        if plan.env_name not in cfg.envs:
+            raise DevStackError(f"unknown env {plan.env_name!r}")
+        release, _lanes = apply_configured_application(
+            cfg,
+            cfg.envs[plan.env_name],
+            publish_only=True,
+        )
+        client = JulepClient(plan.api_url, plan.api_key)
+        try:
+            client.publish_release(release.manifest_bytes)
+        finally:
+            client.close()
+    queues = tuple(release_queue_lines(release))
+    if not queues:
+        raise DevStackError("published release contains no lane queues")
+    print(f"release   {release.release_hash}")
+    print(f"artifact  {release.application_artifact_hash}")
+    for lane, queue in queues:
+        print(f"queue     {lane:24} {queue}")
+    print(f"registered {release.release_hash}")
+    print("traffic   unchanged")
+    return queues
+
+
+@contextmanager
+def _temporary_environment(values: Mapping[str, str]) -> Iterator[None]:
+    previous = dict(os.environ)
+    os.environ.clear()
+    os.environ.update(values)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(previous)
+
+
+def _wait_for_tcp(
+    address: str,
+    *,
+    timeout_s: float,
+    child: Optional[ChildProcess],
+) -> None:
+    host, port = _temporal_endpoint(address)
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if child is not None and child.poll() is not None:
+            raise DevStackError("Temporal dev server exited before becoming ready")
+        try:
+            with socket.create_connection((host, port), timeout=0.25):
+                return
+        except OSError:
+            time.sleep(0.1)
+    raise DevStackError(f"Temporal did not become ready at {address} within {timeout_s:g}s")
+
+
+def _wait_for_api(
+    api_url: str,
+    api_key: str,
+    *,
+    timeout_s: float,
+    child: ChildProcess,
+) -> None:
+    deadline = time.monotonic() + timeout_s
+    request = urllib.request.Request(
+        f"{api_url.rstrip('/')}/v1/ready",
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+    while time.monotonic() < deadline:
+        if child.poll() is not None:
+            raise DevStackError("Julep API exited before becoming ready")
+        try:
+            with urllib.request.urlopen(request, timeout=0.5) as response:  # noqa: S310
+                if response.status == 200:
+                    return
+        except (OSError, urllib.error.HTTPError, urllib.error.URLError):
+            time.sleep(0.1)
+    raise DevStackError(f"Julep API did not become ready within {timeout_s:g}s")
+
+
+def _stop_children(children: Sequence[tuple[str, ChildProcess]]) -> None:
+    for _name, child in reversed(children):
+        if child.poll() is None:
+            child.terminate()
+    for _name, child in reversed(children):
+        if child.poll() is not None:
+            continue
+        try:
+            child.wait(timeout=5.0)
+        except subprocess.TimeoutExpired:
+            child.kill()
+            child.wait(timeout=5.0)
+
+
+def run_dev_stack(
+    plan: DevStackPlan,
+    *,
+    popen: PopenFactory = subprocess.Popen,
+    publish: ReleasePublisher = _publish_and_register,
+    wait_temporal: Callable[..., None] = _wait_for_tcp,
+    wait_api: Callable[..., None] = _wait_for_api,
+    poll_interval_s: float = 0.25,
+) -> None:
+    """Run the plan in the foreground and tear down every child on exit."""
+
+    if plan.temporal is not None and shutil.which(plan.temporal.argv[0]) is None:
+        raise DevStackError(
+            "temporal CLI was not found on PATH; install it or pass --no-start-temporal"
+        )
+    children: list[tuple[str, ChildProcess]] = []
+
+    def start(command: DevCommand, *, extra: Optional[Mapping[str, str]] = None) -> ChildProcess:
+        environment = dict(command.environment)
+        if extra:
+            environment.update(extra)
+        child = popen(command.argv, cwd=plan.root, env=environment)
+        children.append((command.name, child))
+        return child
+
+    try:
+        temporal_child: Optional[ChildProcess] = None
+        if plan.temporal is not None:
+            temporal_child = start(plan.temporal)
+        wait_temporal(
+            plan.temporal_address,
+            timeout_s=plan.startup_timeout_s,
+            child=temporal_child,
+        )
+
+        api_child = start(plan.api)
+        wait_api(
+            plan.api_url,
+            plan.api_key,
+            timeout_s=plan.startup_timeout_s,
+            child=api_child,
+        )
+        queues = publish(plan) if plan.publish_release else ()
+        if plan.start_workers:
+            for lane, queue in queues:
+                start(
+                    DevCommand(
+                        f"worker:{lane}",
+                        plan.worker.argv,
+                        plan.worker.environment,
+                    ),
+                    extra={"TEMPORAL_TASK_QUEUE": queue},
+                )
+        print(
+            f"Julep durable dev stack ready: {plan.api_url} "
+            f"({len(queues)} worker{'s' if len(queues) != 1 else ''})"
+        )
+        while True:
+            for name, child in children:
+                returncode = child.poll()
+                if returncode is not None:
+                    raise DevStackError(f"{name} exited with status {returncode}")
+            time.sleep(poll_interval_s)
+    except KeyboardInterrupt:
+        return
+    finally:
+        _stop_children(children)
+
+
+__all__ = [
+    "DevCommand",
+    "DevStackError",
+    "DevStackPlan",
+    "build_dev_stack_plan",
+    "render_dev_stack_plan",
+    "run_dev_stack",
+]

--- a/julep/cli/dev.py
+++ b/julep/cli/dev.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import os
+import signal
 import shutil
 import socket
 import subprocess
 import sys
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -56,6 +58,129 @@ class ChildProcess(Protocol):
 
 PopenFactory = Callable[..., ChildProcess]
 ReleasePublisher = Callable[[DevStackPlan], tuple[tuple[str, str], ...]]
+
+
+_RUNTIME_ENV_NAMES = frozenset(
+    {
+        "CURL_CA_BUNDLE",
+        "HOME",
+        "HTTPS_PROXY",
+        "HTTP_PROXY",
+        "LANG",
+        "LOGNAME",
+        "NO_PROXY",
+        "PATH",
+        "PATHEXT",
+        "PYTHONPATH",
+        "PYTHONUTF8",
+        "PYTHONIOENCODING",
+        "REQUESTS_CA_BUNDLE",
+        "SSL_CERT_DIR",
+        "SSL_CERT_FILE",
+        "SYSTEMROOT",
+        "TEMP",
+        "TMP",
+        "TMPDIR",
+        "TZ",
+        "USER",
+        "VIRTUAL_ENV",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+    }
+)
+_API_ENV_NAMES = frozenset(
+    {
+        "JULEP_API_KEYS",
+        "JULEP_ARTIFACT_STORE_URL",
+        "JULEP_BUNDLE_ALLOWED_SIGNERS",
+        "JULEP_EXECUTION_STORE_DSN",
+        "JULEP_PROJECTION_BATCH_INTERVAL_S",
+        "JULEP_PROJECTION_BATCH_SIZE",
+        "JULEP_SERVER_HELM_CHART",
+        "JULEP_SERVER_HOST",
+        "JULEP_SERVER_KUBERNETES_NAMESPACE",
+        "JULEP_SERVER_PORT",
+        "JULEP_SERVER_RECONCILE_INTERVAL_S",
+        "JULEP_VAULT_KEY_ID",
+        "JULEP_VAULT_KEYS",
+        "JULEP_WORKER_SECRET_ALLOWLIST",
+        "TEMPORAL_ADDRESS",
+        "TEMPORAL_API_KEY",
+        "TEMPORAL_NAMESPACE",
+        "TEMPORAL_PAYLOAD_ENCRYPTION_REQUIRED",
+        "TEMPORAL_PAYLOAD_KEY_ID",
+        "TEMPORAL_PAYLOAD_KEYS",
+        "TEMPORAL_TLS",
+    }
+)
+_WORKER_ENV_NAMES = frozenset(
+    {
+        "JULEP_ARTIFACT_STORE_URL",
+        "JULEP_BUNDLE_ALLOWED_SIGNERS",
+        "JULEP_EXECUTION_STORE_DSN",
+        "JULEP_REDACTION",
+        "JULEP_WORKER_BUILD_ID",
+        "JULEP_WORKER_VERSIONING",
+        "TEMPORAL_ADDRESS",
+        "TEMPORAL_API_KEY",
+        "TEMPORAL_NAMESPACE",
+        "TEMPORAL_PAYLOAD_ENCRYPTION_REQUIRED",
+        "TEMPORAL_PAYLOAD_KEY_ID",
+        "TEMPORAL_PAYLOAD_KEYS",
+        "TEMPORAL_TLS",
+        "WORKER_APPLICATION",
+        "WORKER_CONTEXT_FACTORY",
+        "WORKER_GRACEFUL_SHUTDOWN_S",
+        "WORKER_HEALTH_PORT",
+        "WORKER_MAX_CONCURRENT_ACTIVITIES",
+        "WORKER_MAX_CONCURRENT_WORKFLOW_TASKS",
+        "WORKER_RUNTIME_DECLARATIONS_HASH",
+    }
+)
+_PUBLICATION_ENV_NAMES = frozenset(
+    {
+        "JULEP_ARTIFACT_STORE_URL",
+        "JULEP_BUNDLE_SIGNING_KEY",
+    }
+)
+
+
+def _selected_environment(
+    source: Mapping[str, str],
+    names: frozenset[str] = frozenset(),
+) -> dict[str, str]:
+    """Copy only role-owned configuration plus non-secret process plumbing."""
+
+    selected = {
+        name: value
+        for name, value in source.items()
+        if name in _RUNTIME_ENV_NAMES or name.startswith("LC_") or name in names
+    }
+    return selected
+
+
+class _TerminationRequested(BaseException):
+    """Internal control flow used to clean up children on SIGTERM."""
+
+
+@contextmanager
+def _sigterm_as_exception() -> Iterator[None]:
+    """Turn SIGTERM into normal supervisor unwinding on the main thread."""
+
+    if threading.current_thread() is not threading.main_thread():
+        yield
+        return
+    previous = signal.getsignal(signal.SIGTERM)
+
+    def terminate(_signum: int, _frame: object) -> None:
+        raise _TerminationRequested
+
+    signal.signal(signal.SIGTERM, terminate)
+    try:
+        yield
+    finally:
+        signal.signal(signal.SIGTERM, previous)
 
 
 def _server_endpoint(api_url: str) -> tuple[str, int]:
@@ -108,6 +233,10 @@ def build_dev_stack_plan(
     if host not in {"127.0.0.1", "localhost", "::1"}:
         raise DevStackError("julep dev up only supervises a loopback API")
 
+    # The caller's ambient environment is used for validation, but is not
+    # wholesale inherited by children. Provider credentials belong in the
+    # selected environment's worker_environment table and are handed only to
+    # workers below.
     effective = dict(source_env)
     # JULEP_API_KEY is a client credential, not server configuration. Keep it
     # out of child environments so worker secret resolution never receives an
@@ -155,27 +284,28 @@ def build_dev_stack_plan(
     # Split generated credentials by process. Workers need the shared payload
     # codec and a worker-role API token, but never the server's static keyring,
     # vault decryption key, or bundle-signing private key.
-    publication_environment = dict(effective)
-    api_environment = dict(effective)
-    api_environment.pop("JULEP_BUNDLE_SIGNING_KEY", None)
-    worker_environment = dict(effective)
+    publication_environment = _selected_environment(
+        effective,
+        _PUBLICATION_ENV_NAMES,
+    )
+    api_environment = _selected_environment(effective, _API_ENV_NAMES)
+    worker_environment = _selected_environment(effective, _WORKER_ENV_NAMES)
+    worker_environment.update(env.worker_environment)
     for server_only in (
         "JULEP_API_KEYS",
         "JULEP_VAULT_KEYS",
         "JULEP_VAULT_KEY_ID",
         "JULEP_BUNDLE_SIGNING_KEY",
+        "JULEP_API_KEY",
+        "JULEP_API_URL",
+        "JULEP_WORKER_API_KEY",
     ):
         worker_environment.pop(server_only, None)
     if worker_api_key:
         worker_environment["JULEP_API_URL"] = api_url
         worker_environment["JULEP_API_KEY"] = worker_api_key
 
-    temporal_environment = dict(worker_environment)
-    temporal_environment.pop("JULEP_API_URL", None)
-    temporal_environment.pop("JULEP_API_KEY", None)
-    temporal_environment.pop("JULEP_BUNDLE_ALLOWED_SIGNERS", None)
-    temporal_environment.pop("TEMPORAL_PAYLOAD_KEYS", None)
-    temporal_environment.pop("TEMPORAL_PAYLOAD_KEY_ID", None)
+    temporal_environment = _selected_environment(effective)
 
     temporal: Optional[DevCommand] = None
     if start_temporal:
@@ -322,16 +452,31 @@ def _wait_for_api(
 
 def _stop_children(children: Sequence[tuple[str, ChildProcess]]) -> None:
     for _name, child in reversed(children):
-        if child.poll() is None:
-            child.terminate()
+        try:
+            if child.poll() is None:
+                child.terminate()
+        except Exception:  # noqa: BLE001 - continue cleaning the remaining children.
+            pass
     for _name, child in reversed(children):
-        if child.poll() is not None:
+        try:
+            running = child.poll() is None
+        except Exception:  # noqa: BLE001 - make a best-effort kill below.
+            running = True
+        if not running:
             continue
         try:
             child.wait(timeout=5.0)
         except subprocess.TimeoutExpired:
-            child.kill()
-            child.wait(timeout=5.0)
+            try:
+                child.kill()
+                child.wait(timeout=5.0)
+            except Exception:  # noqa: BLE001 - no remaining cleanup avenue.
+                pass
+        except Exception:  # noqa: BLE001 - continue cleaning the remaining children.
+            try:
+                child.kill()
+            except Exception:  # noqa: BLE001 - no remaining cleanup avenue.
+                pass
 
 
 def run_dev_stack(
@@ -360,44 +505,52 @@ def run_dev_stack(
         return child
 
     try:
-        temporal_child: Optional[ChildProcess] = None
-        if plan.temporal is not None:
-            temporal_child = start(plan.temporal)
-        wait_temporal(
-            plan.temporal_address,
-            timeout_s=plan.startup_timeout_s,
-            child=temporal_child,
-        )
+        with _sigterm_as_exception():
+            temporal_child: Optional[ChildProcess] = None
+            if plan.temporal is not None:
+                temporal_child = start(plan.temporal)
+            wait_temporal(
+                plan.temporal_address,
+                timeout_s=plan.startup_timeout_s,
+                child=temporal_child,
+            )
 
-        api_child = start(plan.api)
-        wait_api(
-            plan.api_url,
-            plan.api_key,
-            timeout_s=plan.startup_timeout_s,
-            child=api_child,
-        )
-        queues = publish(plan) if plan.publish_release else ()
-        if plan.start_workers:
-            for lane, queue in queues:
-                start(
-                    DevCommand(
-                        f"worker:{lane}",
-                        plan.worker.argv,
-                        plan.worker.environment,
-                    ),
-                    extra={"TEMPORAL_TASK_QUEUE": queue},
-                )
-        print(
-            f"Julep durable dev stack ready: {plan.api_url} "
-            f"({len(queues)} worker{'s' if len(queues) != 1 else ''})"
-        )
-        while True:
-            for name, child in children:
-                returncode = child.poll()
-                if returncode is not None:
-                    raise DevStackError(f"{name} exited with status {returncode}")
-            time.sleep(poll_interval_s)
-    except KeyboardInterrupt:
+            api_child = start(plan.api)
+            wait_api(
+                plan.api_url,
+                plan.api_key,
+                timeout_s=plan.startup_timeout_s,
+                child=api_child,
+            )
+            queues = publish(plan) if plan.publish_release else ()
+            worker_count = 0
+            if plan.start_workers:
+                for lane, queue in queues:
+                    child = start(
+                        DevCommand(
+                            f"worker:{lane}",
+                            plan.worker.argv,
+                            plan.worker.environment,
+                        ),
+                        extra={"TEMPORAL_TASK_QUEUE": queue},
+                    )
+                    returncode = child.poll()
+                    if returncode is not None:
+                        raise DevStackError(
+                            f"worker:{lane} exited with status {returncode} during startup"
+                        )
+                    worker_count += 1
+            print(
+                f"Julep durable dev stack ready: {plan.api_url} "
+                f"({worker_count} worker{'s' if worker_count != 1 else ''})"
+            )
+            while True:
+                for name, child in children:
+                    returncode = child.poll()
+                    if returncode is not None:
+                        raise DevStackError(f"{name} exited with status {returncode}")
+                time.sleep(poll_interval_s)
+    except (KeyboardInterrupt, _TerminationRequested):
         return
     finally:
         _stop_children(children)

--- a/julep/cli/dev.py
+++ b/julep/cli/dev.py
@@ -41,6 +41,7 @@ class DevStackPlan:
     temporal: Optional[DevCommand]
     api: DevCommand
     worker: DevCommand
+    publication_environment: Mapping[str, str] = field(repr=False)
     publish_release: bool = True
     start_workers: bool = True
     startup_timeout_s: float = 30.0
@@ -151,6 +152,31 @@ def build_dev_stack_plan(
         raise DevStackError("durable dev requires Temporal payload encryption keys")
 
     temporal_host, temporal_port = _temporal_endpoint(temporal_address)
+    # Split generated credentials by process. Workers need the shared payload
+    # codec and a worker-role API token, but never the server's static keyring,
+    # vault decryption key, or bundle-signing private key.
+    publication_environment = dict(effective)
+    api_environment = dict(effective)
+    api_environment.pop("JULEP_BUNDLE_SIGNING_KEY", None)
+    worker_environment = dict(effective)
+    for server_only in (
+        "JULEP_API_KEYS",
+        "JULEP_VAULT_KEYS",
+        "JULEP_VAULT_KEY_ID",
+        "JULEP_BUNDLE_SIGNING_KEY",
+    ):
+        worker_environment.pop(server_only, None)
+    if worker_api_key:
+        worker_environment["JULEP_API_URL"] = api_url
+        worker_environment["JULEP_API_KEY"] = worker_api_key
+
+    temporal_environment = dict(worker_environment)
+    temporal_environment.pop("JULEP_API_URL", None)
+    temporal_environment.pop("JULEP_API_KEY", None)
+    temporal_environment.pop("JULEP_BUNDLE_ALLOWED_SIGNERS", None)
+    temporal_environment.pop("TEMPORAL_PAYLOAD_KEYS", None)
+    temporal_environment.pop("TEMPORAL_PAYLOAD_KEY_ID", None)
+
     temporal: Optional[DevCommand] = None
     if start_temporal:
         if temporal_host not in {"127.0.0.1", "localhost", "::1"}:
@@ -165,15 +191,10 @@ def build_dev_stack_plan(
                 "--port",
                 str(temporal_port),
             ),
-            effective,
+            temporal_environment,
         )
 
     base = (python, "-m", "julep.cli.main")
-    api_environment = dict(effective)
-    worker_environment = dict(effective)
-    if worker_api_key:
-        worker_environment["JULEP_API_URL"] = api_url
-        worker_environment["JULEP_API_KEY"] = worker_api_key
     api = DevCommand(
         "api",
         (*base, "serve", "api", "--migrate", "--host", host, "--port", str(port)),
@@ -189,6 +210,7 @@ def build_dev_stack_plan(
         temporal=temporal,
         api=api,
         worker=worker,
+        publication_environment=publication_environment,
         publish_release=publish_release,
         start_workers=start_workers,
         startup_timeout_s=startup_timeout_s,
@@ -217,7 +239,7 @@ def _publish_and_register(plan: DevStackPlan) -> tuple[tuple[str, str], ...]:
     from julep.cli.config import load_config
     from julep.client import JulepClient
 
-    with _temporary_environment(plan.api.environment):
+    with _temporary_environment(plan.publication_environment):
         cfg = load_config(plan.root)
         if plan.env_name not in cfg.envs:
             raise DevStackError(f"unknown env {plan.env_name!r}")

--- a/julep/cli/keygen.py
+++ b/julep/cli/keygen.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import base64
 import json
+import os
 import secrets
 import shlex
+import tempfile
 from collections.abc import Callable, Mapping
+from pathlib import Path
 
 
 def generate_dev_environment(
@@ -15,9 +18,10 @@ def generate_dev_environment(
 ) -> dict[str, str]:
     """Generate mutually independent local-only encryption and signing keys.
 
-    The returned mapping can be loaded into both the API and worker process.
-    No value is persisted by Julep; callers choose whether to print it, feed a
-    secret manager, or write a protected environment file.
+    The returned mapping is a supervisor input, not a shared child-process
+    environment: ``julep dev up`` partitions server, publisher, and worker
+    credentials by role. No value is persisted by Julep; callers choose whether
+    to print it, feed a secret manager, or write a protected environment file.
     """
 
     try:
@@ -84,4 +88,52 @@ def render_dev_environment(
     return "".join(f"export {name}={shlex.quote(value)}\n" for name, value in values.items())
 
 
-__all__ = ["generate_dev_environment", "render_dev_environment"]
+def write_private_file(path: str | Path, content: str, *, replace: bool = False) -> None:
+    """Write a mode-0600 secret file, atomically replacing only when requested."""
+
+    destination = Path(path)
+    if not replace:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(destination, flags, 0o600)
+        try:
+            os.fchmod(descriptor, 0o600)
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                descriptor = -1
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+        except BaseException:
+            if descriptor >= 0:
+                os.close(descriptor)
+            try:
+                destination.unlink()
+            except OSError:
+                pass
+            raise
+        return
+
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=destination.parent,
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+    )
+    temporary = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            descriptor = -1
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, destination)
+    except BaseException:
+        if descriptor >= 0:
+            os.close(descriptor)
+        try:
+            temporary.unlink()
+        except OSError:
+            pass
+        raise
+
+
+__all__ = ["generate_dev_environment", "render_dev_environment", "write_private_file"]

--- a/julep/cli/keygen.py
+++ b/julep/cli/keygen.py
@@ -1,0 +1,87 @@
+"""Development key generation for the durable local stack."""
+
+from __future__ import annotations
+
+import base64
+import json
+import secrets
+import shlex
+from collections.abc import Callable, Mapping
+
+
+def generate_dev_environment(
+    *,
+    random_bytes: Callable[[int], bytes] = secrets.token_bytes,
+) -> dict[str, str]:
+    """Generate mutually independent local-only encryption and signing keys.
+
+    The returned mapping can be loaded into both the API and worker process.
+    No value is persisted by Julep; callers choose whether to print it, feed a
+    secret manager, or write a protected environment file.
+    """
+
+    try:
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise ImportError(
+            "julep keygen requires cryptography; install 'julep[temporal]' or 'julep[store]'"
+        ) from exc
+
+    payload_key = random_bytes(32)
+    vault_key = random_bytes(32)
+    signing_seed = random_bytes(32)
+    admin_api_secret = random_bytes(32)
+    worker_api_secret = random_bytes(32)
+    if len(payload_key) != 32 or len(vault_key) != 32 or len(signing_seed) != 32:
+        raise ValueError("key generator must return exactly 32 bytes")
+    if len(admin_api_secret) != 32 or len(worker_api_secret) != 32:
+        raise ValueError("API token generator must return exactly 32 bytes")
+    if len({payload_key, vault_key, signing_seed, admin_api_secret, worker_api_secret}) != 5:
+        raise ValueError("generated development keys must be distinct")
+
+    public_key = (
+        Ed25519PrivateKey.from_private_bytes(signing_seed)
+        .public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+        .hex()
+    )
+    admin_api_token = base64.urlsafe_b64encode(admin_api_secret).decode("ascii").rstrip("=")
+    worker_api_token = base64.urlsafe_b64encode(worker_api_secret).decode("ascii").rstrip("=")
+    return {
+        "TEMPORAL_PAYLOAD_KEYS": f"dev={payload_key.hex()}",
+        "TEMPORAL_PAYLOAD_KEY_ID": "dev",
+        "TEMPORAL_PAYLOAD_ENCRYPTION_REQUIRED": "true",
+        "JULEP_VAULT_KEYS": f"dev={vault_key.hex()}",
+        "JULEP_VAULT_KEY_ID": "dev",
+        "JULEP_BUNDLE_SIGNING_KEY": signing_seed.hex(),
+        "JULEP_BUNDLE_ALLOWED_SIGNERS": public_key,
+        "JULEP_API_KEYS": (
+            f"local-admin:{admin_api_token}:admin,local-worker:{worker_api_token}:worker"
+        ),
+        # The admin token drives publication and ordinary client requests. The
+        # worker token is kept separate because admin credentials cannot read
+        # operator-vault values and must never be handed to worker code.
+        "JULEP_API_KEY": admin_api_token,
+        "JULEP_WORKER_API_KEY": worker_api_token,
+    }
+
+
+def render_dev_environment(
+    values: Mapping[str, str],
+    *,
+    format: str = "env",
+) -> str:
+    """Render generated keys as shell exports or a JSON object."""
+
+    if format == "json":
+        return json.dumps(dict(values), indent=2, sort_keys=True) + "\n"
+    if format != "env":
+        raise ValueError("key output format must be 'env' or 'json'")
+    return "".join(f"export {name}={shlex.quote(value)}\n" for name, value in values.items())
+
+
+__all__ = ["generate_dev_environment", "render_dev_environment"]

--- a/julep/cli/lint.py
+++ b/julep/cli/lint.py
@@ -12,6 +12,7 @@ from julep.cli.resolve import lint_agent
 from julep.ctx_pipeline import pipeline_spec_from_ctx
 from julep.dotctx import MissingOutputSchemaWarning, Reasoner
 from julep.ir import Node
+from julep.registry import Registry
 from julep.validate import validate
 
 _SEVERITY_ORDER = {"info": 0, "warning": 1, "error": 2}
@@ -47,6 +48,7 @@ def _lint_ctx_pipeline(
     name: str,
     *,
     env_vars: dict[str, str] | None,
+    registry: Registry,
 ) -> tuple[list[Finding], str | None]:
     """Load and structurally validate one configured ctx pipeline, without IO.
 
@@ -66,6 +68,7 @@ def _lint_ctx_pipeline(
                 env_vars=env_vars,
                 agent_round_cap=cfg.agent_round_cap,
                 mcp_servers=cfg.mcp_servers,
+                _registry=registry,
             )
     except Exception as exc:  # noqa: BLE001 - turn user package failures into diagnostics.
         return [], f"{type(exc).__name__}: {exc}"
@@ -111,6 +114,10 @@ def lint_agents(
     findings: list[Finding] = []
     gated = False
     code_names = {agent.name for agent in scan_agents(cfg)}
+    # Mirror application resolution without contaminating the process-global
+    # registry. Sharing this scratch registry across selected pipelines keeps
+    # cross-pipeline reasoner/renderer collision checks intact.
+    registry = Registry()
 
     def append_finding(finding: Finding) -> None:
         nonlocal gated
@@ -128,6 +135,7 @@ def lint_agents(
                 cfg,
                 name,
                 env_vars=env_vars,
+                registry=registry,
             )
             if error is not None:
                 return [Finding(name, "CTX_LOAD", "error", error)], 2

--- a/julep/cli/lint.py
+++ b/julep/cli/lint.py
@@ -1,9 +1,18 @@
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
 
 from julep.cli.config import JulepConfig
+from julep.cli.discover import scan_agents
+from julep.cli.model import Agent, Module
 from julep.cli.resolve import lint_agent
+from julep.ctx_pipeline import pipeline_spec_from_ctx
+from julep.dotctx import MissingOutputSchemaWarning, Reasoner
+from julep.ir import Node
+from julep.validate import validate
 
 _SEVERITY_ORDER = {"info": 0, "warning": 1, "error": 2}
 
@@ -16,6 +25,74 @@ class Finding:
     message: str
 
 
+def include_ctx_pipelines(cfg: JulepConfig, module: Module) -> Module:
+    """Add configured zero-code pipelines to the lint selector namespace."""
+    existing = {agent.name for agent in module.agents}
+    configured = [
+        Agent(
+            name=name,
+            kind="ctx",
+            file=str((cfg.root / pipeline.ctx).resolve()),
+            line=1,
+            tags=list(cfg.tags.get(name, [])),
+        )
+        for name, pipeline in sorted(cfg.pipelines.items())
+        if name not in existing
+    ]
+    return Module(root=module.root, agents=[*module.agents, *configured])
+
+
+def _lint_ctx_pipeline(
+    cfg: JulepConfig,
+    name: str,
+    *,
+    env_vars: dict[str, str] | None,
+) -> tuple[list[Finding], str | None]:
+    """Load and structurally validate one configured ctx pipeline, without IO.
+
+    ``pipeline_spec_from_ctx`` validates tool bindings and only constructs the
+    live MCP snapshot closure. It does not call the closure, compile/deploy an
+    application, publish artifacts, or contact a configured server.
+    """
+    pipeline = cfg.pipelines[name]
+    try:
+        # The CLI renders the same condition as a structured finding below;
+        # suppress the load-time Python warning to avoid duplicate output.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", MissingOutputSchemaWarning)
+            spec = pipeline_spec_from_ctx(
+                pipeline,
+                root=cfg.root,
+                env_vars=env_vars,
+                agent_round_cap=cfg.agent_round_cap,
+                mcp_servers=cfg.mcp_servers,
+            )
+    except Exception as exc:  # noqa: BLE001 - turn user package failures into diagnostics.
+        return [], f"{type(exc).__name__}: {exc}"
+
+    findings = [
+        Finding(name, diagnostic.code, diagnostic.severity, diagnostic.message)
+        for diagnostic in validate(cast(Node, spec.flow))
+    ]
+    reasoner = cast(Reasoner, spec.reasoners[0])
+    if reasoner.reply_schema is None:
+        ctx_path = Path(pipeline.ctx)
+        if not ctx_path.is_absolute():
+            ctx_path = cfg.root / ctx_path
+        findings.append(
+            Finding(
+                name,
+                "CTX_OUTPUT_SCHEMA_MISSING",
+                "warning",
+                (
+                    f"dotctx package {str(ctx_path)!r} does not define class Output "
+                    "in schema.pyi; model replies will not be schema-validated"
+                ),
+            )
+        )
+    return findings, None
+
+
 def lint_agents(
     cfg: JulepConfig,
     names: list[str],
@@ -25,7 +102,7 @@ def lint_agents(
     queues: dict[str, str] | None = None,
     queue_env: str = "local",
 ) -> tuple[list[Finding], int]:
-    """Validate agents (in-child, where pures are live) and gate by severity."""
+    """Validate code agents and configured ctx pipelines, then gate by severity."""
     if fail_severity not in _SEVERITY_ORDER:
         raise ValueError(
             f"unknown fail_severity {fail_severity!r}; expected one of {sorted(_SEVERITY_ORDER)}"
@@ -33,21 +110,50 @@ def lint_agents(
     floor = _SEVERITY_ORDER[fail_severity]
     findings: list[Finding] = []
     gated = False
+    code_names = {agent.name for agent in scan_agents(cfg)}
+
+    def append_finding(finding: Finding) -> None:
+        nonlocal gated
+        findings.append(finding)
+        if _SEVERITY_ORDER.get(
+            finding.severity,
+            _SEVERITY_ORDER["error"],
+        ) >= floor:
+            gated = True
 
     for name in names:
-        resolution = lint_agent(
-            cfg,
-            name,
-            env_vars=env_vars,
-            queues=queues,
-            queue_env=queue_env,
-        )
-        if resolution.error is not None:
-            return [Finding(name, "RESOLVE", "error", resolution.error)], 2
-        for d in resolution.diagnostics:
-            severity = d["severity"]
-            findings.append(Finding(name, d["code"], severity, d["message"]))
-            if _SEVERITY_ORDER.get(severity, _SEVERITY_ORDER["error"]) >= floor:
-                gated = True
+        is_pipeline = name in cfg.pipelines
+        if is_pipeline:
+            pipeline_findings, error = _lint_ctx_pipeline(
+                cfg,
+                name,
+                env_vars=env_vars,
+            )
+            if error is not None:
+                return [Finding(name, "CTX_LOAD", "error", error)], 2
+            for finding in pipeline_findings:
+                append_finding(finding)
+
+        # A configured pipeline can share a name with a discovered legacy
+        # agent. Lint both rather than silently letting one shadow the other.
+        if name in code_names or not is_pipeline:
+            resolution = lint_agent(
+                cfg,
+                name,
+                env_vars=env_vars,
+                queues=queues,
+                queue_env=queue_env,
+            )
+            if resolution.error is not None:
+                return [Finding(name, "RESOLVE", "error", resolution.error)], 2
+            for diagnostic in resolution.diagnostics:
+                append_finding(
+                    Finding(
+                        name,
+                        diagnostic["code"],
+                        diagnostic["severity"],
+                        diagnostic["message"],
+                    )
+                )
 
     return findings, 1 if gated else 0

--- a/julep/cli/main.py
+++ b/julep/cli/main.py
@@ -156,7 +156,11 @@ def keygen(
 ) -> None:
     """Generate independent local payload, vault, signing, and API keys."""
 
-    from julep.cli.keygen import generate_dev_environment, render_dev_environment
+    from julep.cli.keygen import (
+        generate_dev_environment,
+        render_dev_environment,
+        write_private_file,
+    )
 
     try:
         rendered = render_dev_environment(
@@ -171,14 +175,8 @@ def keygen(
         typer.echo(rendered, nl=False)
         return
 
-    flags = _os.O_WRONLY | _os.O_CREAT
-    flags |= _os.O_TRUNC if force else _os.O_EXCL
-    flags |= getattr(_os, "O_NOFOLLOW", 0)
     try:
-        descriptor = _os.open(output, flags, 0o600)
-        with _os.fdopen(descriptor, "w", encoding="utf-8") as handle:
-            handle.write(rendered)
-        output.chmod(0o600)
+        write_private_file(output, rendered, replace=force)
     except FileExistsError:
         typer.echo(
             f"error: {output} already exists; pass --force to replace it",
@@ -245,7 +243,7 @@ def dev_up(
         if env not in cfg.envs:
             raise DevStackError(f"unknown env {env!r}")
         env_cfg = cfg.envs[env]
-        source_env = {**dict(_os.environ), **env_cfg.worker_environment}
+        source_env = dict(_os.environ)
         resolved_url = api_url or source_env.get("JULEP_API_URL") or "http://127.0.0.1:8080"
         resolved_key = api_key or source_env.get("JULEP_API_KEY", "")
         plan = build_dev_stack_plan(

--- a/julep/cli/main.py
+++ b/julep/cli/main.py
@@ -243,6 +243,16 @@ def serve_api(
         "--migrate",
         help="Apply execution-store schema migrations before serving.",
     ),
+    local: bool = typer.Option(
+        False,
+        "--local",
+        help="Run locally with in-memory state and no Temporal or Postgres services.",
+    ),
+    context_factory: str | None = typer.Option(
+        None,
+        "--context-factory",
+        help="WorkerContext factory as module:attribute (local mode only).",
+    ),
 ) -> None:
     """Run the FastAPI control plane."""
 
@@ -252,23 +262,48 @@ def serve_api(
     try:
         import uvicorn
 
-        from julep.server.app import create_app
         from julep.server.settings import ServerSettings
 
-        settings = ServerSettings.from_env()
+        if local and migrate:
+            raise ValueError("--migrate cannot be used with --local")
+        if context_factory is not None and not local:
+            raise ValueError("--context-factory requires --local")
+
+        if local:
+            local_env = dict(_os.environ)
+            local_env["TEMPORAL_PAYLOAD_ENCRYPTION_REQUIRED"] = "false"
+            settings = ServerSettings.from_env(local_env)
+        else:
+            settings = ServerSettings.from_env()
         if host is not None or port is not None:
             settings = replace(
                 settings,
                 host=host if host is not None else settings.host,
                 port=port if port is not None else settings.port,
             )
-        if migrate:
+        if local:
+            from julep.execution.serve import load_context_factory
+            from julep.server import create_local_app
+
+            factory = load_context_factory(context_factory) if context_factory is not None else None
+            api = create_local_app(
+                project_root=Path.cwd(),
+                host=settings.host,
+                context_factory=factory,
+            )
+        elif migrate:
+            from julep.server.app import create_app
+
             store = settings.build_store()
             try:
                 store.apply_schema()
             finally:
                 store.close()
-        api = create_app(settings=settings)
+            api = create_app(settings=settings)
+        else:
+            from julep.server.app import create_app
+
+            api = create_app(settings=settings)
     except (ImportError, RuntimeError, ValueError) as exc:
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(2) from None

--- a/julep/cli/main.py
+++ b/julep/cli/main.py
@@ -1020,7 +1020,7 @@ def lint(
         cfg,
         names,
         fail_severity=floor,
-        env_vars=env_cfg.vars,
+        env_vars={**env_cfg.vars, **env_cfg.worker_environment},
         queues=env_cfg.queues,
         queue_env=env,
     )

--- a/julep/cli/main.py
+++ b/julep/cli/main.py
@@ -24,7 +24,7 @@ from julep.cli.chat import chat_command
 from julep.cli.deploy import deploy_agents
 from julep.cli.doctor import legacy_checks, overall_code, run_checks
 from julep.cli.langfuse_link import trace_url
-from julep.cli.lint import lint_agents
+from julep.cli.lint import include_ctx_pipelines, lint_agents
 from julep.cli.listen import listen_command
 from julep.cli.model import Module, build_module
 from julep.cli.runcache import load_run, save_run
@@ -849,13 +849,13 @@ def lint(
         None, "--fail-severity", help="error|warning|info (default: config)."
     ),
 ) -> None:
-    """Lint selected agents (structural validation + severity gating)."""
+    """Lint selected agents and configured ctx pipelines."""
     cfg = load_config(Path("."))
     if env not in cfg.envs:
         typer.echo(f"error: unknown env {env!r}", err=True)
         raise typer.Exit(2)
-    module = build_module(cfg)
-    names = [a.name for a in select(module, selector, exclude=exclude)]
+    module = include_ctx_pipelines(cfg, build_module(cfg))
+    names = sorted({a.name for a in select(module, selector, exclude=exclude)})
     floor = fail_severity.value if fail_severity is not None else cfg.fail_severity
     # --env defaults to local, preserving the deterministic default target.
     env_cfg = cfg.envs[env]

--- a/julep/cli/main.py
+++ b/julep/cli/main.py
@@ -41,7 +41,9 @@ from julep.projection import ProjectionEvent
 if TYPE_CHECKING:
     from julep.client import JulepClient
 
-app = typer.Typer(add_completion=True, no_args_is_help=True, help="Developer CLI for julep modules.")
+app = typer.Typer(
+    add_completion=True, no_args_is_help=True, help="Developer CLI for julep modules."
+)
 schedule_app = typer.Typer(
     no_args_is_help=True,
     help="Manage Temporal cron schedules from julep.toml.",
@@ -54,9 +56,14 @@ serve_app = typer.Typer(
     no_args_is_help=True,
     help="Run Julep service processes.",
 )
+dev_app = typer.Typer(
+    no_args_is_help=True,
+    help="Run the durable local development stack.",
+)
 app.add_typer(schedule_app, name="schedule")
 app.add_typer(db_app, name="db")
 app.add_typer(serve_app, name="serve")
+app.add_typer(dev_app, name="dev")
 app.command("chat")(chat_command)
 app.command("listen")(listen_command)
 app.command("trigger")(trigger_command)
@@ -127,6 +134,147 @@ def _resolve_db_dsn(dsn: str | None) -> str:
         )
         raise typer.Exit(2)
     return resolved
+
+
+@app.command("keygen")
+def keygen(
+    output_format: str = typer.Option(
+        "env",
+        "--format",
+        help="Output format: env or json.",
+    ),
+    output: Path | None = typer.Option(  # noqa: B008
+        None,
+        "--output",
+        help="Write secrets to this file with mode 0600 instead of stdout.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Replace an existing --output file.",
+    ),
+) -> None:
+    """Generate independent local payload, vault, signing, and API keys."""
+
+    from julep.cli.keygen import generate_dev_environment, render_dev_environment
+
+    try:
+        rendered = render_dev_environment(
+            generate_dev_environment(),
+            format=output_format,
+        )
+    except (ImportError, ValueError) as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(2) from None
+
+    if output is None:
+        typer.echo(rendered, nl=False)
+        return
+
+    flags = _os.O_WRONLY | _os.O_CREAT
+    flags |= _os.O_TRUNC if force else _os.O_EXCL
+    flags |= getattr(_os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = _os.open(output, flags, 0o600)
+        with _os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(rendered)
+        output.chmod(0o600)
+    except FileExistsError:
+        typer.echo(
+            f"error: {output} already exists; pass --force to replace it",
+            err=True,
+        )
+        raise typer.Exit(2) from None
+    except OSError as exc:
+        typer.echo(f"error: could not write {output}: {exc}", err=True)
+        raise typer.Exit(2) from None
+    typer.echo(f"wrote {output} (mode 0600)")
+
+
+@dev_app.command("up")
+def dev_up(
+    env: str = typer.Option("local", "--env", help="Application environment name."),
+    api_url: str = typer.Option(
+        "",
+        "--api-url",
+        help="Loopback control-plane URL (default: JULEP_API_URL or http://127.0.0.1:8080).",
+    ),
+    api_key: str = typer.Option(
+        "",
+        "--api-key",
+        help="Admin key (default: JULEP_API_KEY).",
+    ),
+    start_temporal: bool = typer.Option(
+        True,
+        "--start-temporal/--no-start-temporal",
+        help="Supervise a Temporal development server or use an existing one.",
+    ),
+    publish_release: bool = typer.Option(
+        True,
+        "--publish/--no-publish",
+        help="Publish and register the configured application after startup.",
+    ),
+    start_workers: bool = typer.Option(
+        True,
+        "--worker/--no-worker",
+        help="Start one worker per published release-scoped lane queue.",
+    ),
+    startup_timeout: float = typer.Option(
+        30.0,
+        "--startup-timeout",
+        min=0.001,
+        help="Seconds allowed for Temporal and API readiness.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Validate and print the supervised command plan without starting it.",
+    ),
+) -> None:
+    """Start Temporal, migrate/serve the API, publish, and run lane workers."""
+
+    from julep.cli.dev import (
+        DevStackError,
+        build_dev_stack_plan,
+        render_dev_stack_plan,
+        run_dev_stack,
+    )
+
+    try:
+        cfg = load_config(Path("."))
+        if env not in cfg.envs:
+            raise DevStackError(f"unknown env {env!r}")
+        env_cfg = cfg.envs[env]
+        source_env = {**dict(_os.environ), **env_cfg.worker_environment}
+        resolved_url = api_url or source_env.get("JULEP_API_URL") or "http://127.0.0.1:8080"
+        resolved_key = api_key or source_env.get("JULEP_API_KEY", "")
+        plan = build_dev_stack_plan(
+            cfg,
+            env_cfg,
+            api_url=resolved_url,
+            api_key=resolved_key,
+            source_env=source_env,
+            start_temporal=start_temporal,
+            publish_release=publish_release,
+            start_workers=start_workers,
+            startup_timeout_s=startup_timeout,
+        )
+        if dry_run:
+            typer.echo(render_dev_stack_plan(plan), nl=False)
+            return
+        run_dev_stack(plan)
+    except (
+        BundleError,
+        ArtifactStoreError,
+        DevStackError,
+        ImportError,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(1) from None
 
 
 @db_app.command("migrate")
@@ -208,10 +356,10 @@ def db_reencrypt_secrets(
     finally:
         store.close()
 
-    remaining = ", ".join(
-        f"{key_id}={count}"
-        for key_id, count in report["remaining_key_ids"].items()
-    ) or "none"
+    remaining = (
+        ", ".join(f"{key_id}={count}" for key_id, count in report["remaining_key_ids"].items())
+        or "none"
+    )
     typer.echo(
         f"re-encrypted {report['reencrypted']} secret(s) under "
         f"{report['active_key_id']}"
@@ -565,7 +713,11 @@ def run(
             if result.error is not None:
                 typer.echo(f"error: {result.error}", err=True)
                 save_run(
-                    str(cfg.root), run_id=result.run_id, agent=name, status="error", events=result.events
+                    str(cfg.root),
+                    run_id=result.run_id,
+                    agent=name,
+                    status="error",
+                    events=result.events,
                 )
                 raise typer.Exit(1)
             typer.echo(render_tree(result.events))
@@ -644,7 +796,14 @@ def plan(
             cfg.envs[env],
             mcp_snapshot=mcp_snapshot,
         )
-    except (BundleError, ArtifactStoreError, ImportError, RuntimeError, TypeError, ValueError) as exc:
+    except (
+        BundleError,
+        ArtifactStoreError,
+        ImportError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ) as exc:
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(1) from None
     payload = application_plan.to_json()
@@ -652,16 +811,12 @@ def plan(
         typer.echo(_json.dumps(payload, indent=2, sort_keys=True))
     else:
         artifact = payload["artifact"]
-        typer.echo(
-            f"artifact  {'drift' if artifact['drift'] else 'clean':9} "
-            f"{artifact['desired']}"
-        )
+        typer.echo(f"artifact  {'drift' if artifact['drift'] else 'clean':9} {artifact['desired']}")
         for name, drift in payload["mcpSchema"].items():
             typer.echo(f"mcp       {name:24} {'drift' if drift else 'clean'}")
         image = payload["workerImage"]
         typer.echo(
-            f"image     {'drift' if image['drift'] else 'clean':9} "
-            f"{image['desired'] or '-'}"
+            f"image     {'drift' if image['drift'] else 'clean':9} {image['desired'] or '-'}"
         )
         for lane, state in payload["release"].items():
             typer.echo(f"release   {lane:24} {state}")
@@ -711,7 +866,14 @@ def apply_application(
             publish_only=publish_only,
             mcp_snapshot=mcp_snapshot,
         )
-    except (BundleError, ArtifactStoreError, ImportError, RuntimeError, TypeError, ValueError) as exc:
+    except (
+        BundleError,
+        ArtifactStoreError,
+        ImportError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ) as exc:
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(1) from None
     typer.echo(f"release   {release.release_hash}")
@@ -786,10 +948,7 @@ def status(
             application_plan.artifact_drift
             or application_plan.worker_image_drift
             or any(application_plan.mcp_schema_drift.values())
-            or any(
-                value != "clean"
-                for value in application_plan.deployment_config_drift.values()
-            )
+            or any(value != "clean" for value in application_plan.deployment_config_drift.values())
             or any(value != "clean" for value in application_plan.release_drift.values())
             or any(value != "ready" for value in application_plan.helm_keda_drift.values())
             or any(value != "healthy" for value in application_plan.runtime_drift.values())
@@ -833,9 +992,7 @@ def worker(
             env["JULEP_REDACTION"] = _json.dumps(table)
     settings = WorkerServeSettings.from_env(env)
     if smoke_test_seconds > 0:
-        _asyncio.run(
-            smoke_test_worker(settings, poll_seconds=smoke_test_seconds)
-        )
+        _asyncio.run(smoke_test_worker(settings, poll_seconds=smoke_test_seconds))
     else:
         _asyncio.run(serve(settings))
 
@@ -878,7 +1035,9 @@ def lint(
 def test_cmd(
     selector: str = typer.Argument("", help="Selection expression (default: all)."),
     exclude: str = typer.Option("", "--exclude", help="Exclude expression."),
-    dry_run: bool = typer.Option(False, "--dry-run", help="Print the pytest command without running."),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Print the pytest command without running."
+    ),
 ) -> None:
     """Run pytest for the selected agents.
 
@@ -985,9 +1144,7 @@ def eval_cmd(
 
 @app.command("trace")
 def trace(
-    run_id: str = typer.Argument(
-        ..., help="Run id from a prior `julep run` (or a deployed run)."
-    ),
+    run_id: str = typer.Argument(..., help="Run id from a prior `julep run` (or a deployed run)."),
     remote: bool = typer.Option(False, "--remote", help="Read trace events from the remote API."),
     api_url: str = typer.Option("", "--api-url", help="Remote Julep API base URL."),
     api_key: str = typer.Option("", "--api-key", help="Remote Julep API bearer key."),
@@ -1005,8 +1162,7 @@ def trace(
             else:
                 run_data = client.get_run(run_id)
                 typer.echo(
-                    f"run {run_id!r} status={run_data.get('status')} "
-                    "(no trace events captured)"
+                    f"run {run_id!r} status={run_data.get('status')} (no trace events captured)"
                 )
         except JulepClientError as exc:
             typer.echo(f"error: {exc}", err=True)

--- a/julep/cli/tracetree.py
+++ b/julep/cli/tracetree.py
@@ -20,7 +20,18 @@ def render_tree(events: list[ProjectionEvent]) -> str:
         for i, span in enumerate(kids):
             last = i == len(kids) - 1
             branch = '└─ ' if last else '├─ '
-            cost = f' ${span.cost:.4f}' if span.cost else ''
+            if span.cost is not None:
+                cost = f' ${span.cost:.4f}'
+            elif (
+                span.attrs.get("llm.cost.status") == "unknown"
+                or "llm.model" in span.attrs
+                or "llm.usage" in span.attrs
+            ):
+                # Older stored events predate llm.cost.status but still carry
+                # model/usage attrs, so remote traces can render them honestly.
+                cost = " cost=unknown"
+            else:
+                cost = ''
             lines.append(f'{prefix}{branch}{span.node} [{span.status}]{cost}')
             emit(span.cid, prefix + ('   ' if last else '│  '))
 

--- a/julep/client.py
+++ b/julep/client.py
@@ -1,7 +1,10 @@
-"""Small synchronous client for the Julep execution control plane."""
+"""Sync and async clients for the Julep execution control plane."""
 
 from __future__ import annotations
 
+import math
+import time
+from collections.abc import Mapping
 from typing import Any, Literal, cast
 
 import httpx
@@ -14,6 +17,166 @@ class JulepClientError(RuntimeError):
         self.status_code = status_code
         self.detail = detail
         super().__init__(f"julep API error {status_code}: {detail}")
+
+
+class JulepRunError(RuntimeError):
+    """Base class for execution-adoption errors raised by wait helpers."""
+
+    def __init__(self, message: str, *, run_id: str | None) -> None:
+        self.run_id = run_id
+        super().__init__(message)
+
+
+class JulepRunProtocolError(JulepRunError):
+    """The control plane returned a malformed run or result envelope."""
+
+
+class JulepRunTimeout(JulepRunError):
+    """A run did not finish within the caller's bounded wait."""
+
+    def __init__(self, run_id: str, deadline_s: float) -> None:
+        self.deadline_s = deadline_s
+        super().__init__(
+            f"julep run {run_id} exceeded the {deadline_s:g}s deadline",
+            run_id=run_id,
+        )
+
+
+class JulepRunFailed(JulepRunError):
+    """A run reached a non-success terminal status."""
+
+    def __init__(self, run_id: str, status: str, error: Any = None) -> None:
+        self.status = status
+        self.error = error
+        self.detail = self.error
+        detail = f": {self.error}" if self.error is not None else ""
+        super().__init__(
+            f"julep run {run_id} ended in terminal status {status!r}{detail}",
+            run_id=run_id,
+        )
+
+
+_FAILED_STATUSES = frozenset({"failed", "canceled", "terminated", "start_failed"})
+_PENDING = object()
+
+
+def _error_detail(response: httpx.Response) -> Any:
+    try:
+        payload = response.json()
+        return payload.get("detail", payload) if isinstance(payload, dict) else payload
+    except ValueError:
+        return response.text
+
+
+def _checked_response(
+    response: httpx.Response, expect: tuple[int, ...]
+) -> httpx.Response:
+    if response.status_code not in expect:
+        raise JulepClientError(response.status_code, _error_detail(response))
+    return response
+
+
+def _request_headers(
+    defaults: Mapping[str, str], extra: Mapping[str, str] | None
+) -> dict[str, str]:
+    return {**defaults, **dict(extra or {})}
+
+
+def _start_request(
+    *,
+    pipeline: str,
+    input: Any,
+    release: str | None,
+    session_id: str | None,
+    principal: dict[str, Any] | None,
+    secrets: dict[str, str] | None,
+    mcp_preflight: Literal["pin", "names", "off"] | None,
+    queue_lanes: dict[str, str] | None,
+    idempotency_key: str | None,
+    run_id: str | None,
+) -> tuple[dict[str, Any], dict[str, str]]:
+    if not idempotency_key and not run_id:
+        raise ValueError("start_run requires idempotency_key or run_id")
+    body: dict[str, Any] = {"pipeline": pipeline, "input": input}
+    for key, value in (
+        ("release", release),
+        ("sessionId", session_id),
+        ("principal", principal),
+        ("secrets", secrets),
+        ("mcpPreflight", mcp_preflight),
+        ("queueLanes", queue_lanes),
+        ("runId", run_id),
+    ):
+        if value is not None:
+            body[key] = value
+    headers = {"Idempotency-Key": idempotency_key} if idempotency_key else {}
+    return body, headers
+
+
+def _validate_wait(deadline_s: float, poll_wait_s: float) -> tuple[float, float]:
+    deadline = float(deadline_s)
+    poll_wait = float(poll_wait_s)
+    if not math.isfinite(deadline) or deadline < 0:
+        raise ValueError("deadline_s must be a finite non-negative number")
+    if not math.isfinite(poll_wait) or poll_wait <= 0:
+        raise ValueError("poll_wait_s must be a finite positive number")
+    return deadline, min(poll_wait, 60.0)
+
+
+def _started_run_id(started: Mapping[str, Any]) -> str:
+    value = started.get("run_id")
+    if not isinstance(value, str) or not value:
+        raise JulepRunProtocolError(
+            "julep start_run response did not contain a non-empty run_id",
+            run_id=None,
+        )
+    return value
+
+
+def _resolve_result(envelope: Mapping[str, Any], expected_run_id: str) -> Any:
+    run = envelope.get("run")
+    if not isinstance(run, Mapping):
+        raise JulepRunProtocolError(
+            "julep result response did not contain a run object",
+            run_id=expected_run_id,
+        )
+    run_id = run.get("run_id")
+    if run_id is not None and run_id != expected_run_id:
+        raise JulepRunProtocolError(
+            "julep result response run_id did not match the requested run",
+            run_id=expected_run_id,
+        )
+    status = run.get("status")
+    if status == "completed":
+        if "result" not in envelope:
+            raise JulepRunProtocolError(
+                "completed julep result response did not contain result",
+                run_id=expected_run_id,
+            )
+        return envelope["result"]
+    if isinstance(status, str) and status in _FAILED_STATUSES:
+        raise JulepRunFailed(
+            expected_run_id,
+            status,
+            run.get("error", run.get("detail")),
+        )
+    return _PENDING
+
+
+def _projection_event(row: Mapping[str, Any]) -> ProjectionEvent:
+    return ProjectionEvent(
+        event_id=str(row["event_id"]),
+        type=EventType(row["type"]),
+        node=str(row["node"]),
+        cid=str(row["cid"]),
+        ts=float(row["ts"]),
+        causes=tuple(str(cause) for cause in (row.get("causes") or ())),
+        value_ref=cast(str | None, row.get("value_ref")),
+        shape=cast(str | None, row.get("shape")),
+        cost=cast(float | None, row.get("cost")),
+        error=cast(str | None, row.get("error")),
+        attrs=dict(row.get("attrs") or {}),
+    )
 
 
 class JulepClient:
@@ -43,16 +206,9 @@ class JulepClient:
         expect: tuple[int, ...] = (200, 201, 202),
         **kwargs: Any,
     ) -> httpx.Response:
-        headers = {**self._headers, **dict(kwargs.pop("headers", {}))}
+        headers = _request_headers(self._headers, kwargs.pop("headers", None))
         response = self._client.request(method, path, headers=headers, **kwargs)
-        if response.status_code not in expect:
-            try:
-                payload = response.json()
-                detail = payload.get("detail", payload) if isinstance(payload, dict) else payload
-            except ValueError:
-                detail = response.text
-            raise JulepClientError(response.status_code, detail)
-        return response
+        return _checked_response(response, expect)
 
     def health(self) -> dict[str, Any]:
         return cast(dict[str, Any], self._request("GET", "/v1/health").json())
@@ -96,21 +252,18 @@ class JulepClient:
         idempotency_key: str | None = None,
         run_id: str | None = None,
     ) -> dict[str, Any]:
-        if not idempotency_key and not run_id:
-            raise ValueError("start_run requires idempotency_key or run_id")
-        body: dict[str, Any] = {"pipeline": pipeline, "input": input}
-        for key, value in (
-            ("release", release),
-            ("sessionId", session_id),
-            ("principal", principal),
-            ("secrets", secrets),
-            ("mcpPreflight", mcp_preflight),
-            ("queueLanes", queue_lanes),
-            ("runId", run_id),
-        ):
-            if value is not None:
-                body[key] = value
-        headers = {"Idempotency-Key": idempotency_key} if idempotency_key else {}
+        body, headers = _start_request(
+            pipeline=pipeline,
+            input=input,
+            release=release,
+            session_id=session_id,
+            principal=principal,
+            secrets=secrets,
+            mcp_preflight=mcp_preflight,
+            queue_lanes=queue_lanes,
+            idempotency_key=idempotency_key,
+            run_id=run_id,
+        )
         return cast(
             dict[str, Any],
             self._request("POST", "/v1/runs", json=body, headers=headers).json(),
@@ -126,12 +279,118 @@ class JulepClient:
             dict[str, Any], self._request("POST", f"/v1/runs/{run_id}/terminate").json()
         )
 
-    def get_result(self, run_id: str, *, wait_s: float = 0.0) -> dict[str, Any]:
+    def get_result(
+        self,
+        run_id: str,
+        *,
+        wait_s: float = 0.0,
+        request_timeout_s: float | None = None,
+    ) -> dict[str, Any]:
+        request_options: dict[str, Any] = {}
+        if request_timeout_s is not None:
+            request_options["timeout"] = request_timeout_s
         return cast(
             dict[str, Any],
             self._request(
-                "GET", f"/v1/runs/{run_id}/result", params={"wait_s": wait_s}
+                "GET",
+                f"/v1/runs/{run_id}/result",
+                params={"wait_s": wait_s},
+                **request_options,
             ).json(),
+        )
+
+    def wait_for_run(
+        self,
+        run_id: str,
+        *,
+        deadline_s: float = 300.0,
+        poll_wait_s: float = 20.0,
+    ) -> Any:
+        """Wait for ``run_id`` and return its unwrapped result payload."""
+
+        deadline_seconds, poll_wait = _validate_wait(deadline_s, poll_wait_s)
+        deadline = time.monotonic() + deadline_seconds
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise JulepRunTimeout(run_id, deadline_seconds)
+            try:
+                envelope = self.get_result(
+                    run_id,
+                    wait_s=min(poll_wait, remaining),
+                    request_timeout_s=remaining,
+                )
+            except httpx.TimeoutException as exc:
+                raise JulepRunTimeout(run_id, deadline_seconds) from exc
+            result = _resolve_result(envelope, run_id)
+            if result is not _PENDING:
+                return result
+
+    def start_and_wait(
+        self,
+        *,
+        pipeline: str,
+        input: Any = None,
+        release: str | None = None,
+        session_id: str | None = None,
+        principal: dict[str, Any] | None = None,
+        secrets: dict[str, str] | None = None,
+        mcp_preflight: Literal["pin", "names", "off"] | None = None,
+        queue_lanes: dict[str, str] | None = None,
+        idempotency_key: str | None = None,
+        run_id: str | None = None,
+        deadline_s: float = 300.0,
+        poll_wait_s: float = 20.0,
+    ) -> Any:
+        """Submit idempotently, wait within a deadline, and unwrap the result."""
+
+        started = self.start_run(
+            pipeline=pipeline,
+            input=input,
+            release=release,
+            session_id=session_id,
+            principal=principal,
+            secrets=secrets,
+            mcp_preflight=mcp_preflight,
+            queue_lanes=queue_lanes,
+            idempotency_key=idempotency_key,
+            run_id=run_id,
+        )
+        return self.wait_for_run(
+            _started_run_id(started),
+            deadline_s=deadline_s,
+            poll_wait_s=poll_wait_s,
+        )
+
+    def run_and_wait(
+        self,
+        *,
+        pipeline: str,
+        input: Any = None,
+        release: str | None = None,
+        session_id: str | None = None,
+        principal: dict[str, Any] | None = None,
+        secrets: dict[str, str] | None = None,
+        queue_lanes: dict[str, str] | None = None,
+        idempotency_key: str | None = None,
+        run_id: str | None = None,
+        deadline_s: float = 300.0,
+        poll_wait_s: float = 20.0,
+    ) -> Any:
+        """Alias for :meth:`start_and_wait` with the same typed contract."""
+
+        return self.start_and_wait(
+            pipeline=pipeline,
+            input=input,
+            release=release,
+            session_id=session_id,
+            principal=principal,
+            secrets=secrets,
+            queue_lanes=queue_lanes,
+            idempotency_key=idempotency_key,
+            run_id=run_id,
+            deadline_s=deadline_s,
+            poll_wait_s=poll_wait_s,
         )
 
     def read_events(
@@ -169,22 +428,7 @@ class JulepClient:
         raise ValueError("events response exceeded page limit")
 
     def projection_events(self, run_id: str) -> list[ProjectionEvent]:
-        return [
-            ProjectionEvent(
-                event_id=str(row["event_id"]),
-                type=EventType(row["type"]),
-                node=str(row["node"]),
-                cid=str(row["cid"]),
-                ts=float(row["ts"]),
-                causes=tuple(str(cause) for cause in (row.get("causes") or ())),
-                value_ref=cast(str | None, row.get("value_ref")),
-                shape=cast(str | None, row.get("shape")),
-                cost=cast(float | None, row.get("cost")),
-                error=cast(str | None, row.get("error")),
-                attrs=dict(row.get("attrs") or {}),
-            )
-            for row in self.iter_events(run_id)
-        ]
+        return [_projection_event(row) for row in self.iter_events(run_id)]
 
     def close(self) -> None:
         if self._owns:
@@ -202,4 +446,295 @@ class JulepClient:
         self.close()
 
 
-__all__ = ["JulepClient", "JulepClientError"]
+class AsyncJulepClient:
+    """Asynchronous control-plane client with parity with :class:`JulepClient`."""
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        *,
+        client: httpx.AsyncClient | None = None,
+        timeout: float = 30.0,
+    ) -> None:
+        if client is None:
+            if not base_url:
+                raise ValueError("base_url is required when client is not provided")
+            self._client = httpx.AsyncClient(
+                base_url=base_url.rstrip("/"), timeout=timeout
+            )
+            self._owns = True
+        else:
+            self._client = client
+            self._owns = False
+        self._headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        expect: tuple[int, ...] = (200, 201, 202),
+        **kwargs: Any,
+    ) -> httpx.Response:
+        headers = _request_headers(self._headers, kwargs.pop("headers", None))
+        response = await self._client.request(method, path, headers=headers, **kwargs)
+        return _checked_response(response, expect)
+
+    async def health(self) -> dict[str, Any]:
+        return cast(dict[str, Any], (await self._request("GET", "/v1/health")).json())
+
+    async def publish_release(self, manifest_bytes: bytes) -> dict[str, Any]:
+        return cast(
+            dict[str, Any],
+            (
+                await self._request(
+                    "POST",
+                    "/v1/releases",
+                    content=manifest_bytes,
+                    headers={"Content-Type": "application/json"},
+                )
+            ).json(),
+        )
+
+    async def list_runs(
+        self, *, cursor: str | None = None, limit: int = 50
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"limit": limit}
+        if cursor is not None:
+            params["cursor"] = cursor
+        return cast(
+            dict[str, Any],
+            (await self._request("GET", "/v1/runs", params=params)).json(),
+        )
+
+    async def get_run(self, run_id: str) -> dict[str, Any]:
+        return cast(
+            dict[str, Any],
+            (await self._request("GET", f"/v1/runs/{run_id}")).json(),
+        )
+
+    async def start_run(
+        self,
+        *,
+        pipeline: str,
+        input: Any = None,
+        release: str | None = None,
+        session_id: str | None = None,
+        principal: dict[str, Any] | None = None,
+        secrets: dict[str, str] | None = None,
+        mcp_preflight: Literal["pin", "names", "off"] | None = None,
+        queue_lanes: dict[str, str] | None = None,
+        idempotency_key: str | None = None,
+        run_id: str | None = None,
+    ) -> dict[str, Any]:
+        body, headers = _start_request(
+            pipeline=pipeline,
+            input=input,
+            release=release,
+            session_id=session_id,
+            principal=principal,
+            secrets=secrets,
+            mcp_preflight=mcp_preflight,
+            queue_lanes=queue_lanes,
+            idempotency_key=idempotency_key,
+            run_id=run_id,
+        )
+        return cast(
+            dict[str, Any],
+            (
+                await self._request(
+                    "POST", "/v1/runs", json=body, headers=headers
+                )
+            ).json(),
+        )
+
+    async def cancel_run(self, run_id: str) -> dict[str, Any]:
+        return cast(
+            dict[str, Any],
+            (await self._request("POST", f"/v1/runs/{run_id}/cancel")).json(),
+        )
+
+    async def terminate_run(self, run_id: str) -> dict[str, Any]:
+        return cast(
+            dict[str, Any],
+            (await self._request("POST", f"/v1/runs/{run_id}/terminate")).json(),
+        )
+
+    async def get_result(
+        self,
+        run_id: str,
+        *,
+        wait_s: float = 0.0,
+        request_timeout_s: float | None = None,
+    ) -> dict[str, Any]:
+        request_options: dict[str, Any] = {}
+        if request_timeout_s is not None:
+            request_options["timeout"] = request_timeout_s
+        return cast(
+            dict[str, Any],
+            (
+                await self._request(
+                    "GET",
+                    f"/v1/runs/{run_id}/result",
+                    params={"wait_s": wait_s},
+                    **request_options,
+                )
+            ).json(),
+        )
+
+    async def wait_for_run(
+        self,
+        run_id: str,
+        *,
+        deadline_s: float = 300.0,
+        poll_wait_s: float = 20.0,
+    ) -> Any:
+        deadline_seconds, poll_wait = _validate_wait(deadline_s, poll_wait_s)
+        deadline = time.monotonic() + deadline_seconds
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise JulepRunTimeout(run_id, deadline_seconds)
+            try:
+                envelope = await self.get_result(
+                    run_id,
+                    wait_s=min(poll_wait, remaining),
+                    request_timeout_s=remaining,
+                )
+            except httpx.TimeoutException as exc:
+                raise JulepRunTimeout(run_id, deadline_seconds) from exc
+            result = _resolve_result(envelope, run_id)
+            if result is not _PENDING:
+                return result
+
+    async def start_and_wait(
+        self,
+        *,
+        pipeline: str,
+        input: Any = None,
+        release: str | None = None,
+        session_id: str | None = None,
+        principal: dict[str, Any] | None = None,
+        secrets: dict[str, str] | None = None,
+        mcp_preflight: Literal["pin", "names", "off"] | None = None,
+        queue_lanes: dict[str, str] | None = None,
+        idempotency_key: str | None = None,
+        run_id: str | None = None,
+        deadline_s: float = 300.0,
+        poll_wait_s: float = 20.0,
+    ) -> Any:
+        started = await self.start_run(
+            pipeline=pipeline,
+            input=input,
+            release=release,
+            session_id=session_id,
+            principal=principal,
+            secrets=secrets,
+            mcp_preflight=mcp_preflight,
+            queue_lanes=queue_lanes,
+            idempotency_key=idempotency_key,
+            run_id=run_id,
+        )
+        return await self.wait_for_run(
+            _started_run_id(started),
+            deadline_s=deadline_s,
+            poll_wait_s=poll_wait_s,
+        )
+
+    async def run_and_wait(
+        self,
+        *,
+        pipeline: str,
+        input: Any = None,
+        release: str | None = None,
+        session_id: str | None = None,
+        principal: dict[str, Any] | None = None,
+        secrets: dict[str, str] | None = None,
+        queue_lanes: dict[str, str] | None = None,
+        idempotency_key: str | None = None,
+        run_id: str | None = None,
+        deadline_s: float = 300.0,
+        poll_wait_s: float = 20.0,
+    ) -> Any:
+        return await self.start_and_wait(
+            pipeline=pipeline,
+            input=input,
+            release=release,
+            session_id=session_id,
+            principal=principal,
+            secrets=secrets,
+            queue_lanes=queue_lanes,
+            idempotency_key=idempotency_key,
+            run_id=run_id,
+            deadline_s=deadline_s,
+            poll_wait_s=poll_wait_s,
+        )
+
+    async def read_events(
+        self,
+        run_id: str,
+        *,
+        after: int | str = 0,
+        limit: int = 500,
+    ) -> dict[str, Any]:
+        return cast(
+            dict[str, Any],
+            (
+                await self._request(
+                    "GET",
+                    f"/v1/runs/{run_id}/events",
+                    params={"after": after, "limit": limit},
+                    headers={"Accept": "application/json"},
+                )
+            ).json(),
+        )
+
+    async def iter_events(self, run_id: str) -> list[dict[str, Any]]:
+        events: list[dict[str, Any]] = []
+        cursor: int | str = 0
+        for _page in range(10_000):
+            data = await self.read_events(run_id, after=cursor)
+            items = data.get("items", [])
+            if not isinstance(items, list):
+                raise ValueError("events response items must be a list")
+            events.extend(cast(list[dict[str, Any]], items))
+            next_cursor = data.get("next_cursor")
+            if next_cursor is None:
+                return events
+            if next_cursor == cursor:
+                raise ValueError("events response cursor did not advance")
+            cursor = cast(str, next_cursor)
+        raise ValueError("events response exceeded page limit")
+
+    async def projection_events(self, run_id: str) -> list[ProjectionEvent]:
+        return [_projection_event(row) for row in await self.iter_events(run_id)]
+
+    async def aclose(self) -> None:
+        if self._owns:
+            await self._client.aclose()
+
+    async def close(self) -> None:
+        await self.aclose()
+
+    async def __aenter__(self) -> AsyncJulepClient:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: object,
+    ) -> None:
+        await self.aclose()
+
+
+__all__ = [
+    "AsyncJulepClient",
+    "JulepClient",
+    "JulepClientError",
+    "JulepRunError",
+    "JulepRunFailed",
+    "JulepRunProtocolError",
+    "JulepRunTimeout",
+]

--- a/julep/client.py
+++ b/julep/client.py
@@ -377,7 +377,11 @@ class JulepClient:
         deadline_s: float = 300.0,
         poll_wait_s: float = 20.0,
     ) -> Any:
-        """Alias for :meth:`start_and_wait` with the same typed contract."""
+        """Submit and wait without the admin-only MCP preflight override.
+
+        Either ``idempotency_key`` or ``run_id`` is required.
+        Operators that need ``mcp_preflight=`` can call :meth:`start_and_wait`.
+        """
 
         return self.start_and_wait(
             pipeline=pipeline,
@@ -657,6 +661,12 @@ class AsyncJulepClient:
         deadline_s: float = 300.0,
         poll_wait_s: float = 20.0,
     ) -> Any:
+        """Submit and wait without the admin-only MCP preflight override.
+
+        Either ``idempotency_key`` or ``run_id`` is required.
+        Operators that need ``mcp_preflight=`` can call :meth:`start_and_wait`.
+        """
+
         return await self.start_and_wait(
             pipeline=pipeline,
             input=input,

--- a/julep/ctx_pipeline.py
+++ b/julep/ctx_pipeline.py
@@ -10,6 +10,7 @@ from .app import PipelineSpec
 from .dotctx import load_dotctx, reasoner_to_flow
 from .execution.policy import ExecutionPolicy
 from .freeze import McpSnapshot
+from .registry import DEFAULT_REGISTRY, Registry
 
 
 @dataclass(frozen=True)
@@ -39,12 +40,13 @@ def pipeline_spec_from_ctx(
     env_vars: Mapping[str, str] | None = None,
     agent_round_cap: int = 32,
     mcp_servers: Mapping[str, Any] | None = None,
+    _registry: Registry = DEFAULT_REGISTRY,
 ) -> PipelineSpec[Any, Any]:
     ctx_path = Path(config.ctx)
     if not ctx_path.is_absolute():
         ctx_path = root / ctx_path
     merged_env = {**(env_vars or {}), **config.env}
-    reasoner = load_dotctx(str(ctx_path), env=merged_env)
+    reasoner = load_dotctx(str(ctx_path), env=merged_env, _registry=_registry)
     aliases = normalize_tool_bindings(config.tools)
     if reasoner.tools:
         missing = sorted(set(reasoner.tools) - set(aliases))

--- a/julep/deploy.py
+++ b/julep/deploy.py
@@ -70,6 +70,7 @@ if TYPE_CHECKING:
     from .artifact_store import ArtifactStore
     from .execution.effects import McpCaller
     from .execution.interpreter import Result as InterpreterResult
+    from .registry import Registry
     from .typed import FlowLike
 
 
@@ -736,8 +737,11 @@ class Deployment:
         mcp_call: Optional[McpCaller] = None,
         reasoners: Optional[dict[str, Callable[[Any], Any]]] = None,
         tools: Optional[dict[str, Callable[[Any], Any]]] = None,
+        principal: Optional[dict[str, Any]] = None,
+        registry: Optional[Registry] = None,
+        max_parallel: Optional[int] = None,
     ) -> "InterpreterResult":
-        """Run locally with stashed native tools, an MCP caller, and fake reasoners."""
+        """Run locally with injected effects and optional run identity context."""
         mcp_backed = any(isinstance(tool.ref, McpTool) for tool in self.manifest.values())
         if self._tools is None and not mcp_backed:
             raise ValueError(
@@ -767,6 +771,9 @@ class Deployment:
             max_calls=(
                 self.capabilities.max_call_limits() if self.capabilities is not None else {}
             ),
+            max_parallel=max_parallel,
+            registry=registry,
+            principal=principal,
         )
         return await interpret(self.flow, value, env)
 
@@ -777,6 +784,9 @@ class Deployment:
         mcp_call: Optional[McpCaller] = None,
         reasoners: Optional[dict[str, Callable[[Any], Any]]] = None,
         tools: Optional[dict[str, Callable[[Any], Any]]] = None,
+        principal: Optional[dict[str, Any]] = None,
+        registry: Optional[Registry] = None,
+        max_parallel: Optional[int] = None,
     ) -> "InterpreterResult":
         """Synchronously run this deployment locally via :meth:`adry_run`."""
         return asyncio.run(
@@ -785,6 +795,9 @@ class Deployment:
                 mcp_call=mcp_call,
                 reasoners=reasoners,
                 tools=tools,
+                principal=principal,
+                registry=registry,
+                max_parallel=max_parallel,
             )
         )
 

--- a/julep/dispatch.py
+++ b/julep/dispatch.py
@@ -1,0 +1,397 @@
+"""Public dispatch-boundary primitives for durable workflow starts.
+
+Flows describe what happens after work starts.  This module owns the small,
+backend-facing policies that decide whether and when work starts: stable
+workflow identities, Temporal signal-with-start requests, and batch windows.
+None of these values are part of the frozen IR.
+
+The module is import-safe without the Temporal extra.  Constructing a generic
+:class:`SignalWithStartRequest` and evaluating a :class:`BatchWindow` are pure;
+executing a request (or constructing the built-in debounce collector input)
+requires ``julep[temporal]``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from collections.abc import Awaitable, Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Any, Optional, Protocol
+
+
+_UNSAFE_ID_CHARS = re.compile(r"[^A-Za-z0-9_.-]+")
+_RESERVED_START_OPTIONS = frozenset(
+    {
+        "id",
+        "task_queue",
+        "start_signal",
+        "start_signal_args",
+        "id_reuse_policy",
+        "id_conflict_policy",
+    }
+)
+
+
+def dedup_workflow_id(
+    namespace: str,
+    *identity: Any,
+    max_length: int = 255,
+) -> str:
+    """Return an opaque, deterministic workflow id for a logical dispatch.
+
+    ``identity`` must be JSON-serializable.  Mapping order and insignificant
+    JSON whitespace do not affect the result.  The readable namespace is
+    sanitized and bounded; the identity itself is represented only by a
+    128-bit SHA-256 prefix so tenant ids and other dispatch data do not leak
+    into Temporal workflow listings.
+
+    Reuse the returned id for retries of the *same logical dispatch*.  Change
+    any identity component when a fresh run is intended.
+    """
+
+    if not isinstance(namespace, str) or not namespace.strip():
+        raise ValueError("namespace must be a non-empty string")
+    if max_length < 34:
+        raise ValueError("max_length must be at least 34")
+
+    try:
+        payload = json.dumps(
+            {"namespace": namespace, "identity": identity},
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise TypeError("workflow identity must be finite JSON data") from exc
+
+    digest = hashlib.sha256(payload).hexdigest()[:32]
+    safe_namespace = _UNSAFE_ID_CHARS.sub("-", namespace.strip()).strip("-._")
+    if not safe_namespace:
+        safe_namespace = "dispatch"
+    prefix_limit = max_length - len(digest) - 1
+    safe_namespace = safe_namespace[:prefix_limit].rstrip("-._") or "dispatch"
+    return f"{safe_namespace}:{digest}"
+
+
+class BatchTrigger(str, Enum):
+    """Condition that will (or did) close a batch window."""
+
+    QUIET = "quiet"
+    MAX_ITEMS = "max_items"
+    MAX_WAIT = "max_wait"
+
+
+@dataclass(frozen=True)
+class BatchWindowDecision:
+    """Pure decision produced by :meth:`BatchWindow.evaluate`.
+
+    ``trigger`` is the condition that is due now, or the condition associated
+    with ``deadline`` while waiting.  An empty batch has no trigger, deadline,
+    or wait duration.
+    """
+
+    fire: bool
+    trigger: Optional[BatchTrigger]
+    deadline: Optional[datetime]
+    wait_s: Optional[float]
+
+
+@dataclass(frozen=True)
+class BatchWindow:
+    """Trigger policy for a debounce or batch collector.
+
+    A non-empty batch fires after ``quiet_s`` without an arrival, after
+    ``max_wait_s`` from its first arrival, or as soon as ``max_items`` is
+    reached.  The first condition reached wins.  ``max_items`` is also the
+    natural hard cap used by Julep's collectors.
+    """
+
+    quiet_s: float
+    max_items: Optional[int] = None
+    max_wait_s: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.quiet_s, (int, float)) or not math.isfinite(self.quiet_s):
+            raise ValueError("quiet_s must be finite")
+        if self.quiet_s < 0:
+            raise ValueError("quiet_s must be non-negative")
+        if self.max_items is not None and (
+            not isinstance(self.max_items, int)
+            or isinstance(self.max_items, bool)
+            or self.max_items < 1
+        ):
+            raise ValueError("max_items must be at least 1")
+        if self.max_wait_s is not None:
+            if not isinstance(self.max_wait_s, (int, float)) or not math.isfinite(
+                self.max_wait_s
+            ):
+                raise ValueError("max_wait_s must be finite")
+            if self.max_wait_s < 0:
+                raise ValueError("max_wait_s must be non-negative")
+
+    def evaluate(
+        self,
+        *,
+        item_count: int,
+        opened_at: Optional[datetime],
+        last_arrival_at: Optional[datetime],
+        now: datetime,
+    ) -> BatchWindowDecision:
+        """Evaluate the next trigger using caller-supplied deterministic time."""
+
+        if item_count < 0:
+            raise ValueError("item_count must be non-negative")
+        if item_count == 0:
+            return BatchWindowDecision(False, None, None, None)
+        if opened_at is None or last_arrival_at is None:
+            raise ValueError("non-empty batches require opened_at and last_arrival_at")
+
+        if self.max_items is not None and item_count >= self.max_items:
+            return BatchWindowDecision(True, BatchTrigger.MAX_ITEMS, now, 0.0)
+
+        trigger = BatchTrigger.QUIET
+        deadline = last_arrival_at + timedelta(seconds=self.quiet_s)
+        if self.max_wait_s is not None:
+            max_wait_deadline = opened_at + timedelta(seconds=self.max_wait_s)
+            if max_wait_deadline < deadline:
+                trigger = BatchTrigger.MAX_WAIT
+                deadline = max_wait_deadline
+
+        wait_s = max((deadline - now).total_seconds(), 0.0)
+        return BatchWindowDecision(wait_s == 0.0, trigger, deadline, wait_s)
+
+
+class _StartWorkflowClient(Protocol):
+    def start_workflow(
+        self,
+        workflow: Any,
+        arg: Any,
+        **kwargs: Any,
+    ) -> Awaitable[Any]: ...
+
+
+@dataclass(frozen=True)
+class SignalWithStartRequest:
+    """Backend-neutral description of one Temporal signal-with-start call.
+
+    The explicit Temporal id policies give this request the useful collector
+    semantics: signal the existing open workflow, but allow a fresh workflow
+    with the same deterministic id after the previous collector has closed.
+    """
+
+    workflow: Any
+    input: Any
+    workflow_id: str
+    task_queue: str
+    signal: str
+    signal_args: Sequence[Any] = field(default_factory=tuple)
+    start_options: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("workflow_id", self.workflow_id),
+            ("task_queue", self.task_queue),
+            ("signal", self.signal),
+        ):
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"{name} must be a non-empty string")
+        reserved = _RESERVED_START_OPTIONS.intersection(self.start_options)
+        if reserved:
+            names = ", ".join(sorted(reserved))
+            raise ValueError(f"start_options cannot override managed fields: {names}")
+
+    def temporal_kwargs(self) -> dict[str, Any]:
+        """Materialize Temporal start arguments without importing it at module load."""
+
+        try:
+            from temporalio.common import WorkflowIDConflictPolicy, WorkflowIDReusePolicy
+        except ImportError as exc:  # pragma: no cover - exercised in no-Temporal CI
+            raise RuntimeError(
+                "Temporal dispatch requires the temporal extra; "
+                "install it with pip install 'julep[temporal]'"
+            ) from exc
+
+        return {
+            **dict(self.start_options),
+            "id": self.workflow_id,
+            "task_queue": self.task_queue,
+            "id_reuse_policy": WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+            "id_conflict_policy": WorkflowIDConflictPolicy.USE_EXISTING,
+            "start_signal": self.signal,
+            "start_signal_args": list(self.signal_args),
+        }
+
+    async def start(self, client: _StartWorkflowClient) -> Any:
+        """Execute this request and return the Temporal workflow handle."""
+
+        return await client.start_workflow(
+            self.workflow,
+            self.input,
+            **self.temporal_kwargs(),
+        )
+
+
+async def signal_with_start(
+    client: _StartWorkflowClient,
+    request: SignalWithStartRequest,
+) -> Any:
+    """Execute a pre-built signal-with-start request."""
+
+    return await request.start(client)
+
+
+def build_debounce_request(
+    flow_json: Mapping[str, Any],
+    manifest_json: Mapping[str, Any],
+    *,
+    key: str,
+    item: Any,
+    window: BatchWindow,
+    task_queue: str = "julep",
+    policy: Optional[Mapping[str, Any]] = None,
+    pinned_pures: Optional[Mapping[str, str]] = None,
+    max_call_limits: Optional[Mapping[str, int]] = None,
+    principal: Optional[Mapping[str, Any]] = None,
+    bundle: Optional[Sequence[Mapping[str, str]]] = None,
+    runtime_declarations_ref: Optional[Mapping[str, Any]] = None,
+    scope: Any = None,
+    workflow_id: Optional[str] = None,
+    start_options: Optional[Mapping[str, Any]] = None,
+) -> SignalWithStartRequest:
+    """Build an atomic debounce-by-key signal-with-start request.
+
+    Unless ``workflow_id`` is supplied for migration compatibility, the id is
+    derived from ``key``, ``scope``, and all collector configuration.  Items
+    are deliberately excluded, so submissions with different items join the
+    same open collector while a changed flow, principal, window, or queue does
+    not accidentally signal an incompatible collector.
+    """
+
+    if not isinstance(key, str) or not key.strip():
+        raise ValueError("key must be a non-empty string")
+    if not isinstance(task_queue, str) or not task_queue.strip():
+        raise ValueError("task_queue must be a non-empty string")
+
+    try:
+        from .execution.debounce import DebounceInput
+    except ImportError as exc:  # pragma: no cover - exercised in no-Temporal CI
+        raise RuntimeError(
+            "Debounce dispatch requires the temporal extra; "
+            "install it with pip install 'julep[temporal]'"
+        ) from exc
+
+    flow = dict(flow_json)
+    manifest = dict(manifest_json)
+    policy_dict = dict(policy) if policy is not None else None
+    pinned = dict(pinned_pures) if pinned_pures is not None else None
+    limits = dict(max_call_limits) if max_call_limits is not None else None
+    principal_dict = dict(principal) if principal is not None else None
+    bundle_list = [dict(row) for row in bundle] if bundle is not None else None
+    declarations = (
+        dict(runtime_declarations_ref) if runtime_declarations_ref is not None else None
+    )
+
+    if workflow_id is None:
+        workflow_id = dedup_workflow_id(
+            "debounce",
+            {
+                "key": key,
+                "scope": scope,
+                "flow": flow,
+                "manifest": manifest,
+                "window": {
+                    "quiet_s": window.quiet_s,
+                    "max_items": window.max_items,
+                    "max_wait_s": window.max_wait_s,
+                },
+                "task_queue": task_queue,
+                "policy": policy_dict,
+                "pinned_pures": pinned,
+                "max_call_limits": limits,
+                "principal": principal_dict,
+                "bundle": bundle_list,
+                "runtime_declarations_ref": declarations,
+            },
+        )
+
+    return SignalWithStartRequest(
+        workflow="DebounceCollector",
+        input=DebounceInput(
+            key=key,
+            flow_json=flow,
+            manifest_json=manifest,
+            quiet_s=window.quiet_s,
+            max_items=window.max_items,
+            max_wait_s=window.max_wait_s,
+            policy=policy_dict,
+            pinned_pures=pinned,
+            max_call_limits=limits,
+            principal=principal_dict,
+            bundle=bundle_list,
+            runtime_declarations_ref=declarations,
+        ),
+        workflow_id=workflow_id,
+        task_queue=task_queue,
+        signal="submit",
+        signal_args=(item,),
+        start_options=start_options or {},
+    )
+
+
+async def dispatch_debounced(
+    client: _StartWorkflowClient,
+    flow_json: Mapping[str, Any],
+    manifest_json: Mapping[str, Any],
+    *,
+    key: str,
+    item: Any,
+    window: BatchWindow,
+    task_queue: str = "julep",
+    policy: Optional[Mapping[str, Any]] = None,
+    pinned_pures: Optional[Mapping[str, str]] = None,
+    max_call_limits: Optional[Mapping[str, int]] = None,
+    principal: Optional[Mapping[str, Any]] = None,
+    bundle: Optional[Sequence[Mapping[str, str]]] = None,
+    runtime_declarations_ref: Optional[Mapping[str, Any]] = None,
+    scope: Any = None,
+    workflow_id: Optional[str] = None,
+    start_options: Optional[Mapping[str, Any]] = None,
+) -> Any:
+    """Submit one item to the durable debounce collector for ``key``."""
+
+    request = build_debounce_request(
+        flow_json,
+        manifest_json,
+        key=key,
+        item=item,
+        window=window,
+        task_queue=task_queue,
+        policy=policy,
+        pinned_pures=pinned_pures,
+        max_call_limits=max_call_limits,
+        principal=principal,
+        bundle=bundle,
+        runtime_declarations_ref=runtime_declarations_ref,
+        scope=scope,
+        workflow_id=workflow_id,
+        start_options=start_options,
+    )
+    return await signal_with_start(client, request)
+
+
+__all__ = [
+    "BatchTrigger",
+    "BatchWindow",
+    "BatchWindowDecision",
+    "SignalWithStartRequest",
+    "build_debounce_request",
+    "dedup_workflow_id",
+    "dispatch_debounced",
+    "signal_with_start",
+]

--- a/julep/dotctx.py
+++ b/julep/dotctx.py
@@ -45,7 +45,7 @@ from .dsl import app, iter_up_to, sub, think
 from .ir import ContextPolicy, Node, SubContract
 from .kinds import ContextScope, Shape, SummaryPolicy
 from .model_slugs import EFFORT_LEVELS, normalize_model_slug
-from .registry import DEFAULT_REGISTRY
+from .registry import DEFAULT_REGISTRY, Registry
 
 _REPLY_UNSET = object()
 _SUPPORTED_REPLY_FORMS = "pydantic v2 model with model_json_schema() or TypedDict"
@@ -444,8 +444,13 @@ def _model_and_effort(settings: dict[str, Any]) -> tuple[str, Optional[str], int
     return slug.model, (effort or slug.reasoning_effort), retries
 
 
-def reasoner_from_settings(settings: dict[str, Any], *, name: Optional[str] = None,
-                        base_dir: Optional[str] = None) -> Reasoner:
+def reasoner_from_settings(
+    settings: dict[str, Any],
+    *,
+    name: Optional[str] = None,
+    base_dir: Optional[str] = None,
+    _registry: Registry = DEFAULT_REGISTRY,
+) -> Reasoner:
     """Build (and register) a :class:`Reasoner` from a settings mapping.
 
     ``base_dir`` lets ``system_file`` / ``schema_file`` resolve relative paths;
@@ -495,7 +500,7 @@ def reasoner_from_settings(settings: dict[str, Any], *, name: Optional[str] = No
         response_format=_response_format_setting(settings),
         prompt_cache=_prompt_cache_setting(settings),
     )
-    return DEFAULT_REGISTRY.register_reasoner(reasoner)
+    return _registry.register_reasoner(reasoner)
 
 
 # Rich-layout markers: any of these turns the package over to dotctx_rich
@@ -508,7 +513,12 @@ def is_rich_dotctx(path: str) -> bool:
     return any(os.path.exists(os.path.join(path, m)) for m in _RICH_MARKERS)
 
 
-def load_dotctx(path: str, *, env: Optional[Mapping[str, str]] = None) -> Reasoner:
+def load_dotctx(
+    path: str,
+    *,
+    env: Optional[Mapping[str, str]] = None,
+    _registry: Registry = DEFAULT_REGISTRY,
+) -> Reasoner:
     """Read a dotctx directory — or a single ``.ctx`` file — into a Reasoner.
 
     A directory reads ``<path>/settings.yaml`` (or ``settings.yml``); the
@@ -533,7 +543,7 @@ def load_dotctx(path: str, *, env: Optional[Mapping[str, str]] = None) -> Reason
 
         return _warn_missing_output_schema(
             path,
-            dotctx_rich.load_single_file_dotctx(path, env=env).reasoner,
+            dotctx_rich.load_single_file_dotctx(path, registry=_registry, env=env).reasoner,
         )
     if not os.path.isdir(path):
         raise FileNotFoundError(f"dotctx path does not exist: {path!r}")
@@ -543,7 +553,7 @@ def load_dotctx(path: str, *, env: Optional[Mapping[str, str]] = None) -> Reason
 
         return _warn_missing_output_schema(
             path,
-            dotctx_rich.load_rich_dotctx(path, env=env).reasoner,
+            dotctx_rich.load_rich_dotctx(path, registry=_registry, env=env).reasoner,
         )
 
     settings_path = None
@@ -577,6 +587,7 @@ def load_dotctx(path: str, *, env: Optional[Mapping[str, str]] = None) -> Reason
             settings,
             name=settings.get("name", default_name),
             base_dir=path,
+            _registry=_registry,
         ),
     )
 

--- a/julep/dotctx.py
+++ b/julep/dotctx.py
@@ -31,6 +31,7 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
+    TypeVar,
     Union,
     cast,
     get_args,
@@ -48,6 +49,14 @@ from .registry import DEFAULT_REGISTRY
 
 _REPLY_UNSET = object()
 _SUPPORTED_REPLY_FORMS = "pydantic v2 model with model_json_schema() or TypedDict"
+
+
+_KEEP: Any = object()
+_T = TypeVar("_T")
+
+
+def _replacement(value: Any, current: _T) -> _T:
+    return current if value is _KEEP else cast(_T, value)
 
 
 class MissingOutputSchemaWarning(UserWarning):
@@ -234,6 +243,57 @@ class Reasoner:
                 "supported values are '5m' or '1h'"
             )
         object.__setattr__(self, "prompt_cache", prompt_cache)
+
+    def replace(
+        self,
+        *,
+        name: str = _KEEP,
+        model: str = _KEEP,
+        system: str = _KEEP,
+        reply: Any = _KEEP,
+        tools: Sequence[str] = _KEEP,
+        temperature: Optional[float] = _KEEP,
+        max_rounds: Optional[int] = _KEEP,
+        is_agent: bool = _KEEP,
+        sub_contract: Optional[SubContract] = _KEEP,
+        context_scope: ContextScope = _KEEP,
+        system_render: Optional[str] = _KEEP,
+        user_render: Optional[str] = _KEEP,
+        max_tokens: Optional[int] = _KEEP,
+        reasoning_effort: Optional[str] = _KEEP,
+        output_retries: int = _KEEP,
+        require_tool_call: bool = _KEEP,
+        response_format: Optional[str] = _KEEP,
+        prompt_cache: Optional[str] = _KEEP,
+    ) -> Reasoner:
+        """Return a copy with selected fields replaced.
+
+        Omitting ``reply`` preserves the already-materialized reply schema;
+        passing ``reply=None`` explicitly clears it, while a Pydantic model or
+        ``TypedDict`` is materialized exactly as it is during construction.
+        """
+
+        replacement_reply = self.reply_schema if reply is _KEEP else reply
+        return Reasoner(
+            name=_replacement(name, self.name),
+            model=_replacement(model, self.model),
+            system=_replacement(system, self.system),
+            reply=replacement_reply,
+            tools=_replacement(tools, self.tools),
+            temperature=_replacement(temperature, self.temperature),
+            max_rounds=_replacement(max_rounds, self.max_rounds),
+            is_agent=_replacement(is_agent, self.is_agent),
+            sub_contract=_replacement(sub_contract, self.sub_contract),
+            context_scope=_replacement(context_scope, self.context_scope),
+            system_render=_replacement(system_render, self.system_render),
+            user_render=_replacement(user_render, self.user_render),
+            max_tokens=_replacement(max_tokens, self.max_tokens),
+            reasoning_effort=_replacement(reasoning_effort, self.reasoning_effort),
+            output_retries=_replacement(output_retries, self.output_retries),
+            require_tool_call=_replacement(require_tool_call, self.require_tool_call),
+            response_format=_replacement(response_format, self.response_format),
+            prompt_cache=_replacement(prompt_cache, self.prompt_cache),
+        )
 
 
 _REASONERS: dict[str, Reasoner] = DEFAULT_REGISTRY.reasoners

--- a/julep/dotctx.py
+++ b/julep/dotctx.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import os
 import types
+import warnings
 from dataclasses import dataclass
 from typing import (
     Any,
@@ -47,6 +48,21 @@ from .registry import DEFAULT_REGISTRY
 
 _REPLY_UNSET = object()
 _SUPPORTED_REPLY_FORMS = "pydantic v2 model with model_json_schema() or TypedDict"
+
+
+class MissingOutputSchemaWarning(UserWarning):
+    """A loaded dotctx package has no reply schema to validate model output."""
+
+
+def _warn_missing_output_schema(path: str, reasoner: "Reasoner") -> "Reasoner":
+    if reasoner.reply_schema is None:
+        warnings.warn(
+            f"dotctx package {path!r} does not define class Output in schema.pyi; "
+            "model replies will not be schema-validated",
+            MissingOutputSchemaWarning,
+            stacklevel=3,
+        )
+    return reasoner
 
 
 def _unsupported_reply_type(value: object) -> TypeError:
@@ -441,14 +457,20 @@ def load_dotctx(path: str, *, env: Optional[Mapping[str, str]] = None) -> Reason
             raise ValueError(f"single-file dotctx must end in .ctx: {path!r}")
         from . import dotctx_rich  # hard ImportError without the [dotctx] extra
 
-        return dotctx_rich.load_single_file_dotctx(path, env=env).reasoner
+        return _warn_missing_output_schema(
+            path,
+            dotctx_rich.load_single_file_dotctx(path, env=env).reasoner,
+        )
     if not os.path.isdir(path):
         raise FileNotFoundError(f"dotctx path does not exist: {path!r}")
 
     if is_rich_dotctx(path):
         from . import dotctx_rich  # hard ImportError without the [dotctx] extra
 
-        return dotctx_rich.load_rich_dotctx(path, env=env).reasoner
+        return _warn_missing_output_schema(
+            path,
+            dotctx_rich.load_rich_dotctx(path, env=env).reasoner,
+        )
 
     settings_path = None
     for fn in ("settings.yaml", "settings.yml"):
@@ -475,8 +497,14 @@ def load_dotctx(path: str, *, env: Optional[Mapping[str, str]] = None) -> Reason
 
         settings = yaml.safe_load(text) or {}
     default_name = os.path.basename(os.path.normpath(path))
-    return reasoner_from_settings(settings, name=settings.get("name", default_name),
-                               base_dir=path)
+    return _warn_missing_output_schema(
+        path,
+        reasoner_from_settings(
+            settings,
+            name=settings.get("name", default_name),
+            base_dir=path,
+        ),
+    )
 
 
 # --------------------------------------------------------------------------- #

--- a/julep/dotctx.py
+++ b/julep/dotctx.py
@@ -53,6 +53,14 @@ _SUPPORTED_REPLY_FORMS = "pydantic v2 model with model_json_schema() or TypedDic
 
 _KEEP: Any = object()
 _T = TypeVar("_T")
+_REPLACE_HANDLED_FIELDS = frozenset(
+    {
+        "name", "model", "system", "reply_schema", "tools", "temperature",
+        "max_rounds", "is_agent", "sub_contract", "context_scope",
+        "system_render", "user_render", "max_tokens", "reasoning_effort",
+        "output_retries", "require_tool_call", "response_format", "prompt_cache",
+    }
+)
 
 
 def _replacement(value: Any, current: _T) -> _T:
@@ -274,7 +282,7 @@ class Reasoner:
         """
 
         replacement_reply = self.reply_schema if reply is _KEEP else reply
-        return Reasoner(
+        replaced = Reasoner(
             name=_replacement(name, self.name),
             model=_replacement(model, self.model),
             system=_replacement(system, self.system),
@@ -294,6 +302,12 @@ class Reasoner:
             response_format=_replacement(response_format, self.response_format),
             prompt_cache=_replacement(prompt_cache, self.prompt_cache),
         )
+        # Preserve extension/future fields this version cannot yet override.
+        # Declared fields still go through the constructor above for validation.
+        for field_name, value in vars(self).items():
+            if field_name not in _REPLACE_HANDLED_FIELDS:
+                object.__setattr__(replaced, field_name, value)
+        return replaced
 
 
 _REASONERS: dict[str, Reasoner] = DEFAULT_REGISTRY.reasoners

--- a/julep/execution/dbos_backend.py
+++ b/julep/execution/dbos_backend.py
@@ -591,6 +591,10 @@ class DbosEnv:
                 config["nativeTools"] = app_config["nativeTools"]
             if "requireToolCall" in app_config:
                 config["requireToolCall"] = app_config["requireToolCall"]
+            if "replySchema" in app_config:
+                config["replySchema"] = app_config["replySchema"]
+            if "outputRetries" in app_config:
+                config["outputRetries"] = app_config["outputRetries"]
 
             tools = app_config.get("tools") if "tools" in app_config else None
             granted_tools = None if tools is None else list(tools)
@@ -604,15 +608,37 @@ class DbosEnv:
             subflows = app_config.get("subflows") if "subflows" in app_config else None
             granted_subflows = None if subflows is None else list(subflows)
             if tools is not None:
-                granted_contracts = al.manifest_contracts_for_agent(
-                    self.manifest,
-                    granted_tools,
-                    self._max_call_limits,
-                )
+                if "toolContracts" in app_config:
+                    granted_contracts = {
+                        str(alias): dict(contract)
+                        for alias, contract in app_config["toolContracts"].items()
+                    }
+                    for raw_alias in granted_tools or ():
+                        alias = str(raw_alias)
+                        wire = (tool_aliases or {}).get(alias, alias)
+                        limit = self._max_call_limits.get(wire)
+                        if limit is None:
+                            continue
+                        contract = granted_contracts.setdefault(alias, {})
+                        authored_limit = contract.get(
+                            "maxCalls",
+                            contract.get("max_calls"),
+                        )
+                        contract["maxCalls"] = (
+                            int(limit)
+                            if authored_limit is None
+                            else min(int(limit), int(authored_limit))
+                        )
+                else:
+                    granted_contracts = al.manifest_contracts_for_agent(
+                        self.manifest,
+                        granted_tools,
+                        self._max_call_limits,
+                    )
 
         # Parity with run_sub: parent call counts seed the child agent so an
-        # app node cannot reset an already-consumed maxCalls budget. Counts
-        # flow one-way; the child's counts are not merged back.
+        # app node cannot reset an already-consumed maxCalls budget. Terminal
+        # counts merge back below as canonical wire-keyed high-water marks.
         state_json = (
             al.AgentState(last=value, call_counts=dict(self._call_counts)).to_json()
             if self._call_counts
@@ -638,7 +664,15 @@ class DbosEnv:
             "rootRunId": self.root_run_id,
             "segmentSeq": 0,
         }
-        return await _run_agent_chain(payload, base_id=base_id)
+        out = await _run_agent_chain(payload, base_id=base_id)
+        if isinstance(out, dict) and isinstance(out.get("callCounts"), dict):
+            for tool, raw_count in out["callCounts"].items():
+                key = str(tool)
+                self._call_counts[key] = max(
+                    self._call_counts.get(key, 0),
+                    int(raw_count),
+                )
+        return out
 
     async def human_gate(self, value: Any, cid: str, timeout_s: Optional[int]) -> Any:
         payload = await DBOS.recv_async(
@@ -927,7 +961,9 @@ async def agent_workflow(inp: dict) -> Any:
             session_id=f"{session}-sub-{state.round}",
             emitter=emitter,
             policy=policy,
-            max_call_limits=al.max_call_limits_from_contracts(contracts) or {},
+            max_call_limits=(
+                al.max_call_limits_from_contracts(contracts, tool_aliases) or {}
+            ),
             call_counts=dict(state.call_counts),
             principal=principal,
             root_run_id=root_run_id,
@@ -944,6 +980,7 @@ async def agent_workflow(inp: dict) -> Any:
         granted=None if unconstrained else granted_set,
         granted_subflows=None if granted_subflows is None else set(granted_subflows),
         contracts=contracts,
+        tool_count_keys=tool_aliases,
         tool_schemas=tool_schemas,
         mode=cfg.mode,
         prod_gap=prod_gap,

--- a/julep/execution/debounce.py
+++ b/julep/execution/debounce.py
@@ -35,10 +35,12 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field, replace
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any, Optional
 
 from temporalio import workflow
+
+from ..dispatch import BatchWindow, dispatch_debounced
 
 with workflow.unsafe.imports_passed_through():
     from .harness import FlowWorkflow, build_flow_input
@@ -114,25 +116,25 @@ class DebounceCollector:
             self._last_at = _parse_at(inp.pending_last_at) or opened
 
         # --- collect until the fire condition holds -------------------------- #
+        window = BatchWindow(
+            quiet_s=inp.quiet_s,
+            max_items=inp.max_items,
+            max_wait_s=inp.max_wait_s,
+        )
         while True:
-            if inp.max_items is not None and len(self._items) >= inp.max_items:
+            decision = window.evaluate(
+                item_count=len(self._items),
+                opened_at=opened if self._items else None,
+                last_arrival_at=self._last_at,
+                now=workflow.now(),
+            )
+            if decision.fire:
                 break
-            now = workflow.now()
-            if self._items:
-                assert self._last_at is not None
-                deadline = self._last_at + timedelta(seconds=inp.quiet_s)
-                if inp.max_wait_s is not None:
-                    deadline = min(deadline, opened + timedelta(seconds=inp.max_wait_s))
-                if now >= deadline:
-                    break
-                timeout: Optional[float] = max((deadline - now).total_seconds(), 0.0)
-            else:
-                # Signal-with-start means at least one signal is on its way.
-                timeout = None
             count = len(self._items)
             try:
                 await workflow.wait_condition(
-                    lambda count=count: len(self._items) > count, timeout=timeout
+                    lambda count=count: len(self._items) > count,
+                    timeout=decision.wait_s,
                 )
             except asyncio.TimeoutError:
                 pass  # re-evaluate the fire condition against workflow.now()
@@ -211,26 +213,28 @@ async def submit_debounced(
     fixed by whichever submission opens the collector; later submissions to an
     open batch contribute only their item.
     """
-    return await client.start_workflow(
-        DebounceCollector.run,
-        DebounceInput(
-            key=key,
-            flow_json=flow_json,
-            manifest_json=manifest_json,
+    return await dispatch_debounced(
+        client,
+        flow_json,
+        manifest_json,
+        key=key,
+        item=item,
+        window=BatchWindow(
             quiet_s=quiet_s,
             max_items=max_items,
             max_wait_s=max_wait_s,
-            policy=policy,
-            pinned_pures=pinned_pures,
-            max_call_limits=max_call_limits,
-            principal=principal,
-            bundle=bundle,
-            runtime_declarations_ref=runtime_declarations_ref,
         ),
-        id=f"debounce:{key}",
         task_queue=task_queue,
-        start_signal="submit",
-        start_signal_args=[item],
+        policy=policy,
+        pinned_pures=pinned_pures,
+        max_call_limits=max_call_limits,
+        principal=principal,
+        bundle=bundle,
+        runtime_declarations_ref=runtime_declarations_ref,
+        # Keep the historical collector id for callers of this compatibility
+        # wrapper.  New code should use julep.dispatch.dispatch_debounced,
+        # whose id also scopes the frozen target/configuration.
+        workflow_id=f"debounce:{key}",
     )
 
 

--- a/julep/execution/harness.py
+++ b/julep/execution/harness.py
@@ -587,6 +587,14 @@ def _agent_frozen_tool_input_validation_enabled() -> bool:
         return False
 
 
+def _agent_canonical_tool_counts_enabled() -> bool:
+    """Replay gate for wire-keyed maxCalls counters across provider aliases."""
+    try:
+        return workflow.patched("agent-canonical-tool-counts-v1")
+    except Exception:
+        return False
+
+
 def _mcp_preflight_enabled() -> bool:
     """Replay gate for MCP preflight, safe for direct workflow unit calls."""
     try:
@@ -1203,6 +1211,7 @@ class _TemporalEnv:
         cid: str,
         app_config: Optional[dict[str, Any]] = None,
     ) -> Any:
+        canonical_tool_counts = _agent_canonical_tool_counts_enabled()
         child_id = self._child_id("agent", cid)
         config: Optional[dict[str, Any]] = None
         granted_tools: Optional[list[str]] = None
@@ -1261,8 +1270,16 @@ class _TemporalEnv:
                         alias = str(raw_alias)
                         wire = (tool_aliases or {}).get(alias, alias)
                         if wire in self._max_call_limits:
-                            granted_contracts.setdefault(alias, {})["maxCalls"] = int(
-                                self._max_call_limits[wire]
+                            contract = granted_contracts.setdefault(alias, {})
+                            authored_limit = contract.get(
+                                "maxCalls",
+                                contract.get("max_calls"),
+                            )
+                            parent_limit = int(self._max_call_limits[wire])
+                            contract["maxCalls"] = (
+                                parent_limit
+                                if authored_limit is None or not canonical_tool_counts
+                                else min(parent_limit, int(authored_limit))
                             )
                 else:
                     granted_contracts = al.manifest_contracts_for_agent(
@@ -2695,6 +2712,7 @@ class AgentWorkflow:
             )
 
         policy = ExecutionPolicy.from_json(inp.policy)
+        canonical_tool_counts = _agent_canonical_tool_counts_enabled()
 
         # Resolve config + grant metadata once, then carry it through
         # continue-as-new. Inline app config can supply grant semantics while
@@ -2810,7 +2828,6 @@ class AgentWorkflow:
             state = al.AgentState.from_json(inp.state)
         else:
             state = al.AgentState(last=inp.input)
-
         # Per-segment continue-as-new cadence: carried state keeps the
         # cumulative round count, so truncation is measured from this
         # segment's entry round, not from zero.
@@ -3126,7 +3143,16 @@ class AgentWorkflow:
                     continue
                 for entry in calls:
                     tool = entry["tool"]
-                    denial = al.charge_tool_call(state, tool, contracts)
+                    denial = al.charge_tool_call(
+                        state,
+                        tool,
+                        contracts,
+                        count_key=(
+                            tool_aliases.get(tool, tool)
+                            if canonical_tool_counts
+                            else tool
+                        ),
+                    )
                     if denial is not None:
                         terminal = al.terminal_result("denied", state, reason=denial.reason)
                         await self._finish_trajectory(
@@ -3297,7 +3323,12 @@ class AgentWorkflow:
                     )
                     state.round += 1
                     continue
-                denial = al.charge_tool_call(state, tool, contracts)
+                denial = al.charge_tool_call(
+                    state,
+                    tool,
+                    contracts,
+                    count_key=wire_tool if canonical_tool_counts else tool,
+                )
                 if denial is not None:
                     terminal = al.terminal_result("denied", state, reason=denial.reason)
                     await self._finish_trajectory(
@@ -3437,7 +3468,10 @@ class AgentWorkflow:
                         input=sub_input,
                         ref=ref,
                         policy=policy.to_json(),
-                        max_call_limits=al.max_call_limits_from_contracts(contracts),
+                        max_call_limits=al.max_call_limits_from_contracts(
+                            contracts,
+                            tool_aliases if canonical_tool_counts else None,
+                        ),
                         call_counts=dict(state.call_counts),
                         principal=inp.principal,
                         root_run_id=(inp.root_run_id or inp.session_id),

--- a/julep/execution/harness.py
+++ b/julep/execution/harness.py
@@ -111,6 +111,14 @@ with workflow.unsafe.imports_passed_through():
         redacted_failure_text,
         secret_safe_activity,
     )
+    from .mcp_preflight import (
+        McpPreflightError,
+        _MCP_PREFLIGHT_CACHE,
+        _MCP_PREFLIGHT_CACHE_MAX_ENTRIES,
+        _MCP_PREFLIGHT_CACHE_TTL_S,
+        _prune_mcp_preflight_cache as _prune_mcp_preflight_cache_core,
+        preflight_mcp,
+    )
     from .session_store import value_fingerprint
     from .projection_store import finalize_projection_run, persist_projection_batch
     from .timeouts import activity_timeout
@@ -174,29 +182,15 @@ _NON_RETRYABLE = [
 ]
 
 
-_MCP_PREFLIGHT_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
-_MCP_PREFLIGHT_CACHE_TTL_S = 30.0
-_MCP_PREFLIGHT_CACHE_MAX_ENTRIES = 256
-
-
 def _prune_mcp_preflight_cache(now: float) -> None:
     """Drop stale entries and bound per-worker preflight cache growth."""
-    expired = [
-        key
-        for key, (cached_at, _result) in _MCP_PREFLIGHT_CACHE.items()
-        if now - cached_at > _MCP_PREFLIGHT_CACHE_TTL_S
-    ]
-    for key in expired:
-        _MCP_PREFLIGHT_CACHE.pop(key, None)
-    overflow = len(_MCP_PREFLIGHT_CACHE) - _MCP_PREFLIGHT_CACHE_MAX_ENTRIES
-    if overflow <= 0:
-        return
-    oldest = sorted(
-        _MCP_PREFLIGHT_CACHE,
-        key=lambda key: (_MCP_PREFLIGHT_CACHE[key][0], key),
+
+    _prune_mcp_preflight_cache_core(
+        now,
+        cache=_MCP_PREFLIGHT_CACHE,
+        ttl_s=_MCP_PREFLIGHT_CACHE_TTL_S,
+        max_entries=_MCP_PREFLIGHT_CACHE_MAX_ENTRIES,
     )
-    for key in oldest[:overflow]:
-        _MCP_PREFLIGHT_CACHE.pop(key, None)
 
 
 def _reserved_channel_tool_name(node: Node) -> Optional[str]:
@@ -214,229 +208,21 @@ def _reserved_channel_tool_name(node: Node) -> Optional[str]:
 @activity.defn(name="preflightMcp")
 @secret_safe_activity
 async def preflightMcp(inp: dict[str, Any]) -> dict[str, Any]:
-    """Validate run bindings and the frozen MCP surface on the worker path."""
-    import hashlib
-    import json
-    import time
+    """Temporal activity wrapper around backend-neutral MCP preflight."""
 
-    from ..contracts import manifest_from_json
-    from ..deploy import snapshot_from_listings
-    from ..ir import McpTool, Node, Op, SubStep, canonical_json
-    from ..mcp_auth import _SECRET_REF, transport_for_mcp_caller
-    from ..mcp_surface import (
-        McpSurfaceMismatchError,
-        McpSurfacePolicy,
-        assert_mcp_surface,
-        canonical_surface_digest,
-    )
-    from . import effects as _effects
-
-    policy = McpSurfacePolicy.coerce(str(inp.get("policy", "off")))
-    now = time.monotonic()
-    _prune_mcp_preflight_cache(now)
-    # Preflight the entire statically reachable release surface, not only the
-    # root manifest.  Ref children are frozen independently and resolved from
-    # the release-scoped worker registry at runtime; walking them here keeps the
-    # workflow command sequence unchanged while still refusing drift before the
-    # root can schedule user/tool effects.
-    manifest_jsons: list[Mapping[str, Any]] = [
-        dict(inp.get("manifestJson") or {})
-    ]
-    pending_flows: list[Mapping[str, Any]] = []
-    root_flow = inp.get("flowJson")
-    if isinstance(root_flow, Mapping):
-        pending_flows.append(root_flow)
-    seen_refs: set[str] = set()
-    while pending_flows:
-        flow = Node.from_json(dict(pending_flows.pop()))
-        refs: set[str] = set()
-        for node in flow.walk():
-            if isinstance(node.step, SubStep):
-                refs.add(node.step.ref)
-            if node.op is Op.APP and isinstance(node.subflows, (list, tuple)):
-                refs.update(str(ref) for ref in node.subflows)
-        for ref in sorted(refs):
-            if ref in seen_refs:
-                continue
-            seen_refs.add(ref)
-            spec = _effects._CTX.subflows.get(ref)
-            if spec is None:
-                # Preserve existing lazy failure semantics for an unregistered
-                # branch; preflight only expands frozen children the release
-                # worker can actually resolve.
-                continue
-            child_manifest = spec.get("manifestJson")
-            if isinstance(child_manifest, Mapping):
-                manifest_jsons.append(child_manifest)
-            child_flow = spec.get("flowJson")
-            if isinstance(child_flow, Mapping):
-                pending_flows.append(child_flow)
-
-    frozen = [
-        tool
-        for manifest_json in manifest_jsons
-        for tool in manifest_from_json(dict(manifest_json)).values()
-        if isinstance(tool.ref, McpTool)
-    ]
-    if not frozen:
-        unused = sorted(dict(inp.get("secrets") or {}))
-        if unused:
-            raise ApplicationError(
-                json.dumps(
-                    {
-                        "error": "invalid_run_secret_binding",
-                        "names": unused,
-                        "allowed": [],
-                    },
-                    sort_keys=True,
-                ),
-                type="invalid_run_secret_binding",
-                non_retryable=True,
-            )
-        return {"policy": policy.value, "completed": True, "surfaceDigest": None}
-
-    frozen_digest = canonical_surface_digest(frozen)
-    run_secrets = dict(inp.get("secrets") or {})
-    if policy is McpSurfacePolicy.OFF and not run_secrets:
-        return {
-            "policy": policy.value,
-            "completed": True,
-            "surfaceDigest": frozen_digest,
-        }
-
-    transport = _effects._CTX.mcp_transport
-    if transport is None:
-        transport = transport_for_mcp_caller(_effects._CTX.mcp_call)
-    if transport is None:
-        raise RuntimeError("worker has no MCP transport configured for preflight")
-
-    servers = sorted({tool.ref.server for tool in frozen})
-
-    # Only whole-string references in the request-time config for referenced
-    # servers are valid run bindings.  Values never enter this diagnostic.
-    allowed_names: set[str] = set()
-    configs: dict[str, Any] = {}
-    for server in servers:
-        config = transport._config(server)
-        configs[server] = config
-        for value in config.headers.values():
-            match = _SECRET_REF.fullmatch(value)
-            if match is not None:
-                allowed_names.add(match.group(1))
-    unused = sorted(set(run_secrets) - allowed_names)
-    if unused:
-        raise ApplicationError(
-            json.dumps(
-                {
-                    "error": "invalid_run_secret_binding",
-                    "names": unused,
-                    "allowed": sorted(allowed_names),
-                },
-                sort_keys=True,
-            ),
-            type="invalid_run_secret_binding",
-            non_retryable=True,
-        )
-
-    if policy is McpSurfacePolicy.OFF:
-        return {
-            "policy": policy.value,
-            "completed": True,
-            "surfaceDigest": frozen_digest,
-        }
-    sinks: list[tuple[str, str]] = []
-    for server in servers:
-        config = configs[server]
-        sinks.append(
-            (
-                f"{server}:url",
-                hashlib.sha256(str(config.url).encode("utf-8")).hexdigest(),
-            )
-        )
-        if config.version is not None:
-            sinks.append(
-                (
-                    f"{server}:version",
-                    hashlib.sha256(str(config.version).encode("utf-8")).hexdigest(),
-                )
-            )
-        for header, raw_value in sorted(config.headers.items(), key=lambda item: item[0].lower()):
-            resolved = await transport._resolve_ref(raw_value, run_secrets)
-            sinks.append(
-                (
-                    f"{server}:header:{header.lower()}",
-                    hashlib.sha256(resolved.encode("utf-8")).hexdigest(),
-                )
-            )
-    cache_payload = {
-        "frozen": frozen_digest,
-        # Keep per-manifest duplicates in the cache identity. The public
-        # surface digest intentionally collapses by wire ref, but two reachable
-        # flows can pin different definitions for that same ref and must not
-        # reuse a cache entry produced for only one of them.
-        "frozenDefinitions": sorted(
-            (tool.ref.server, tool.ref.tool, tool.definition_hash)
-            for tool in frozen
-        ),
-        "policy": policy.value,
-        "sinks": sinks,
-        "principalHash": hashlib.sha256(
-            canonical_json(inp.get("principal")).encode("utf-8")
-        ).hexdigest(),
-        "auth": (
-            None
-            if transport._auth is None
-            else {"issuer": transport._auth.issuer, "kid": transport._auth.kid}
-        ),
-    }
-    cache_key = hashlib.sha256(canonical_json(cache_payload).encode("utf-8")).hexdigest()
-    cached = _MCP_PREFLIGHT_CACHE.get(cache_key)
-    if cached is not None and now - cached[0] <= _MCP_PREFLIGHT_CACHE_TTL_S:
-        return dict(cached[1])
-
-    listings = await asyncio.gather(
-        *(
-            transport.list_tools(
-                server,
-                workflow_id=str(inp["workflowId"]),
-                principal=inp.get("principal"),
-                run_secrets=run_secrets,
-            )
-            for server in servers
-        )
-    )
-    fresh = snapshot_from_listings(
-        {server: listing.tools for server, listing in zip(servers, listings, strict=True)},
-        versions={server: listing.version for server, listing in zip(servers, listings, strict=True)},
-        protocol_versions={
-            server: listing.protocol_version
-            for server, listing in zip(servers, listings, strict=True)
-        },
-        server_versions={
-            server: listing.server_version
-            for server, listing in zip(servers, listings, strict=True)
-        },
-    )
     try:
-        assert_mcp_surface(frozen, fresh, policy=policy)
-    except McpSurfaceMismatchError as exc:
+        return await preflight_mcp(
+            inp,
+            cache=_MCP_PREFLIGHT_CACHE,
+            cache_ttl_s=_MCP_PREFLIGHT_CACHE_TTL_S,
+            cache_max_entries=_MCP_PREFLIGHT_CACHE_MAX_ENTRIES,
+        )
+    except McpPreflightError as exc:
         raise ApplicationError(
-            json.dumps(
-                {"error": "tool_surface_mismatch", "details": exc.details},
-                sort_keys=True,
-            ),
-            type="tool_surface_mismatch",
-            non_retryable=True,
+            exc.detail,
+            type=exc.type,
+            non_retryable=exc.non_retryable,
         ) from None
-
-    result = {
-        "policy": policy.value,
-        "completed": True,
-        "surfaceDigest": frozen_digest,
-    }
-    _MCP_PREFLIGHT_CACHE[cache_key] = (time.monotonic(), result)
-    _prune_mcp_preflight_cache(time.monotonic())
-    return dict(result)
 
 
 @activity.defn(name="finishTrajectory")

--- a/julep/execution/interpreter.py
+++ b/julep/execution/interpreter.py
@@ -970,7 +970,12 @@ class InMemoryEnv:
         if controller not in self._reasoners:
             raise KeyError(f"no in-memory reasoner or agent for {controller!r}")
 
-        from ..agent_loop import AgentConfig, drive_agent_loop, tool_input_schemas
+        from ..agent_loop import (
+            AgentConfig,
+            AgentState,
+            drive_agent_loop,
+            tool_input_schemas,
+        )
 
         authored = dict(app_config or {})
         cfg = AgentConfig.from_json(authored)
@@ -983,6 +988,18 @@ class InMemoryEnv:
             str(alias): dict(contract)
             for alias, contract in authored.get("toolContracts", {}).items()
         }
+        for alias in set(contracts) | grants:
+            wire = aliases.get(alias, alias)
+            limit = self._max_calls.get(alias, self._max_calls.get(wire))
+            if limit is None:
+                continue
+            contract = contracts.setdefault(alias, {})
+            authored_limit = contract.get("maxCalls", contract.get("max_calls"))
+            contract["maxCalls"] = (
+                int(limit)
+                if authored_limit is None
+                else min(int(limit), int(authored_limit))
+            )
         schemas = (
             tool_input_schemas(authored.get("toolDefs"))
             if authored.get("toolDefs") is not None
@@ -1018,7 +1035,17 @@ class InMemoryEnv:
                 )
             raise KeyError(f"no in-memory fake or MCP caller for tool alias {alias!r}")
 
-        return await drive_agent_loop(
+        initial_counts = dict(self.call_counts)
+        for alias in set(contracts) | grants:
+            wire = aliases.get(alias, alias)
+            count = max(
+                initial_counts.get(alias, 0),
+                initial_counts.get(wire, 0),
+            )
+            if count:
+                initial_counts[alias] = count
+
+        result = await drive_agent_loop(
             input=value,
             cfg=cfg,
             invoke_controller=invoke_controller,
@@ -1026,8 +1053,16 @@ class InMemoryEnv:
             granted=grants,
             contracts=contracts,
             tool_schemas=schemas,
+            state=AgentState(last=value, call_counts=initial_counts),
             get_pure=self.get_pure,
         )
+        carried_counts = result.get("callCounts")
+        if isinstance(carried_counts, dict):
+            for alias, raw_count in carried_counts.items():
+                count = int(raw_count)
+                wire = aliases.get(str(alias), str(alias))
+                self.call_counts[wire] = max(self.call_counts.get(wire, 0), count)
+        return result
 
     async def compile_plan(self, planner: str, value: Any, cid: str) -> Node:
         if planner not in self._planners:

--- a/julep/execution/interpreter.py
+++ b/julep/execution/interpreter.py
@@ -990,7 +990,7 @@ class InMemoryEnv:
         }
         for alias in set(contracts) | grants:
             wire = aliases.get(alias, alias)
-            limit = self._max_calls.get(alias, self._max_calls.get(wire))
+            limit = self._max_calls.get(wire)
             if limit is None:
                 continue
             contract = contracts.setdefault(alias, {})
@@ -1035,16 +1035,6 @@ class InMemoryEnv:
                 )
             raise KeyError(f"no in-memory fake or MCP caller for tool alias {alias!r}")
 
-        initial_counts = dict(self.call_counts)
-        for alias in set(contracts) | grants:
-            wire = aliases.get(alias, alias)
-            count = max(
-                initial_counts.get(alias, 0),
-                initial_counts.get(wire, 0),
-            )
-            if count:
-                initial_counts[alias] = count
-
         result = await drive_agent_loop(
             input=value,
             cfg=cfg,
@@ -1052,16 +1042,17 @@ class InMemoryEnv:
             call_tool=call_tool,
             granted=grants,
             contracts=contracts,
+            tool_count_keys=aliases,
             tool_schemas=schemas,
-            state=AgentState(last=value, call_counts=initial_counts),
+            state=AgentState(last=value, call_counts=dict(self.call_counts)),
             get_pure=self.get_pure,
         )
         carried_counts = result.get("callCounts")
         if isinstance(carried_counts, dict):
-            for alias, raw_count in carried_counts.items():
+            for tool, raw_count in carried_counts.items():
                 count = int(raw_count)
-                wire = aliases.get(str(alias), str(alias))
-                self.call_counts[wire] = max(self.call_counts.get(wire, 0), count)
+                key = str(tool)
+                self.call_counts[key] = max(self.call_counts.get(key, 0), count)
         return result
 
     async def compile_plan(self, planner: str, value: Any, cid: str) -> Node:

--- a/julep/execution/interpreter.py
+++ b/julep/execution/interpreter.py
@@ -437,7 +437,13 @@ async def _eval_prim(node: Node, value: Any, env: Env, cid: str) -> Result:
         batchable = bool(node.ann.batchable) if node.ann else False
         out = await env.invoke_reasoner(step.reasoner, value, cid, timeout_s, batchable)
         reply, attrs = _unwrap_julep_meta(out)
-        return Result(reply, attrs=attrs, reported_cost=_reported_reasoner_cost(reply))
+        reported_cost = _reported_reasoner_cost(reply, attrs)
+        reasoner_attrs = dict(attrs or {})
+        reasoner_attrs.setdefault(
+            "llm.cost.status",
+            "reported" if reported_cost is not None else "unknown",
+        )
+        return Result(reply, attrs=reasoner_attrs, reported_cost=reported_cost)
     if isinstance(step, SubStep):
         return Result(await env.run_sub(step.ref, step.contract, value, cid, node.id))
     raise JulepError(f"interpreter: prim with no usable step at {node.id!r}")
@@ -548,7 +554,10 @@ def _projection_cost(node: Node, reported_cost: Optional[float]) -> Optional[flo
 
     step = node.step
     if isinstance(step, ThinkStep):
-        return reported_cost if reported_cost is not None else DEFAULT_THINK_COST
+        # The staged DEFAULT_THINK_COST is a budget/admission weight, not a USD
+        # price. Projection costs must only contain a declared annotation or a
+        # provider-reported charge; otherwise trace consumers render unknown.
+        return reported_cost
     if isinstance(step, SubStep):
         return DEFAULT_SUB_COST
     if isinstance(step, CallStep):
@@ -576,7 +585,15 @@ def _unwrap_julep_meta(value: Any) -> tuple[Any, Optional[dict[str, Any]]]:
     return value, None
 
 
-def _reported_reasoner_cost(value: Any) -> Optional[float]:
+def _reported_reasoner_cost(
+    value: Any,
+    attrs: Optional[dict[str, Any]] = None,
+) -> Optional[float]:
+    if attrs is not None:
+        meta_cost = attrs.get("llm.cost")
+        if isinstance(meta_cost, (int, float)) and not isinstance(meta_cost, bool):
+            return float(meta_cost)
+
     if not isinstance(value, dict):
         return None
 

--- a/julep/execution/interpreter.py
+++ b/julep/execution/interpreter.py
@@ -37,6 +37,7 @@ from ..errors import (
     JulepError,
     PureExecutionError,
     RaceAllFailed,
+    ToolInputValidation,
 )
 from ..freeze import bind
 from ..ir import (
@@ -905,12 +906,21 @@ class InMemoryEnv:
         key = call_ref_key(node, self.manifest)
         fn = self._tools.get(key)
         if fn is not None:
-            return fn(value)
+            out = fn(value)
+            return await out if inspect.isawaitable(out) else out
 
         step = node.step
         assert isinstance(step, CallStep)
-        ref = bind(node, self.manifest).ref if step.frozen_hash is not None else step.tool
+        frozen = bind(node, self.manifest) if step.frozen_hash is not None else None
+        ref = frozen.ref if frozen is not None else step.tool
         if isinstance(ref, McpTool) and self._mcp_call is not None:
+            input_schema_validated = False
+            if frozen is not None:
+                from .llm import json_schema_error
+
+                if json_schema_error(value, frozen.input_schema) is not None:
+                    raise ToolInputValidation(ref.server, ref.tool)
+                input_schema_validated = True
             return await self._mcp_call(
                 ref.server,
                 ref.tool,
@@ -918,7 +928,7 @@ class InMemoryEnv:
                 cid,
                 self.principal,
                 None,
-                False,
+                input_schema_validated,
             )
         raise KeyError(f"no in-memory tool for {key!r}")
 

--- a/julep/execution/llm.py
+++ b/julep/execution/llm.py
@@ -846,26 +846,7 @@ def _with_model(reasoner: Reasoner, model: str) -> Reasoner:
     """A copy of ``reasoner`` addressed at a different model (not re-registered)."""
     if model == reasoner.model:
         return reasoner
-    return Reasoner(
-        name=reasoner.name,
-        model=model,
-        system=reasoner.system,
-        tools=reasoner.tools,
-        temperature=reasoner.temperature,
-        max_rounds=reasoner.max_rounds,
-        is_agent=reasoner.is_agent,
-        sub_contract=reasoner.sub_contract,
-        context_scope=reasoner.context_scope,
-        system_render=reasoner.system_render,
-        user_render=reasoner.user_render,
-        max_tokens=reasoner.max_tokens,
-        reply=reasoner.reply_schema,
-        reasoning_effort=reasoner.reasoning_effort,
-        output_retries=reasoner.output_retries,
-        require_tool_call=reasoner.require_tool_call,
-        response_format=reasoner.response_format,
-        prompt_cache=reasoner.prompt_cache,
-    )
+    return reasoner.replace(model=model)
 
 
 def make_resilient_llm_caller(

--- a/julep/execution/mcp_preflight.py
+++ b/julep/execution/mcp_preflight.py
@@ -1,0 +1,328 @@
+"""Backend-neutral run-start validation for frozen MCP tool surfaces."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import time
+from collections.abc import Mapping, MutableMapping
+from typing import Any
+
+from ..contracts import manifest_from_json
+from ..deploy import snapshot_from_listings
+from ..ir import McpTool, Node, Op, SubStep, canonical_json
+from ..mcp_auth import _SECRET_REF, transport_for_mcp_caller
+from ..mcp_surface import (
+    McpSurfaceMismatchError,
+    McpSurfacePolicy,
+    assert_mcp_surface,
+    canonical_surface_digest,
+)
+from ..secrets import REDACTED, operator_secret_redactor, scrubber_for_values
+from . import effects
+
+
+McpPreflightCache = MutableMapping[str, tuple[float, dict[str, Any]]]
+
+_MCP_PREFLIGHT_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
+_MCP_PREFLIGHT_CACHE_TTL_S = 30.0
+_MCP_PREFLIGHT_CACHE_MAX_ENTRIES = 256
+
+
+class McpPreflightError(RuntimeError):
+    """A typed preflight refusal independent of any execution backend."""
+
+    def __init__(
+        self,
+        detail: str,
+        *,
+        error_type: str,
+        non_retryable: bool = True,
+    ) -> None:
+        super().__init__(detail)
+        self.detail = detail
+        self.type = error_type
+        self.non_retryable = non_retryable
+
+
+def scrub_mcp_preflight_failure(
+    error: BaseException,
+    run_secrets: Mapping[str, str] | None,
+) -> McpPreflightError:
+    """Preserve failure type while removing operator and per-run secret values."""
+
+    redactor = operator_secret_redactor()
+    if run_secrets:
+        redactor = scrubber_for_values(run_secrets.values(), base=redactor)
+    try:
+        redacted = redactor(str(error))
+    except Exception:
+        redacted = REDACTED
+    detail = redacted if isinstance(redacted, str) else REDACTED
+    return McpPreflightError(
+        detail,
+        error_type=(
+            error.type if isinstance(error, McpPreflightError) else type(error).__name__
+        ),
+        non_retryable=(
+            error.non_retryable if isinstance(error, McpPreflightError) else False
+        ),
+    )
+
+
+def _prune_mcp_preflight_cache(
+    now: float,
+    *,
+    cache: McpPreflightCache = _MCP_PREFLIGHT_CACHE,
+    ttl_s: float = _MCP_PREFLIGHT_CACHE_TTL_S,
+    max_entries: int = _MCP_PREFLIGHT_CACHE_MAX_ENTRIES,
+) -> None:
+    """Drop stale entries and bound per-process preflight cache growth."""
+
+    expired = [
+        key
+        for key, (cached_at, _result) in cache.items()
+        if now - cached_at > ttl_s
+    ]
+    for key in expired:
+        cache.pop(key, None)
+    overflow = len(cache) - max_entries
+    if overflow <= 0:
+        return
+    oldest = sorted(cache, key=lambda key: (cache[key][0], key))
+    for key in oldest[:overflow]:
+        cache.pop(key, None)
+
+
+def _refusal(error_type: str, payload: Mapping[str, Any]) -> McpPreflightError:
+    return McpPreflightError(
+        json.dumps(dict(payload), sort_keys=True),
+        error_type=error_type,
+    )
+
+
+async def preflight_mcp(
+    inp: Mapping[str, Any],
+    *,
+    cache: McpPreflightCache = _MCP_PREFLIGHT_CACHE,
+    cache_ttl_s: float = _MCP_PREFLIGHT_CACHE_TTL_S,
+    cache_max_entries: int = _MCP_PREFLIGHT_CACHE_MAX_ENTRIES,
+) -> dict[str, Any]:
+    """Validate run bindings and the frozen MCP surface on an effect context."""
+
+    policy = McpSurfacePolicy.coerce(str(inp.get("policy", "off")))
+    now = time.monotonic()
+    _prune_mcp_preflight_cache(
+        now,
+        cache=cache,
+        ttl_s=cache_ttl_s,
+        max_entries=cache_max_entries,
+    )
+    # Preflight the entire statically reachable release surface, not only the
+    # root manifest. Ref children are frozen independently and resolved from
+    # the release-scoped worker registry at runtime.
+    manifest_jsons: list[Mapping[str, Any]] = [dict(inp.get("manifestJson") or {})]
+    pending_flows: list[Mapping[str, Any]] = []
+    root_flow = inp.get("flowJson")
+    if isinstance(root_flow, Mapping):
+        pending_flows.append(root_flow)
+    seen_refs: set[str] = set()
+    while pending_flows:
+        flow = Node.from_json(dict(pending_flows.pop()))
+        refs: set[str] = set()
+        for node in flow.walk():
+            if isinstance(node.step, SubStep):
+                refs.add(node.step.ref)
+            if node.op is Op.APP and isinstance(node.subflows, (list, tuple)):
+                refs.update(str(ref) for ref in node.subflows)
+        for ref in sorted(refs):
+            if ref in seen_refs:
+                continue
+            seen_refs.add(ref)
+            spec = effects._CTX.subflows.get(ref)
+            if spec is None:
+                # Preserve lazy failure for an unregistered branch. Preflight
+                # expands only children the release worker can resolve.
+                continue
+            child_manifest = spec.get("manifestJson")
+            if isinstance(child_manifest, Mapping):
+                manifest_jsons.append(child_manifest)
+            child_flow = spec.get("flowJson")
+            if isinstance(child_flow, Mapping):
+                pending_flows.append(child_flow)
+
+    frozen = [
+        tool
+        for manifest_json in manifest_jsons
+        for tool in manifest_from_json(dict(manifest_json)).values()
+        if isinstance(tool.ref, McpTool)
+    ]
+    if not frozen:
+        unused = sorted(dict(inp.get("secrets") or {}))
+        if unused:
+            raise _refusal(
+                "invalid_run_secret_binding",
+                {
+                    "error": "invalid_run_secret_binding",
+                    "names": unused,
+                    "allowed": [],
+                },
+            )
+        return {"policy": policy.value, "completed": True, "surfaceDigest": None}
+
+    frozen_digest = canonical_surface_digest(frozen)
+    run_secrets = dict(inp.get("secrets") or {})
+    if policy is McpSurfacePolicy.OFF and not run_secrets:
+        return {
+            "policy": policy.value,
+            "completed": True,
+            "surfaceDigest": frozen_digest,
+        }
+
+    transport = effects._CTX.mcp_transport
+    if transport is None:
+        transport = transport_for_mcp_caller(effects._CTX.mcp_call)
+    if transport is None:
+        raise RuntimeError("worker has no MCP transport configured for preflight")
+
+    servers = sorted({tool.ref.server for tool in frozen})
+
+    # Only whole-string references in the request-time config for referenced
+    # servers are valid run bindings. Values never enter this diagnostic.
+    allowed_names: set[str] = set()
+    configs: dict[str, Any] = {}
+    for server in servers:
+        config = transport._config(server)
+        configs[server] = config
+        for value in config.headers.values():
+            match = _SECRET_REF.fullmatch(value)
+            if match is not None:
+                allowed_names.add(match.group(1))
+    unused = sorted(set(run_secrets) - allowed_names)
+    if unused:
+        raise _refusal(
+            "invalid_run_secret_binding",
+            {
+                "error": "invalid_run_secret_binding",
+                "names": unused,
+                "allowed": sorted(allowed_names),
+            },
+        )
+
+    if policy is McpSurfacePolicy.OFF:
+        return {
+            "policy": policy.value,
+            "completed": True,
+            "surfaceDigest": frozen_digest,
+        }
+
+    sinks: list[tuple[str, str]] = []
+    for server in servers:
+        config = configs[server]
+        sinks.append(
+            (
+                f"{server}:url",
+                hashlib.sha256(str(config.url).encode("utf-8")).hexdigest(),
+            )
+        )
+        if config.version is not None:
+            sinks.append(
+                (
+                    f"{server}:version",
+                    hashlib.sha256(str(config.version).encode("utf-8")).hexdigest(),
+                )
+            )
+        for header, raw_value in sorted(
+            config.headers.items(), key=lambda item: item[0].lower()
+        ):
+            resolved = await transport._resolve_ref(raw_value, run_secrets)
+            sinks.append(
+                (
+                    f"{server}:header:{header.lower()}",
+                    hashlib.sha256(resolved.encode("utf-8")).hexdigest(),
+                )
+            )
+    cache_payload = {
+        "frozen": frozen_digest,
+        # Keep per-manifest duplicates in the cache identity. The public
+        # surface digest collapses by wire ref, but two reachable flows can pin
+        # different definitions for that ref and must not share an entry.
+        "frozenDefinitions": sorted(
+            (tool.ref.server, tool.ref.tool, tool.definition_hash) for tool in frozen
+        ),
+        "policy": policy.value,
+        "sinks": sinks,
+        "principalHash": hashlib.sha256(
+            canonical_json(inp.get("principal")).encode("utf-8")
+        ).hexdigest(),
+        "auth": (
+            None
+            if transport._auth is None
+            else {"issuer": transport._auth.issuer, "kid": transport._auth.kid}
+        ),
+    }
+    cache_key = hashlib.sha256(
+        canonical_json(cache_payload).encode("utf-8")
+    ).hexdigest()
+    cached = cache.get(cache_key)
+    if cached is not None and now - cached[0] <= cache_ttl_s:
+        return dict(cached[1])
+
+    listings = await asyncio.gather(
+        *(
+            transport.list_tools(
+                server,
+                workflow_id=str(inp["workflowId"]),
+                principal=inp.get("principal"),
+                run_secrets=run_secrets,
+            )
+            for server in servers
+        )
+    )
+    fresh = snapshot_from_listings(
+        {
+            server: listing.tools
+            for server, listing in zip(servers, listings, strict=True)
+        },
+        versions={
+            server: listing.version
+            for server, listing in zip(servers, listings, strict=True)
+        },
+        protocol_versions={
+            server: listing.protocol_version
+            for server, listing in zip(servers, listings, strict=True)
+        },
+        server_versions={
+            server: listing.server_version
+            for server, listing in zip(servers, listings, strict=True)
+        },
+    )
+    try:
+        assert_mcp_surface(frozen, fresh, policy=policy)
+    except McpSurfaceMismatchError as exc:
+        raise _refusal(
+            "tool_surface_mismatch",
+            {"error": "tool_surface_mismatch", "details": exc.details},
+        ) from None
+
+    result = {
+        "policy": policy.value,
+        "completed": True,
+        "surfaceDigest": frozen_digest,
+    }
+    cache[cache_key] = (time.monotonic(), result)
+    _prune_mcp_preflight_cache(
+        time.monotonic(),
+        cache=cache,
+        ttl_s=cache_ttl_s,
+        max_entries=cache_max_entries,
+    )
+    return dict(result)
+
+
+__all__ = [
+    "McpPreflightError",
+    "preflight_mcp",
+    "scrub_mcp_preflight_failure",
+]

--- a/julep/execution/reasoner_batch.py
+++ b/julep/execution/reasoner_batch.py
@@ -13,6 +13,7 @@ from temporalio import activity, workflow
 from temporalio.exceptions import ApplicationError
 from temporalio.workflow import ParentClosePolicy
 
+from ..dispatch import BatchWindow
 from ..ir import canonical_json
 from .batch_provider import BatchReply
 from .failure_scrub import activity_redacted_failure_text, secret_safe_activity
@@ -232,25 +233,25 @@ class BatchCollector:
             self._last_at = _parse_at(inp.pending_last_at) or opened
 
         # --- collect until the fire condition holds -------------------------- #
+        window = BatchWindow(
+            quiet_s=inp.quiet_s,
+            max_items=inp.max_items,
+            max_wait_s=inp.max_wait_s,
+        )
         while True:
-            if inp.max_items is not None and len(self._items) >= inp.max_items:
+            decision = window.evaluate(
+                item_count=len(self._items),
+                opened_at=opened if self._items else None,
+                last_arrival_at=self._last_at,
+                now=workflow.now(),
+            )
+            if decision.fire:
                 break
-            now = workflow.now()
-            if self._items:
-                assert self._last_at is not None
-                deadline = self._last_at + timedelta(seconds=inp.quiet_s)
-                if inp.max_wait_s is not None:
-                    deadline = min(deadline, opened + timedelta(seconds=inp.max_wait_s))
-                if now >= deadline:
-                    break
-                timeout: Optional[float] = max((deadline - now).total_seconds(), 0.0)
-            else:
-                # Signal-with-start means at least one signal is on its way.
-                timeout = None
             count = len(self._items)
             try:
                 await workflow.wait_condition(
-                    lambda count=count: len(self._items) > count, timeout=timeout
+                    lambda count=count: len(self._items) > count,
+                    timeout=decision.wait_s,
                 )
             except asyncio.TimeoutError:
                 pass  # re-evaluate the fire condition against workflow.now()

--- a/julep/freeze.py
+++ b/julep/freeze.py
@@ -14,7 +14,7 @@ admission has a real contract to check.
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
@@ -300,6 +300,8 @@ def _check_tool_schema_drift(
     flow: Node,
     snapshot: McpSnapshot,
     expectations: Mapping[str, ToolSchemaExpectation],
+    *,
+    scoped_fallbacks: Collection[str] = frozenset(),
 ) -> None:
     """TOOL_SCHEMA_DRIFT: a dotctx package's expected tool schema (tools.pyi)
     must match the served schema by canonical hash when the snapshot resolves
@@ -340,6 +342,11 @@ def _check_tool_schema_drift(
     for key in sorted(_expected_tool_keys(flow)):
         if (key, key) in checked or any(wire == key for _, wire in checked):
             continue
+        if key in scoped_fallbacks:
+            # This bare-name entry exists only as a compatibility lookup for a
+            # scoped dotctx APP. It must not bind an unrelated authored/native
+            # call with the same common name (for example, ``lookup``).
+            continue
         expectation = expectations.get(key)
         if expectation is None:
             continue
@@ -375,6 +382,7 @@ def freeze(
     (``expected_tool_schemas``; defaults to the registry's recorded ones).
     """
     overrides = overrides or CapabilityOverrides()
+    using_default_expectations = expected_tool_schemas is None
     expectations: Mapping[str, ToolSchemaExpectation] = (
         expected_tool_schemas
         if expected_tool_schemas is not None
@@ -459,7 +467,16 @@ def freeze(
         node.tool_contracts = tool_contracts
 
     # 6. Verify recorded dotctx tool-schema expectations against the snapshot.
-    _check_tool_schema_drift(frozen_flow, snapshot, expectations)
+    _check_tool_schema_drift(
+        frozen_flow,
+        snapshot,
+        expectations,
+        scoped_fallbacks=(
+            DEFAULT_REGISTRY.scoped_tool_fallbacks
+            if using_default_expectations
+            else frozenset()
+        ),
+    )
 
     return FreezeResult(flow=frozen_flow, manifest=manifest, source_map=source_map)
 

--- a/julep/freeze.py
+++ b/julep/freeze.py
@@ -273,27 +273,29 @@ def _app_tool_expectation(
     return expectations.get(alias) or expectations.get(wire_key)
 
 
-def _expected_tool_keys(flow: Node) -> set[str]:
-    """Every toolref key the flow can reach: call leaves, app inline grants,
-    and the granted tools of each registered reasoner the flow references."""
-    keys: set[str] = set()
+def _reasoners_with_tool_expectations(flow: Node) -> set[str]:
+    """Reasoners whose declared tools are part of this non-APP flow surface."""
     reasoners: set[str] = set()
     for node in flow.walk():
         step = node.step
-        if isinstance(step, CallStep):
-            keys.add(toolref_key(step.tool))
         if isinstance(step, ThinkStep):
             reasoners.add(step.reasoner)
-        if node.op in (Op.APP, Op.EVAL_PLAN) and node.controller is not None:
+        if node.op == Op.EVAL_PLAN and node.controller is not None:
             reasoners.add(node.controller)
-        if node.op == Op.APP and node.tools:
-            aliases = node.tool_aliases or {}
-            keys.update(aliases.get(str(k), str(k)) for k in node.tools)
-    for name in reasoners:
-        reasoner = DEFAULT_REGISTRY.reasoners.get(name)
-        if reasoner is not None:
-            keys.update(reasoner.tools)
-    return keys
+        # APP nodes with explicit grants are checked through their alias-to-wire
+        # surface below. Retain the registered-reasoner fallback for legacy APPs
+        # that carry no inline grant list.
+        if node.op == Op.APP and node.controller is not None and not node.tools:
+            reasoners.add(node.controller)
+    return reasoners
+
+
+def _direct_tool_keys(flow: Node) -> set[str]:
+    return {
+        toolref_key(step.tool)
+        for node in flow.walk()
+        if isinstance((step := node.step), CallStep)
+    }
 
 
 def _check_tool_schema_drift(
@@ -339,30 +341,47 @@ def _check_tool_schema_drift(
                     f"{expectation.ctx_path!r} was written against {expected_hash}"
                 )
 
-    for key in sorted(_expected_tool_keys(flow)):
+    def check_tool(key: str, expectation: ToolSchemaExpectation) -> None:
+        served = _served_input_schema(key, snapshot)
+        if served is None:
+            return  # not resolved by this snapshot; missing call tools raise in _resolve
+        expected_hash = _schema_hash(expectation.input_schema)
+        served_hash = _schema_hash(served)
+        if expected_hash == served_hash:
+            return
+        ref = _toolref_from_key(key)
+        server = ref.server if isinstance(ref, McpTool) else "<native>"
+        raise FreezeError(
+            f"TOOL_SCHEMA_DRIFT: tool {key!r} (server {server!r}) serves schema "
+            f"{served_hash}, but {expectation.ctx_path!r} was written against "
+            f"{expected_hash}"
+        )
+
+    # A scoped fallback is unsafe for an unrelated authored call, but remains
+    # authoritative for the reasoner whose dotctx package registered it.
+    for reasoner_name in sorted(_reasoners_with_tool_expectations(flow)):
+        reasoner = DEFAULT_REGISTRY.reasoners.get(reasoner_name)
+        if reasoner is None:
+            continue
+        for key in sorted(reasoner.tools):
+            expectation = expectations.get(
+                scoped_tool_expectation_key(reasoner_name, key)
+            )
+            if expectation is not None:
+                check_tool(key, expectation)
+
+    for key in sorted(_direct_tool_keys(flow)):
         if (key, key) in checked or any(wire == key for _, wire in checked):
             continue
         if key in scoped_fallbacks:
-            # This bare-name entry exists only as a compatibility lookup for a
-            # scoped dotctx APP. It must not bind an unrelated authored/native
+            # This unscoped entry exists only as a compatibility lookup for a
+            # scoped dotctx package. It must not bind an unrelated authored
             # call with the same common name (for example, ``lookup``).
             continue
         expectation = expectations.get(key)
         if expectation is None:
             continue
-        served = _served_input_schema(key, snapshot)
-        if served is None:
-            continue  # not resolved by this snapshot; missing call tools raise in _resolve
-        expected_hash = _schema_hash(expectation.input_schema)
-        served_hash = _schema_hash(served)
-        if expected_hash != served_hash:
-            ref = _toolref_from_key(key)
-            server = ref.server if isinstance(ref, McpTool) else "<native>"
-            raise FreezeError(
-                f"TOOL_SCHEMA_DRIFT: tool {key!r} (server {server!r}) serves schema "
-                f"{served_hash}, but {expectation.ctx_path!r} was written against "
-                f"{expected_hash}"
-            )
+        check_tool(key, expectation)
 
 
 def freeze(

--- a/julep/freeze.py
+++ b/julep/freeze.py
@@ -367,6 +367,8 @@ def _check_tool_schema_drift(
             expectation = expectations.get(
                 scoped_tool_expectation_key(reasoner_name, key)
             )
+            if expectation is None and key not in scoped_fallbacks:
+                expectation = expectations.get(key)
             if expectation is not None:
                 check_tool(key, expectation)
 

--- a/julep/llm.py
+++ b/julep/llm.py
@@ -40,19 +40,14 @@ def _normalize_litellm_model(model: Any) -> Any:
     normalized = model.strip()
     if not normalized:
         return model
-    if "@" in normalized:
-        candidate, suffix = normalized.rsplit("@", 1)
-        if suffix.strip().lower() in EFFORT_LEVELS:
-            normalized = candidate.strip()
-    colon = normalized.find(":")
-    slash = normalized.find("/")
-    if colon >= 0 and (slash < 0 or colon < slash):
-        provider, remainder = normalized.split(":", 1)
-        remainder = remainder.lstrip("/")
-        if provider == "fireworks" and remainder.startswith("accounts/"):
-            return f"fireworks_ai/{remainder}"
-        return f"{provider}/{remainder}"
-    return normalized
+    parsed = normalize_model_slug(normalized)
+    provider, separator, remainder = parsed.model.partition(":")
+    if not separator:
+        return parsed.model
+    remainder = remainder.lstrip("/")
+    if provider == "fireworks" and remainder.startswith("accounts/"):
+        provider = "fireworks_ai"
+    return f"{provider}/{remainder}"
 
 
 def _slug_effort(model: Any) -> Optional[str]:
@@ -182,8 +177,18 @@ def litellm_caller(
         parallel_tool_calls: Optional[bool] = None,
     ) -> Any:
         del principal  # Provider credentials are resolved by LiteLLM itself.
+        # ``complete_reasoner`` consumes canonical ``provider:model`` slugs.
+        # Normalize slash-form dotctx inputs before its provider split so
+        # ``openai/gpt-*`` cannot fall through to the Anthropic default.
+        parsed_model = normalize_model_slug(reasoner.model)
+        normalized_reasoner = reasoner.replace(
+            model=parsed_model.model,
+            reasoning_effort=(
+                parsed_model.reasoning_effort or reasoner.reasoning_effort
+            ),
+        )
         return await complete_reasoner(
-            reasoner,
+            normalized_reasoner,
             value,
             acompletion=completion,
             transcript=transcript,  # type: ignore[arg-type]
@@ -202,7 +207,12 @@ def _provider(model: str) -> str:
 
 def _reasoner_for_model(reasoner: Reasoner, model: str) -> Reasoner:
     parsed = normalize_model_slug(model)
-    effort = parsed.reasoning_effort or reasoner.reasoning_effort
+    base = normalize_model_slug(reasoner.model)
+    effort = (
+        parsed.reasoning_effort
+        or base.reasoning_effort
+        or reasoner.reasoning_effort
+    )
     return reasoner.replace(model=parsed.model, reasoning_effort=effort)
 
 

--- a/julep/llm.py
+++ b/julep/llm.py
@@ -1,0 +1,305 @@
+"""Public model-caller adapters and composition helpers.
+
+The execution engine owns a small, provider-neutral :class:`LlmCaller` seam.
+This module contains integrations that consumers otherwise tend to rebuild in
+worker glue: a LiteLLM adapter and a model fallback ladder around an arbitrary
+caller.  Imports of LiteLLM remain lazy so the core package stays lightweight.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from importlib import import_module
+from typing import Any, Optional, cast
+
+from .dotctx import Reasoner
+from .errors import ResilienceExhausted
+from .execution.effects import LlmCaller, RunPrincipal
+from .execution.llm import complete_reasoner
+from .execution.llm_result import AttemptMeta, LlmResult
+from .model_slugs import EFFORT_LEVELS, normalize_model_slug
+from .qos import ReasonerDispatch
+from .resilience import AttemptRecord, ErrorClass, OnAttempt, classify_error
+from .transcript import Transcript
+
+LiteLlmCompletion = Callable[..., Awaitable[Any]]
+
+_DEFAULT_DISPATCH = ReasonerDispatch()
+_ANTHROPIC_THINKING_BUDGETS: Mapping[str, int] = {
+    "minimal": 128,
+    "low": 1024,
+    "medium": 2048,
+    "high": 4096,
+}
+
+
+def _normalize_litellm_model(model: Any) -> Any:
+    if not isinstance(model, str):
+        return model
+    normalized = model.strip()
+    if not normalized:
+        return model
+    if "@" in normalized:
+        candidate, suffix = normalized.rsplit("@", 1)
+        if suffix.strip().lower() in EFFORT_LEVELS:
+            normalized = candidate.strip()
+    colon = normalized.find(":")
+    slash = normalized.find("/")
+    if colon >= 0 and (slash < 0 or colon < slash):
+        provider, remainder = normalized.split(":", 1)
+        remainder = remainder.lstrip("/")
+        if provider == "fireworks" and remainder.startswith("accounts/"):
+            return f"fireworks_ai/{remainder}"
+        return f"{provider}/{remainder}"
+    return normalized
+
+
+def _slug_effort(model: Any) -> Optional[str]:
+    if not isinstance(model, str) or "@" not in model:
+        return None
+    suffix = model.rsplit("@", 1)[1].strip().lower()
+    return suffix if suffix in EFFORT_LEVELS else None
+
+
+def prepare_litellm_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Translate Julep model slugs and reasoning controls for LiteLLM.
+
+    The mapping is deliberately pure and public so eval runners and workers use
+    the same provider payload contract.  An ``@effort`` model suffix wins over
+    an explicit ``reasoning_effort`` field, matching model override precedence.
+    """
+
+    prepared = dict(payload)
+    raw_model = prepared.get("model")
+    model = _normalize_litellm_model(raw_model)
+    if model is not None:
+        prepared["model"] = model
+
+    explicit = prepared.get("reasoning_effort")
+    explicit_effort = (
+        explicit.strip().lower() if isinstance(explicit, str) and explicit.strip() else None
+    )
+    effort = _slug_effort(raw_model) or explicit_effort
+
+    if (
+        effort is not None
+        and isinstance(model, str)
+        and model.lower().startswith("openai/gpt-5")
+        and prepared.get("temperature") not in (None, 1, 1.0)
+    ):
+        prepared["temperature"] = 1.0
+
+    if effort is None:
+        prepared.pop("reasoning_effort", None)
+        return prepared
+
+    if isinstance(model, str) and model.startswith("openrouter/"):
+        raw_extra = prepared.get("extra_body")
+        extra = dict(raw_extra) if isinstance(raw_extra, Mapping) else {}
+        raw_reasoning = extra.get("reasoning")
+        reasoning = dict(raw_reasoning) if isinstance(raw_reasoning, Mapping) else {}
+        reasoning["effort"] = effort
+        extra["reasoning"] = reasoning
+        prepared["extra_body"] = extra
+        prepared.pop("reasoning_effort", None)
+        return prepared
+
+    if isinstance(model, str) and model.startswith("anthropic/"):
+        prepared.pop("reasoning_effort", None)
+        if model.lower().startswith("anthropic/claude-opus-4-7"):
+            prepared.pop("temperature", None)
+            prepared.pop("top_p", None)
+            prepared.pop("top_k", None)
+            if effort == "none":
+                return prepared
+            output = prepared.get("output_config")
+            output_config = dict(output) if isinstance(output, Mapping) else {}
+            output_config["effort"] = "low" if effort == "minimal" else effort
+            prepared["thinking"] = {"type": "adaptive"}
+            prepared["output_config"] = output_config
+            return prepared
+        budget = _ANTHROPIC_THINKING_BUDGETS.get(effort)
+        if budget is not None:
+            prepared["temperature"] = 1.0
+            prepared["thinking"] = {"type": "enabled", "budget_tokens": budget}
+        return prepared
+
+    prepared["reasoning_effort"] = effort
+    raw_allowed = prepared.get("allowed_openai_params")
+    allowed = list(raw_allowed) if isinstance(raw_allowed, list) else []
+    if "reasoning_effort" not in allowed:
+        allowed.append("reasoning_effort")
+    prepared["allowed_openai_params"] = allowed
+    return prepared
+
+
+def litellm_caller(
+    *,
+    request_timeout_s: Optional[float] = None,
+    acompletion: Optional[LiteLlmCompletion] = None,
+) -> LlmCaller:
+    """Return Julep's canonical five-argument caller backed by LiteLLM.
+
+    ``acompletion`` is injectable for tests.  When omitted, ``litellm`` is
+    imported on the first model call and a clear install hint is raised if the
+    optional dependency is unavailable.
+    """
+
+    async def completion(
+        *,
+        provider: str,
+        model: str,
+        messages: list[dict[str, Any]],
+        **kwargs: Any,
+    ) -> Any:
+        backend = acompletion
+        if backend is None:
+            try:
+                litellm = import_module("litellm")
+            except ImportError as exc:  # pragma: no cover - optional dependency
+                raise ImportError(
+                    "litellm_caller requires LiteLLM; install 'julep[litellm]'"
+                ) from exc
+            backend = cast(LiteLlmCompletion, vars(litellm)["acompletion"])
+        payload: dict[str, Any] = {
+            "model": f"{provider}:{model}",
+            "messages": messages,
+            **kwargs,
+        }
+        if request_timeout_s is not None:
+            payload["timeout"] = request_timeout_s
+        return await backend(**prepare_litellm_payload(payload))
+
+    async def caller(
+        reasoner: Reasoner,
+        value: Any,
+        principal: Optional[RunPrincipal] = None,
+        transcript: Optional[Transcript] = None,
+        dispatch: ReasonerDispatch = _DEFAULT_DISPATCH,
+        *,
+        tools: Optional[list[dict[str, Any]]] = None,
+        parallel_tool_calls: Optional[bool] = None,
+    ) -> Any:
+        del principal  # Provider credentials are resolved by LiteLLM itself.
+        return await complete_reasoner(
+            reasoner,
+            value,
+            acompletion=completion,
+            transcript=transcript,  # type: ignore[arg-type]
+            dispatch=dispatch,
+            tools=tools,
+            parallel_tool_calls=parallel_tool_calls,
+        )
+
+    return caller
+
+
+def _provider(model: str) -> str:
+    normalized = normalize_model_slug(model).model
+    return normalized.split(":", 1)[0] if ":" in normalized else ""
+
+
+def _reasoner_for_model(reasoner: Reasoner, model: str) -> Reasoner:
+    parsed = normalize_model_slug(model)
+    effort = parsed.reasoning_effort or reasoner.reasoning_effort
+    return reasoner.replace(model=parsed.model, reasoning_effort=effort)
+
+
+def with_model_ladder(
+    caller: LlmCaller,
+    *,
+    models: Sequence[str],
+    classify: Callable[[BaseException], ErrorClass] = classify_error,
+    on_attempt: Optional[OnAttempt] = None,
+) -> LlmCaller:
+    """Wrap a caller with ordered provider-transient model failover.
+
+    The reasoner's primary model is always attempted first, followed by
+    ``models`` with stable de-duplication.  Only transient and timeout failures
+    advance the ladder.  Configuration and model-behavior failures remain loud
+    on the model that produced them.
+    """
+
+    async def wrapped(
+        reasoner: Reasoner,
+        value: Any,
+        principal: Optional[RunPrincipal] = None,
+        transcript: Optional[Transcript] = None,
+        dispatch: ReasonerDispatch = _DEFAULT_DISPATCH,
+        *,
+        tools: Optional[list[dict[str, Any]]] = None,
+        parallel_tool_calls: Optional[bool] = None,
+    ) -> Any:
+        candidates: list[str] = []
+        for candidate in (reasoner.model, *models):
+            if candidate not in candidates:
+                candidates.append(candidate)
+        attempts: list[AttemptRecord] = []
+        last_exc: Optional[Exception] = None
+        for model in candidates:
+            attempt_reasoner = _reasoner_for_model(reasoner, model)
+            provider = _provider(attempt_reasoner.model)
+            try:
+                extra: dict[str, Any] = {}
+                if tools is not None:
+                    extra["tools"] = tools
+                if parallel_tool_calls is not None:
+                    extra["parallel_tool_calls"] = parallel_tool_calls
+                result = await cast(Any, caller)(
+                    attempt_reasoner,
+                    value,
+                    principal,
+                    transcript,
+                    dispatch,
+                    **extra,
+                )
+            except Exception as exc:
+                error_class = classify(exc)
+                record = AttemptRecord(
+                    model=attempt_reasoner.model,
+                    provider=provider,
+                    outcome=error_class.value,
+                    detail=str(exc),
+                )
+                attempts.append(record)
+                if on_attempt is not None:
+                    on_attempt(record)
+                if error_class not in (ErrorClass.TRANSIENT, ErrorClass.TIMEOUT):
+                    raise
+                last_exc = exc
+                continue
+
+            record = AttemptRecord(
+                model=attempt_reasoner.model,
+                provider=provider,
+                outcome="ok",
+            )
+            attempts.append(record)
+            if on_attempt is not None:
+                on_attempt(record)
+            if isinstance(result, LlmResult):
+                ladder_attempts = tuple(
+                    AttemptMeta(model=item.model, provider=item.provider, outcome=item.outcome)
+                    for item in attempts
+                )
+                return LlmResult(
+                    reply=result.reply,
+                    meta=dataclasses.replace(result.meta, attempts=ladder_attempts),
+                )
+            return result
+
+        exhausted = ResilienceExhausted(attempts)
+        if last_exc is not None:
+            raise exhausted from last_exc
+        raise exhausted
+
+    return wrapped
+
+
+__all__ = [
+    "LiteLlmCompletion",
+    "litellm_caller",
+    "prepare_litellm_payload",
+    "with_model_ladder",
+]

--- a/julep/llm.py
+++ b/julep/llm.py
@@ -241,14 +241,17 @@ def with_model_ladder(
         tools: Optional[list[dict[str, Any]]] = None,
         parallel_tool_calls: Optional[bool] = None,
     ) -> Any:
-        candidates: list[str] = []
+        candidates: list[Reasoner] = []
+        seen_candidates: set[tuple[str, Optional[str]]] = set()
         for candidate in (reasoner.model, *models):
-            if candidate not in candidates:
-                candidates.append(candidate)
+            normalized = _reasoner_for_model(reasoner, candidate)
+            identity = (normalized.model, normalized.reasoning_effort)
+            if identity not in seen_candidates:
+                seen_candidates.add(identity)
+                candidates.append(normalized)
         attempts: list[AttemptRecord] = []
         last_exc: Optional[Exception] = None
-        for model in candidates:
-            attempt_reasoner = _reasoner_for_model(reasoner, model)
+        for attempt_reasoner in candidates:
             provider = _provider(attempt_reasoner.model)
             try:
                 extra: dict[str, Any] = {}

--- a/julep/local.py
+++ b/julep/local.py
@@ -350,11 +350,9 @@ def _reasoner_handlers(
     for node in flow.walk():
         if node.op is not Op.APP or node.controller is None:
             continue
-        if not node.tool_defs:
-            continue
-        definitions = tuple(dict(definition) for definition in node.tool_defs)
+        definitions = tuple(dict(definition) for definition in (node.tool_defs or ()))
         previous = controller_tools.get(node.controller)
-        if previous is not None and previous != definitions:
+        if node.controller in controller_tools and previous != definitions:
             raise LocalExecutionConfigurationError(
                 f"reasoner {node.controller!r} is used by foreground agents with "
                 "different frozen tool surfaces"

--- a/julep/local.py
+++ b/julep/local.py
@@ -309,6 +309,11 @@ def _assert_foreground_supported(flow: Any) -> None:
                 "foreground execution does not support transcript-scoped agents; "
                 "use the local API or a durable worker"
             )
+        if node.op is Op.APP and node.subflows:
+            raise LocalExecutionUnsupported(
+                "foreground execution does not resolve agent subflows; use the "
+                "local API or a durable worker"
+            )
         if isinstance(node.step, SubStep):
             raise LocalExecutionUnsupported(
                 "foreground execution does not resolve subflows; use the local API "
@@ -346,11 +351,20 @@ def _reasoner_handlers(
                     "pipeline's compiled declaration"
                 )
 
+    ordinary_reasoners = {
+        node.step.reasoner
+        for node in flow.walk()
+        if isinstance(node.step, ThinkStep)
+    }
     controller_tools: dict[str, tuple[dict[str, Any], ...]] = {}
     for node in flow.walk():
         if node.op is not Op.APP or node.controller is None:
             continue
-        definitions = tuple(dict(definition) for definition in (node.tool_defs or ()))
+        definitions = (
+            tuple(dict(definition) for definition in (node.tool_defs or ()))
+            if node.native_tools
+            else ()
+        )
         previous = controller_tools.get(node.controller)
         if node.controller in controller_tools and previous != definitions:
             raise LocalExecutionConfigurationError(
@@ -358,6 +372,13 @@ def _reasoner_handlers(
                 "different frozen tool surfaces"
             )
         controller_tools[node.controller] = definitions
+
+    for name in sorted(ordinary_reasoners & controller_tools.keys()):
+        if controller_tools[name]:
+            raise LocalExecutionConfigurationError(
+                f"reasoner {name!r} is used by both ordinary foreground reasoning "
+                "and a native-tool agent; use separate reasoner names"
+            )
 
     async def invoke_named(
         name: str,

--- a/julep/local.py
+++ b/julep/local.py
@@ -1,0 +1,459 @@
+"""Foreground execution for one configured pipeline.
+
+This module is the low-latency counterpart to the local HTTP control plane.  It
+uses the same config, application compiler, frozen deployment, and interpreter,
+but invokes effects in the caller's process.  There is no PostgreSQL, Temporal,
+HTTP control-plane hop, release lifecycle, or durable retry boundary.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from dataclasses import dataclass, replace
+from pathlib import Path
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Mapping, Optional, cast
+
+from .app import Application, CompiledPipeline
+from .dotctx import Reasoner
+from .errors import JulepError
+from .execution.effects import LlmCaller, RunPrincipal, WorkerContext
+from .execution.llm_result import LlmResult
+from .ir import (
+    EMIT_TOOL,
+    HUMAN_GATE_TOOL,
+    RECV_TOOL,
+    SLEEP_TOOL,
+    Ann,
+    CallStep,
+    McpTool,
+    NativeTool,
+    SubStep,
+    ThinkStep,
+)
+from .kinds import ContextScope, Op
+from .prompt import rendered_reasoner_for
+from .qos import QoSTier, ReasonerDispatch
+from .registry import DEFAULT_REGISTRY
+
+if TYPE_CHECKING:
+    from .cli.config import JulepConfig
+
+
+_JULEP_META_KEY = "__julep_meta__"
+_LOCAL_UNSUPPORTED_NATIVE_TOOLS = frozenset(
+    {HUMAN_GATE_TOOL, SLEEP_TOOL, RECV_TOOL, EMIT_TOOL}
+)
+
+
+class LocalPipelineError(JulepError):
+    """Base error for configured foreground execution."""
+
+
+class LocalPipelineNotFound(LocalPipelineError):
+    """The selected environment or pipeline does not exist."""
+
+    def __init__(self, kind: str, name: str, available: list[str]) -> None:
+        self.kind = kind
+        self.name = name
+        self.available = tuple(available)
+        choices = ", ".join(available) if available else "none"
+        super().__init__(f"unknown {kind} {name!r}; configured {kind}s: {choices}")
+
+
+class LocalExecutionConfigurationError(LocalPipelineError):
+    """Foreground execution is missing an explicitly injected effect."""
+
+
+class LocalExecutionUnsupported(LocalPipelineError):
+    """A durable/session-only operator was selected for foreground execution."""
+
+
+ReasonerHandler = Callable[[Any], Awaitable[Any]]
+
+
+@dataclass(frozen=True)
+class LocalPipeline:
+    """One compiled configured pipeline reusable across foreground calls."""
+
+    name: str
+    environment: str
+    compiled: CompiledPipeline[Any, Any]
+    reasoners: Mapping[str, Reasoner]
+
+    @property
+    def artifact_hash(self) -> str:
+        """The frozen deployment identity used by every call on this object."""
+
+        return self.compiled.deployment.artifact_hash
+
+    async def arun(
+        self,
+        input: Any = None,
+        *,
+        llm: Optional[LlmCaller] = None,
+        context: Optional[WorkerContext] = None,
+        principal: Optional[RunPrincipal] = None,
+    ) -> Any:
+        """Execute in-process and return the interpreter's unwrapped value."""
+
+        worker = context or WorkerContext()
+        caller = llm or worker.llm
+        if self.reasoners and caller is None:
+            raise LocalExecutionConfigurationError(
+                f"pipeline {self.name!r} invokes a reasoner; pass llm= or "
+                "WorkerContext(llm=...)"
+            )
+
+        deployment = self.compiled.deployment
+        deployment.assert_artifact_integrity()
+        _assert_foreground_supported(deployment.flow)
+
+        reasoner_handlers = _reasoner_handlers(
+            deployment.flow,
+            self.reasoners,
+            caller=caller,
+            context=worker,
+            principal=principal,
+        )
+        mcp_backed = any(
+            isinstance(tool.ref, McpTool) for tool in deployment.manifest.values()
+        )
+        if mcp_backed and worker.mcp_call is None:
+            raise LocalExecutionConfigurationError(
+                f"pipeline {self.name!r} invokes MCP tools; pass "
+                "WorkerContext(mcp_call=...)"
+            )
+
+        # Snapshot-only deployments intentionally require a native-tool binding
+        # for the legacy ``Deployment.dry_run`` API.  A configured reasoner-only
+        # pipeline has no native calls to bind, so make that empty binding
+        # explicit on a copy without mutating the frozen deployment.
+        has_native_tool = any(
+            isinstance(tool.ref, NativeTool) for tool in deployment.manifest.values()
+        )
+        local_deployment = (
+            deployment
+            if deployment._tools is not None or mcp_backed or has_native_tool
+            else replace(deployment, _tools=())
+        )
+        policy = self.compiled.spec.execution_policy
+        result = await local_deployment.adry_run(
+            input,
+            mcp_call=worker.mcp_call,
+            reasoners=reasoner_handlers,
+            principal=principal,
+            registry=worker.registry,
+            max_parallel=None if policy is None else policy.max_parallel,
+        )
+        return result.value
+
+    def run(
+        self,
+        input: Any = None,
+        *,
+        llm: Optional[LlmCaller] = None,
+        context: Optional[WorkerContext] = None,
+        principal: Optional[RunPrincipal] = None,
+    ) -> Any:
+        """Synchronous foreground execution; use :meth:`arun` in an event loop."""
+
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+        else:
+            raise LocalExecutionConfigurationError(
+                "LocalPipeline.run() cannot run inside an active event loop; "
+                "await LocalPipeline.arun() instead"
+            )
+        return asyncio.run(
+            self.arun(input, llm=llm, context=context, principal=principal)
+        )
+
+
+def prepare_local_pipeline(
+    pipeline: str,
+    *,
+    project_root: str | Path = ".",
+    config: Optional[JulepConfig] = None,
+    env: str = "local",
+) -> LocalPipeline:
+    """Load and compile one configured pipeline for repeated foreground calls."""
+
+    from .cli.application import resolve_application
+    from .cli.config import load_config
+
+    cfg = config or load_config(project_root)
+    if env not in cfg.envs:
+        raise LocalPipelineNotFound("environment", env, sorted(cfg.envs))
+    env_config = cfg.envs[env]
+    application = resolve_application(cfg, env_config)
+    matches = [spec for spec in application.pipelines if spec.name == pipeline]
+    if not matches:
+        raise LocalPipelineNotFound(
+            "pipeline",
+            pipeline,
+            sorted(spec.name for spec in application.pipelines),
+        )
+
+    # Compile only the selected pipeline.  This preserves its normal application
+    # compilation gates while keeping unrelated MCP surfaces off the foreground
+    # startup path.
+    selected = Application(application.name, (matches[0],))
+    compiled_application = selected.compile_live(
+        env_vars={**env_config.vars, **env_config.worker_environment}
+    )
+    compiled = compiled_application.pipelines[0]
+    reasoners = _resolve_pipeline_reasoners(compiled)
+    return LocalPipeline(
+        name=pipeline,
+        environment=env,
+        compiled=compiled,
+        reasoners=MappingProxyType(dict(reasoners)),
+    )
+
+
+async def arun_local_pipeline(
+    pipeline: str,
+    input: Any = None,
+    *,
+    project_root: str | Path = ".",
+    config: Optional[JulepConfig] = None,
+    env: str = "local",
+    llm: Optional[LlmCaller] = None,
+    context: Optional[WorkerContext] = None,
+    principal: Optional[RunPrincipal] = None,
+) -> Any:
+    """Compile and execute one configured pipeline in the current event loop."""
+
+    prepared = prepare_local_pipeline(
+        pipeline,
+        project_root=project_root,
+        config=config,
+        env=env,
+    )
+    return await prepared.arun(input, llm=llm, context=context, principal=principal)
+
+
+def run_local_pipeline(
+    pipeline: str,
+    input: Any = None,
+    *,
+    project_root: str | Path = ".",
+    config: Optional[JulepConfig] = None,
+    env: str = "local",
+    llm: Optional[LlmCaller] = None,
+    context: Optional[WorkerContext] = None,
+    principal: Optional[RunPrincipal] = None,
+) -> Any:
+    """Compile and synchronously execute one configured pipeline in-process."""
+
+    prepared = prepare_local_pipeline(
+        pipeline,
+        project_root=project_root,
+        config=config,
+        env=env,
+    )
+    return prepared.run(input, llm=llm, context=context, principal=principal)
+
+
+def _resolve_pipeline_reasoners(
+    compiled: CompiledPipeline[Any, Any],
+) -> dict[str, Reasoner]:
+    inline = {
+        declaration.name: declaration
+        for declaration in compiled.spec.reasoners
+        if isinstance(declaration, Reasoner)
+    }
+    names = set(compiled.spec.reasoner_names)
+    for node in compiled.deployment.flow.walk():
+        if isinstance(node.step, ThinkStep):
+            names.add(node.step.reasoner)
+        if node.controller is not None:
+            names.add(node.controller)
+        if node.summarizer is not None:
+            names.add(node.summarizer)
+
+    resolved: dict[str, Reasoner] = {}
+    for name in sorted(names):
+        reasoner = inline.get(name)
+        if reasoner is None:
+            reasoner = DEFAULT_REGISTRY.reasoners.get(name)
+        if reasoner is None:
+            raise LocalExecutionConfigurationError(
+                f"pipeline {compiled.spec.name!r} references unknown reasoner {name!r}"
+            )
+        resolved[name] = reasoner
+    return resolved
+
+
+def _assert_foreground_supported(flow: Any) -> None:
+    for node in flow.walk():
+        if node.op is Op.LOOP:
+            raise LocalExecutionUnsupported(
+                "foreground execution does not support session LOOP flows; "
+                "use the local API or a durable worker"
+            )
+        if node.op is Op.EVAL_PLAN:
+            raise LocalExecutionUnsupported(
+                "foreground execution does not support staged plans; use the local API"
+            )
+        if (
+            node.op is Op.APP
+            and node.ctx is not None
+            and node.ctx.scope in {ContextScope.WHOLE_SESSION, ContextScope.SUMMARY}
+        ):
+            raise LocalExecutionUnsupported(
+                "foreground execution does not support transcript-scoped agents; "
+                "use the local API or a durable worker"
+            )
+        if isinstance(node.step, SubStep):
+            raise LocalExecutionUnsupported(
+                "foreground execution does not resolve subflows; use the local API "
+                "or a durable worker"
+            )
+        if (
+            isinstance(node.step, CallStep)
+            and isinstance(node.step.tool, NativeTool)
+            and node.step.tool.name in _LOCAL_UNSUPPORTED_NATIVE_TOOLS
+        ):
+            raise LocalExecutionUnsupported(
+                f"foreground execution does not support reserved effect "
+                f"{node.step.tool.name!r}; use the local API or a durable worker"
+            )
+
+
+def _reasoner_handlers(
+    flow: Any,
+    prepared_reasoners: Mapping[str, Reasoner],
+    *,
+    caller: Optional[LlmCaller],
+    context: WorkerContext,
+    principal: Optional[RunPrincipal],
+) -> dict[str, ReasonerHandler]:
+    if caller is None:
+        return {}
+
+    reasoners = dict(prepared_reasoners)
+    if context.registry is not None:
+        for name, reasoner in reasoners.items():
+            override = context.registry.reasoners.get(name)
+            if override is not None and override != reasoner:
+                raise LocalExecutionConfigurationError(
+                    f"WorkerContext reasoner {name!r} differs from the configured "
+                    "pipeline's compiled declaration"
+                )
+
+    controller_tools: dict[str, tuple[dict[str, Any], ...]] = {}
+    for node in flow.walk():
+        if node.op is not Op.APP or node.controller is None:
+            continue
+        if not node.tool_defs:
+            continue
+        definitions = tuple(dict(definition) for definition in node.tool_defs)
+        previous = controller_tools.get(node.controller)
+        if previous is not None and previous != definitions:
+            raise LocalExecutionConfigurationError(
+                f"reasoner {node.controller!r} is used by foreground agents with "
+                "different frozen tool surfaces"
+            )
+        controller_tools[node.controller] = definitions
+
+    async def invoke_named(
+        name: str,
+        value: Any,
+        *,
+        tool_defs: tuple[dict[str, Any], ...] = (),
+    ) -> Any:
+        reasoner = reasoners.get(name)
+        if reasoner is None:
+            raise LocalExecutionConfigurationError(
+                f"foreground pipeline references unknown reasoner {name!r}"
+            )
+        rendered = rendered_reasoner_for(reasoner, value)
+        dispatch = _foreground_dispatch(rendered, context, principal)
+        if tool_defs:
+            if not _accepts_keyword(caller, "tools"):
+                raise LocalExecutionConfigurationError(
+                    f"pipeline reasoner {name!r} uses native tool calling, but its "
+                    "LlmCaller does not accept the optional tools= keyword extension"
+                )
+            raw = await cast(Any, caller)(
+                rendered,
+                value,
+                principal,
+                None,
+                dispatch,
+                tools=list(tool_defs),
+            )
+        else:
+            raw = await caller(rendered, value, principal, None, dispatch)
+        return _pack_reasoner_result(raw)
+
+    handlers: dict[str, ReasonerHandler] = {}
+    for name in reasoners:
+        tools = controller_tools.get(name, ())
+
+        async def handler(
+            value: Any,
+            *,
+            _name: str = name,
+            _tools: tuple[dict[str, Any], ...] = tools,
+        ) -> Any:
+            return await invoke_named(_name, value, tool_defs=_tools)
+
+        handlers[name] = handler
+    return handlers
+
+
+def _foreground_dispatch(
+    reasoner: Reasoner,
+    context: WorkerContext,
+    principal: Optional[RunPrincipal],
+) -> ReasonerDispatch:
+    tier = QoSTier(context.resolve_qos(reasoner, Ann(batchable=False), principal))
+    # BATCH needs a durable submit/wait boundary.  Foreground calls use the same
+    # non-batchable clamp as the durable resolver.
+    if tier is QoSTier.BATCH:
+        tier = QoSTier.FLEX
+    return ReasonerDispatch(qos=tier)
+
+
+def _accepts_keyword(fn: Callable[..., Any], keyword: str) -> bool:
+    try:
+        signature = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return True
+    if any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    ):
+        return True
+    parameter = signature.parameters.get(keyword)
+    return parameter is not None and parameter.kind in {
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    }
+
+
+def _pack_reasoner_result(raw: Any) -> Any:
+    if not isinstance(raw, LlmResult):
+        return raw
+    attrs = raw.meta.to_attrs()
+    if not attrs:
+        return raw.reply
+    return {"reply": raw.reply, _JULEP_META_KEY: attrs}
+
+
+__all__ = [
+    "LocalExecutionConfigurationError",
+    "LocalExecutionUnsupported",
+    "LocalPipeline",
+    "LocalPipelineError",
+    "LocalPipelineNotFound",
+    "arun_local_pipeline",
+    "prepare_local_pipeline",
+    "run_local_pipeline",
+]

--- a/julep/prompt.py
+++ b/julep/prompt.py
@@ -83,19 +83,7 @@ def rendered_user_for(reasoner: Reasoner, value: Any) -> Optional[str]:
 
 
 def _with_rendered_system(reasoner: Reasoner, system: str) -> Reasoner:
-    return Reasoner(
-        name=reasoner.name, model=reasoner.model, system=system,
-        reply=reasoner.reply_schema, tools=reasoner.tools,
-        temperature=reasoner.temperature, max_rounds=reasoner.max_rounds,
-        is_agent=reasoner.is_agent, sub_contract=reasoner.sub_contract,
-        context_scope=reasoner.context_scope, system_render=None,
-        user_render=reasoner.user_render, max_tokens=reasoner.max_tokens,
-        reasoning_effort=reasoner.reasoning_effort,
-        output_retries=reasoner.output_retries,
-        require_tool_call=reasoner.require_tool_call,
-        response_format=reasoner.response_format,
-        prompt_cache=reasoner.prompt_cache,
-    )
+    return reasoner.replace(system=system, system_render=None)
 
 
 def rendered_reasoner_for(reasoner: Reasoner, value: Any) -> Reasoner:

--- a/julep/registry.py
+++ b/julep/registry.py
@@ -178,6 +178,10 @@ class Registry:
         self.renderers: dict[str, RendererEntry] = {}
         self.renderer_declarations: dict[str, RendererDeclaration] = {}
         self.tool_expectations: dict[str, ToolSchemaExpectation] = {}
+        # Compatibility aliases installed by a scoped dotctx package are kept
+        # queryable, but must not constrain unrelated top-level native calls
+        # that happen to reuse the same bare tool name.
+        self.scoped_tool_fallbacks: set[str] = set()
         # Release-hydrated AgentWorkflow specs keyed by controller name.
         self.agent_specs: dict[str, dict[str, Any]] = {}
 
@@ -444,7 +448,11 @@ class Registry:
         # Retain the historical unscoped lookup for callers loading one package.
         # A second package may reuse the same model-visible alias with a different
         # schema; its scoped entry remains authoritative at freeze.
-        self.tool_expectations.setdefault(exp.key, exp)
+        if scope is None:
+            self.scoped_tool_fallbacks.discard(exp.key)
+        elif exp.key not in self.tool_expectations:
+            self.tool_expectations[exp.key] = exp
+            self.scoped_tool_fallbacks.add(exp.key)
         return exp
 
     def get_tool_expectation(

--- a/julep/server/__init__.py
+++ b/julep/server/__init__.py
@@ -1,5 +1,7 @@
 """Optional FastAPI control-plane primitives."""
 
+from typing import TYPE_CHECKING, Any
+
 from .auth import (
     ApiKey,
     KeyRing,
@@ -13,13 +15,26 @@ from .auth import (
 from .settings import ServerSettings
 from .temporal import TemporalClientGateway, TemporalGateway, create_temporal_gateway
 
+if TYPE_CHECKING:
+    from .local import LocalExecutionGateway, create_local_app
+
+
+def __getattr__(name: str) -> Any:
+    if name in {"LocalExecutionGateway", "create_local_app"}:
+        from . import local
+
+        return getattr(local, name)
+    raise AttributeError(name)
+
 __all__ = [
     "ApiKey",
     "KeyRing",
+    "LocalExecutionGateway",
     "ServerSettings",
     "TemporalClientGateway",
     "TemporalGateway",
     "create_temporal_gateway",
+    "create_local_app",
     "merge_principal",
     "owner_scoped",
     "require_admin",

--- a/julep/server/app.py
+++ b/julep/server/app.py
@@ -13,7 +13,7 @@ from fastapi import FastAPI
 
 from ..app_deploy import LaneReconciler
 from ..artifact_store import ArtifactStore
-from ..execution.projection_store import ExecutionStore
+from ..execution.projection_store import ExecutionStore, SecretCipher
 from .auth import KeyRing
 from .routes.artifacts import router as artifacts_router
 from .routes.deployments import router as deployments_router
@@ -61,6 +61,8 @@ def create_app(
     gateway: Optional[TemporalGateway] = None,
     artifacts: Optional[ArtifactStore] = None,
     reconciler: Optional[LaneReconciler] = None,
+    keyring: Optional[KeyRing] = None,
+    vault_cipher: Optional[SecretCipher] = None,
     enable_reconciler: bool = True,
     reconcile_interval_s: Optional[float] = None,
     sse_heartbeat_seconds: int = DEFAULT_HEARTBEAT_SECONDS,
@@ -86,8 +88,10 @@ def create_app(
     if sse_poll_seconds <= 0:
         raise ValueError("sse_poll_seconds must be positive")
 
-    keyring = KeyRing.from_settings(resolved_settings)
-    vault_cipher = resolved_settings.build_vault_cipher()
+    resolved_keyring = keyring or KeyRing.from_settings(resolved_settings)
+    resolved_vault_cipher = (
+        vault_cipher if vault_cipher is not None else resolved_settings.build_vault_cipher()
+    )
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
@@ -99,7 +103,14 @@ def create_app(
                 app.state.gateway_error = f"{type(exc).__name__}: {exc}"
                 logger.warning("Temporal connection failed: %s", type(exc).__name__)
 
-        installed_sighup = keyring.install_sighup_handler()
+        current_gateway = app.state.gateway
+        start = getattr(current_gateway, "start", None)
+        if callable(start):
+            result = start()
+            if inspect.isawaitable(result):
+                await result
+
+        installed_sighup = resolved_keyring.install_sighup_handler()
         task: Optional[asyncio.Task[None]] = None
         if enable_reconciler and interval_s > 0:
             task = asyncio.create_task(
@@ -115,10 +126,10 @@ def create_app(
                 with suppress(asyncio.CancelledError):
                     await task
             if installed_sighup:
-                keyring.restore_sighup_handler()
-            current_gateway: Any = app.state.gateway
-            if current_gateway is not None:
-                await _close_optional(current_gateway)
+                resolved_keyring.restore_sighup_handler()
+            closing_gateway: Any = app.state.gateway
+            if closing_gateway is not None:
+                await _close_optional(closing_gateway)
             resolved_store.close()
 
     app = FastAPI(title="Julep Control Plane", version="1", lifespan=lifespan)
@@ -127,8 +138,8 @@ def create_app(
     app.state.gateway = gateway
     app.state.gateway_error = None
     app.state.artifacts = resolved_artifact_store
-    app.state.keyring = keyring
-    app.state.vault_cipher = vault_cipher
+    app.state.keyring = resolved_keyring
+    app.state.vault_cipher = resolved_vault_cipher
     app.state.reconciler = resolved_reconciler
     app.state.deployment_reconcile_status = {}
     app.state.sse_heartbeat_seconds = sse_heartbeat_seconds

--- a/julep/server/local.py
+++ b/julep/server/local.py
@@ -34,8 +34,12 @@ from ..execution.effects import (
     WorkerContext,
     toolref_json_from_key,
 )
-from ..execution.harness import preflightMcp
 from ..execution.interpreter import InMemoryEnv, Result, call_ref_key, interpret
+from ..execution.mcp_preflight import (
+    McpPreflightError,
+    preflight_mcp,
+    scrub_mcp_preflight_failure,
+)
 from ..execution.policy import ExecutionPolicy
 from ..execution.projection_store import (
     ExecutionStore,
@@ -625,16 +629,19 @@ class LocalExecutionGateway:
             _validate_finite_flow(flow)
 
             if self._context is not None:
-                await preflightMcp(
-                    {
-                        "workflowId": record.workflow_id,
-                        "flowJson": flow_json,
-                        "manifestJson": manifest_json,
-                        "policy": pipeline.mcp_preflight_policy or "off",
-                        "principal": principal,
-                        **({"secrets": secrets} if secrets else {}),
-                    }
-                )
+                try:
+                    await preflight_mcp(
+                        {
+                            "workflowId": record.workflow_id,
+                            "flowJson": flow_json,
+                            "manifestJson": manifest_json,
+                            "policy": pipeline.mcp_preflight_policy or "off",
+                            "principal": principal,
+                            **({"secrets": secrets} if secrets else {}),
+                        }
+                    )
+                except Exception as exc:
+                    raise scrub_mcp_preflight_failure(exc, secrets) from None
                 await effects.verifyPures(
                     VerifyPuresInput(
                         pinned=dict(pipeline.pinned_pures),
@@ -753,11 +760,14 @@ class LocalExecutionGateway:
             return
         except Exception as exc:  # noqa: BLE001 - persist a terminal local run
             record.status = "failed"
+            error_type = (
+                exc.type if isinstance(exc, McpPreflightError) else type(exc).__name__
+            )
             self._finalize(
                 record,
                 status="failed",
                 result=None,
-                error=f"{type(exc).__name__}: {exc}",
+                error=f"{error_type}: {exc}",
                 cause=last_event_id,
                 secrets=secrets,
             )

--- a/julep/server/local.py
+++ b/julep/server/local.py
@@ -1,0 +1,928 @@
+"""Service-free control-plane application and execution gateway.
+
+Local mode intentionally preserves the HTTP release/run lifecycle while replacing
+PostgreSQL and Temporal with process-local implementations.  It is a development
+surface, not a durability backend.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import ipaddress
+import os
+import secrets as _secrets
+import time
+import uuid
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional
+
+from fastapi import FastAPI
+
+from ..app_deploy import PipelineRelease
+from ..artifact_store import LocalDirArtifactStore
+from ..continuation import continuation_value, is_continuation
+from ..contracts import manifest_from_json
+from ..execution import effects
+from ..execution.effects import (
+    CallToolInput,
+    CompilePlanInput,
+    InvokeReasonerInput,
+    VerifyPuresInput,
+    WorkerContext,
+    toolref_json_from_key,
+)
+from ..execution.harness import preflightMcp
+from ..execution.interpreter import InMemoryEnv, Result, call_ref_key, interpret
+from ..execution.policy import ExecutionPolicy
+from ..execution.projection_store import (
+    ExecutionStore,
+    InMemoryExecutionStore,
+    _capture_value,
+    _normalise_event,
+    _redact_projection_metadata,
+)
+from ..ir import CallStep, EMIT_TOOL, NativeTool, Node, RECV_TOOL, SubStep, toolref_key
+from ..kinds import Op
+from ..projection import (
+    EventType,
+    InMemoryProjection,
+    ProjectionEmitter,
+    ProjectionEvent,
+    ProjectionSink,
+    TeeStore,
+)
+from ..registry import DEFAULT_REGISTRY, Registry
+from ..secrets import VaultCipher
+from .app import create_app
+from .auth import ApiKey, KeyRing
+from .settings import ServerSettings
+
+ContextFactory = str | Callable[[], WorkerContext | Any]
+
+
+class _ExecutionProjectionSink(ProjectionSink):
+    """Persist interpreter events immediately through the control-plane store."""
+
+    def __init__(
+        self,
+        store: ExecutionStore,
+        projection: InMemoryProjection,
+        *,
+        run_id: str,
+        workflow_id: str,
+        segment_seq: int,
+        secrets: Optional[Mapping[str, str]],
+    ) -> None:
+        self._store = store
+        self._projection = projection
+        self._run_id = run_id
+        self._workflow_id = workflow_id
+        self._segment_seq = segment_seq
+        self._secrets = secrets
+
+    def append(self, event: ProjectionEvent) -> None:
+        candidate = event.to_json()
+        captured = None
+        if event.value_ref is not None:
+            captured = _capture_value(
+                self._projection.values.get(event.value_ref), self._secrets
+            )
+        candidate = _redact_projection_metadata(candidate, self._secrets)
+        persisted_ref = None if captured is None else captured.value_ref
+        if captured is not None:
+            self._store.put_value(
+                captured.value_ref,
+                captured.payload,
+                captured.byte_len,
+                captured.oversize,
+            )
+        self._store.insert_events(
+            [
+                _normalise_event(
+                    candidate,
+                    run_id=self._run_id,
+                    workflow_id=self._workflow_id,
+                    segment_seq=self._segment_seq,
+                    value_ref=persisted_ref,
+                )
+            ]
+        )
+
+
+@dataclass
+class _LocalRun:
+    run_id: str
+    workflow_id: str
+    local_run_id: str
+    task: Optional[asyncio.Task[None]] = None
+    stop_status: Optional[str] = None
+    status: str = "running"
+    segment_seq: int = 0
+    projection: Optional[InMemoryProjection] = None
+
+    def __post_init__(self) -> None:
+        self.open_gates: dict[str, asyncio.Future[Any]] = {}
+        self.early_signals: dict[str, Any] = {}
+
+
+def _echo_tools(flow: Node) -> dict[str, Callable[[Any], Any]]:
+    return {toolref_key(ref): lambda value: value for ref in flow.tool_refs()}
+
+
+def _echo_reasoners(flow: Node) -> dict[str, Callable[[Any], Any]]:
+    names: set[str] = set()
+    for node in flow.walk():
+        reasoner = getattr(node.step, "reasoner", None)
+        if isinstance(reasoner, str):
+            names.add(reasoner)
+        if node.op in {Op.APP, Op.EVAL_PLAN} and node.controller is not None:
+            names.add(node.controller)
+    return {name: lambda value: value for name in names}
+
+
+def _echo_subs(flow: Node) -> dict[str, Callable[[Any], Any]]:
+    refs = {
+        node.step.ref
+        for node in flow.walk()
+        if isinstance(node.step, SubStep)
+    }
+    return {ref: lambda value: value for ref in refs}
+
+
+def _echo_agents(flow: Node) -> dict[str, Callable[[Any], Any]]:
+    controllers = {
+        node.controller
+        for node in flow.walk()
+        if node.op is Op.APP and node.controller is not None
+    }
+    return {controller: lambda value: value for controller in controllers}
+
+
+class _LocalEffectsEnv(InMemoryEnv):
+    """Interpreter environment that invokes the configured worker effects directly."""
+
+    def __init__(
+        self,
+        manifest: Any,
+        emitter: ProjectionEmitter,
+        *,
+        session_id: str,
+        manifest_json: dict[str, Any],
+        policy: ExecutionPolicy,
+        gate: Callable[[Any, str, Optional[int]], Any],
+        max_calls: Mapping[str, int],
+        principal: Optional[dict[str, Any]],
+        secrets: Optional[dict[str, str]],
+        runtime_declarations_ref: Optional[dict[str, Any]],
+        root_run_id: str,
+        segment_seq: int,
+        call_counts: dict[str, int],
+    ) -> None:
+        super().__init__(
+            manifest,
+            emitter,
+            max_parallel=policy.max_parallel,
+            max_calls=dict(max_calls),
+            principal=principal,
+            root_run_id=root_run_id,
+            segment_seq=segment_seq,
+        )
+        self._session_id = session_id
+        self._manifest_json = manifest_json
+        self._policy = policy
+        self._gate_waiter = gate
+        self._secrets = secrets
+        self._runtime_declarations_ref = runtime_declarations_ref
+        # Share one mutable counter map across continuation segments and inline
+        # subflows so a local execution cannot reset release-scoped maxCalls.
+        self.call_counts = call_counts
+
+    def next_cid(self, node_id: str) -> str:
+        return f"{self._session_id}/{super().next_cid(node_id)}"
+
+    def get_pure(self, name: str) -> Callable[..., Any]:
+        registry = effects._hydrate_runtime_declarations(
+            self._runtime_declarations_ref
+        )
+        return registry.get_pure(name)
+
+    async def run_call(self, node: Node, value: Any, cid: str) -> Any:
+        key = call_ref_key(node, self.manifest)
+        step = node.step
+        frozen_input_schema = (
+            self.manifest[step.frozen_hash].input_schema
+            if isinstance(step, CallStep) and step.frozen_hash is not None
+            else None
+        )
+        cache = (
+            node.ann.cache.to_json()
+            if node.ann is not None and node.ann.cache is not None
+            else None
+        )
+        return await effects.callTool(
+            CallToolInput(
+                tool_ref=toolref_json_from_key(key),
+                value=value,
+                cid=cid,
+                cache=cache,
+                principal=self.principal,
+                run_id=self._session_id,
+                root_run_id=self.root_run_id,
+                segment_seq=self.segment_seq,
+                node_id=node.id,
+                op="call",
+                kind="tool",
+                secrets=self._secrets,
+                frozen_input_schema=frozen_input_schema,
+            )
+        )
+
+    async def invoke_reasoner(
+        self,
+        reasoner: str,
+        value: Any,
+        cid: str,
+        timeout_s: Optional[int],
+        batchable: bool = False,
+    ) -> Any:
+        del timeout_s, batchable
+        return await effects.invokeReasoner(
+            InvokeReasonerInput(
+                reasoner=reasoner,
+                value=value,
+                cid=cid,
+                principal=self.principal,
+                run_id=self._session_id,
+                root_run_id=self.root_run_id,
+                segment_seq=self.segment_seq,
+                op="think",
+                kind="reasoner",
+                runtime_declarations_ref=self._runtime_declarations_ref,
+                secrets=self._secrets,
+            )
+        )
+
+    async def compile_plan(self, planner: str, value: Any, cid: str) -> Node:
+        plan = await effects.compilePlan(
+            CompilePlanInput(
+                planner=planner,
+                value=value,
+                cid=cid,
+                manifest=self._manifest_json,
+                principal=self.principal,
+                runtime_declarations_ref=self._runtime_declarations_ref,
+            )
+        )
+        compiled = Node.from_json(plan)
+        _validate_finite_flow(compiled)
+        return compiled
+
+    async def run_sub(
+        self,
+        ref: str,
+        contract: Any,
+        value: Any,
+        cid: str,
+        node_id: Optional[str] = None,
+    ) -> Any:
+        del contract, node_id
+        spec = await effects.resolveSubflow(ref)
+        child_json = dict(spec["flowJson"])
+        child = Node.from_json(child_json)
+        _validate_finite_flow(child)
+        await effects.verifyPures(
+            VerifyPuresInput(
+                pinned=dict(spec.get("pinnedPures") or {}),
+                bundle=spec.get("bundle"),
+                flow_json=child_json,
+            )
+        )
+        child_manifest_json = dict(spec.get("manifestJson") or {})
+        child_env = _LocalEffectsEnv(
+            manifest_from_json(child_manifest_json),
+            self.emitter,
+            session_id=f"{self._session_id}-sub-{cid}",
+            manifest_json=child_manifest_json,
+            policy=self._policy,
+            gate=self._gate_waiter,
+            max_calls=self._max_calls,
+            principal=self.principal,
+            secrets=self._secrets,
+            runtime_declarations_ref=(
+                spec.get("runtimeDeclarationsRef")
+                or self._runtime_declarations_ref
+            ),
+            root_run_id=self.root_run_id or self._session_id,
+            segment_seq=self.segment_seq,
+            call_counts=self.call_counts,
+        )
+        child_value = value
+        for _ in range(1000):
+            result = await interpret(child, child_value, child_env)
+            if not is_continuation(result.value):
+                return result.value
+            child_value = continuation_value(result.value)
+        raise RuntimeError(f"local subflow {ref!r} did not settle within 1000 segments")
+
+    async def run_agent(
+        self,
+        controller: str,
+        value: Any,
+        cid: str,
+        app_config: Optional[dict[str, Any]] = None,
+    ) -> Any:
+        from ..agent_loop import (
+            AgentConfig,
+            AgentState,
+            drive_agent_loop,
+            tool_input_schemas,
+        )
+
+        resolved = await effects.resolveAgentSpec(
+            effects.ResolveAgentSpecInput(
+                controller=controller,
+                runtime_declarations_ref=self._runtime_declarations_ref,
+            )
+        )
+        authored = {**dict(resolved.get("config") or {}), **dict(app_config or {})}
+        cfg = AgentConfig.from_json(authored)
+        raw_grants = (
+            app_config.get("tools")
+            if app_config is not None and "tools" in app_config
+            else resolved.get("grantedTools")
+        )
+        grants = (
+            None if raw_grants is None else set(str(name) for name in raw_grants)
+        )
+        raw_subflows = (
+            app_config.get("subflows")
+            if app_config is not None and "subflows" in app_config
+            else resolved.get("grantedSubflows")
+        )
+        granted_subflows = (
+            None
+            if raw_subflows is None
+            else set(str(name) for name in raw_subflows)
+        )
+        aliases = {
+            str(alias): str(wire)
+            for alias, wire in {
+                **dict(resolved.get("toolAliases") or {}),
+                **dict((app_config or {}).get("toolAliases") or {}),
+            }.items()
+        }
+        contracts = {
+            str(alias): dict(contract)
+            for alias, contract in dict(resolved.get("grantedContracts") or {}).items()
+        }
+        contracts.update(
+            {
+                str(alias): dict(contract)
+                for alias, contract in dict(
+                    (app_config or {}).get("toolContracts") or {}
+                ).items()
+            }
+        )
+        for alias in set(contracts) | (grants or set()):
+            wire = aliases.get(alias, alias)
+            limit = self._max_calls.get(alias, self._max_calls.get(wire))
+            if limit is None:
+                continue
+            contract = contracts.setdefault(alias, {})
+            authored_limit = contract.get("maxCalls", contract.get("max_calls"))
+            contract["maxCalls"] = (
+                int(limit)
+                if authored_limit is None
+                else min(int(limit), int(authored_limit))
+            )
+        tool_defs = (app_config or {}).get("toolDefs", resolved.get("toolDefs"))
+        schemas = tool_input_schemas(tool_defs) if tool_defs is not None else None
+
+        async def invoke_controller(payload: dict[str, Any]) -> Any:
+            return await self.invoke_reasoner(
+                controller,
+                payload,
+                self.next_cid(f"agent:{controller}:reason"),
+                None,
+            )
+
+        async def call_tool(
+            name: str, value: Any, *, call_index: Optional[int] = None
+        ) -> Any:
+            del call_index
+            alias = name
+            args = value
+            wire = aliases.get(alias, alias)
+            return await effects.callTool(
+                CallToolInput(
+                    tool_ref=toolref_json_from_key(wire),
+                    value=args,
+                    cid=self.next_cid(f"agent:{controller}:{alias}"),
+                    principal=self.principal,
+                    run_id=self._session_id,
+                    root_run_id=self.root_run_id,
+                    segment_seq=self.segment_seq,
+                    secrets=self._secrets,
+                    frozen_input_schema=(None if schemas is None else schemas.get(alias)),
+                )
+            )
+
+        async def run_subflow(ref: str, sub_input: Any) -> Any:
+            return await self.run_sub(
+                ref,
+                None,
+                sub_input,
+                self.next_cid(f"agent:{controller}:sub:{ref}"),
+            )
+
+        result = await drive_agent_loop(
+            input=value,
+            cfg=cfg,
+            invoke_controller=invoke_controller,
+            call_tool=call_tool,
+            run_subflow=run_subflow,
+            granted=grants,
+            granted_subflows=granted_subflows,
+            contracts=contracts,
+            tool_schemas=schemas,
+            state=AgentState(last=value, call_counts=dict(self.call_counts)),
+            get_pure=self.get_pure,
+        )
+        carried_counts = result.get("callCounts")
+        if isinstance(carried_counts, Mapping):
+            self.call_counts.update(
+                {str(tool): int(count) for tool, count in carried_counts.items()}
+            )
+        return result
+
+    async def human_gate(self, value: Any, cid: str, timeout_s: Optional[int]) -> Any:
+        return await self._gate_waiter(value, cid, timeout_s)
+
+
+def _validate_finite_flow(flow: Node) -> None:
+    for node in flow.walk():
+        if node.op is Op.LOOP:
+            raise ValueError("local flow execution cannot run session LOOP artifacts")
+        step = node.step
+        if (
+            isinstance(step, CallStep)
+            and isinstance(step.tool, NativeTool)
+            and step.tool.name in {RECV_TOOL, EMIT_TOOL}
+        ):
+            raise ValueError("local flow execution cannot run session channel operations")
+
+
+class LocalExecutionGateway:
+    """A process-local implementation of the control-plane gateway protocol."""
+
+    accepts_secrets: bool
+
+    def __init__(
+        self,
+        store: ExecutionStore,
+        *,
+        context_factory: Optional[ContextFactory] = None,
+        artifact_store_url: Optional[str] = None,
+    ) -> None:
+        self._store = store
+        self._context_factory = context_factory
+        self._context: Optional[WorkerContext] = None
+        self._previous_context: Optional[WorkerContext] = None
+        self._artifact_store_url = artifact_store_url
+        self._previous_artifact_store_url: Optional[str] = None
+        self._started = False
+        self._effects_lock = asyncio.Lock()
+        self._runs: dict[str, _LocalRun] = {}
+        self.accepts_secrets = context_factory is not None
+
+    async def start(self) -> None:
+        if self._started:
+            return
+        self._started = True
+        if self._artifact_store_url is not None:
+            self._previous_artifact_store_url = os.environ.get(
+                "JULEP_ARTIFACT_STORE_URL"
+            )
+            os.environ["JULEP_ARTIFACT_STORE_URL"] = self._artifact_store_url
+        if self._context_factory is None:
+            return
+        try:
+            factory: Callable[[], Any]
+            if isinstance(self._context_factory, str):
+                from ..execution.serve import load_context_factory
+
+                factory = load_context_factory(self._context_factory)
+            else:
+                factory = self._context_factory
+            context = factory()
+            if inspect.isawaitable(context):
+                context = await context
+            if not isinstance(context, WorkerContext):
+                raise TypeError("local context factory must return a WorkerContext")
+            self._previous_context = effects._CTX
+            effects.configure(context)
+            self._context = context
+        except BaseException:
+            if self._artifact_store_url is not None:
+                if self._previous_artifact_store_url is None:
+                    os.environ.pop("JULEP_ARTIFACT_STORE_URL", None)
+                else:
+                    os.environ["JULEP_ARTIFACT_STORE_URL"] = (
+                        self._previous_artifact_store_url
+                    )
+            if self._previous_context is not None:
+                effects.configure(self._previous_context)
+            self._context = None
+            self._previous_context = None
+            self._previous_artifact_store_url = None
+            self._started = False
+            raise
+
+    async def ready(self) -> bool:
+        return True
+
+    async def start_flow(
+        self,
+        pipeline: PipelineRelease,
+        *,
+        workflow_id: str,
+        run_id: str,
+        input: Any,
+        principal: dict[str, Any],
+        queue_lanes: Optional[dict[str, str]],
+        secrets: Optional[dict[str, str]],
+    ) -> str:
+        del queue_lanes
+        if secrets and not self.accepts_secrets:
+            raise ValueError("local echo execution does not accept run secrets")
+        local_run_id = f"local-{uuid.uuid4()}"
+        record = _LocalRun(run_id, workflow_id, local_run_id)
+        self._runs[workflow_id] = record
+        record.task = asyncio.create_task(
+            self._execute(record, pipeline, input, principal, secrets),
+            name=f"julep-local-{run_id}",
+        )
+        return local_run_id
+
+    async def _execute(
+        self,
+        record: _LocalRun,
+        pipeline: PipelineRelease,
+        input: Any,
+        principal: dict[str, Any],
+        secrets: Optional[dict[str, str]],
+    ) -> None:
+        value = input
+        result: Any = None
+        last_event_id: Optional[str] = None
+        call_counts: dict[str, int] = {}
+        try:
+            flow_json = dict(pipeline.flow_json)
+            manifest_json = dict(pipeline.manifest_json)
+            flow = Node.from_json(flow_json)
+            _validate_finite_flow(flow)
+
+            if self._context is not None:
+                await preflightMcp(
+                    {
+                        "workflowId": record.workflow_id,
+                        "flowJson": flow_json,
+                        "manifestJson": manifest_json,
+                        "policy": pipeline.mcp_preflight_policy or "off",
+                        "principal": principal,
+                        **({"secrets": secrets} if secrets else {}),
+                    }
+                )
+                await effects.verifyPures(
+                    VerifyPuresInput(
+                        pinned=dict(pipeline.pinned_pures),
+                        bundle=pipeline.bundle_ref,
+                        flow_json=flow_json,
+                        artifact_hash=pipeline.artifact_hash,
+                    )
+                )
+                echo_registry: Optional[Registry] = None
+            else:
+                echo_registry = (
+                    DEFAULT_REGISTRY
+                    if pipeline.runtime_declarations_ref is None
+                    else effects._hydrate_runtime_declarations(
+                        pipeline.runtime_declarations_ref
+                    )
+                )
+                # Bundle resolution and pin verification are implemented by the
+                # backend-neutral effect. Temporarily point it at this release's
+                # registry, then restore the process context before execution.
+                async with self._effects_lock:
+                    previous_context = effects._CTX
+                    try:
+                        effects.configure(WorkerContext(registry=echo_registry))
+                        await effects.verifyPures(
+                            VerifyPuresInput(
+                                pinned=dict(pipeline.pinned_pures),
+                                bundle=pipeline.bundle_ref,
+                                flow_json=flow_json,
+                                artifact_hash=pipeline.artifact_hash,
+                            )
+                        )
+                    finally:
+                        effects.configure(previous_context)
+
+            for segment_seq in range(1000):
+                record.segment_seq = segment_seq
+                projection = InMemoryProjection()
+                record.projection = projection
+                sink = _ExecutionProjectionSink(
+                    self._store,
+                    projection,
+                    run_id=record.run_id,
+                    workflow_id=record.workflow_id,
+                    segment_seq=segment_seq,
+                    secrets=secrets,
+                )
+                emitter = ProjectionEmitter(TeeStore(projection, sink))
+                gate = lambda gate_value, cid, timeout_s: self._await_human(  # noqa: E731
+                    record, gate_value, cid, timeout_s
+                )
+                if self._context is None:
+                    env: Any = InMemoryEnv(
+                        manifest_from_json(manifest_json),
+                        emitter,
+                        tools=_echo_tools(flow),
+                        reasoners=_echo_reasoners(flow),
+                        subs=_echo_subs(flow),
+                        agents=_echo_agents(flow),
+                        gate=lambda _value: None,
+                        max_calls=dict(pipeline.max_call_limits),
+                        max_parallel=(
+                            pipeline.execution_policy.max_parallel
+                            if pipeline.execution_policy is not None
+                            else None
+                        ),
+                        principal=principal,
+                        root_run_id=record.run_id,
+                        segment_seq=segment_seq,
+                        registry=echo_registry,
+                    )
+                    env.call_counts = call_counts
+
+                    async def echo_gate(
+                        gate_value: Any, cid: str, timeout_s: Optional[int]
+                    ) -> Any:
+                        return await self._await_human(
+                            record, gate_value, cid, timeout_s
+                        )
+
+                    env.human_gate = echo_gate
+                else:
+                    env = _LocalEffectsEnv(
+                        manifest_from_json(manifest_json),
+                        emitter,
+                        session_id=record.workflow_id,
+                        manifest_json=manifest_json,
+                        policy=pipeline.execution_policy or ExecutionPolicy(),
+                        gate=gate,
+                        max_calls=pipeline.max_call_limits,
+                        principal=principal,
+                        secrets=secrets,
+                        runtime_declarations_ref=pipeline.runtime_declarations_ref,
+                        root_run_id=record.run_id,
+                        segment_seq=segment_seq,
+                        call_counts=call_counts,
+                    )
+                segment: Result = await interpret(flow, value, env)
+                result = segment.value
+                last_event_id = segment.event_id
+                if not is_continuation(result):
+                    break
+                value = continuation_value(result)
+            else:
+                raise RuntimeError("local flow did not settle within 1000 segments")
+        except asyncio.CancelledError:
+            status = record.stop_status or "canceled"
+            record.status = status
+            self._finalize(record, status=status, result=None, cause=last_event_id)
+            return
+        except Exception as exc:  # noqa: BLE001 - persist a terminal local run
+            record.status = "failed"
+            self._finalize(
+                record,
+                status="failed",
+                result=None,
+                error=f"{type(exc).__name__}: {exc}",
+                cause=last_event_id,
+                secrets=secrets,
+            )
+            return
+
+        record.status = "completed"
+        self._finalize(
+            record,
+            status="completed",
+            result=result,
+            cause=last_event_id,
+            secrets=secrets,
+        )
+
+    async def _await_human(
+        self,
+        record: _LocalRun,
+        value: Any,
+        cid: str,
+        timeout_s: Optional[int],
+    ) -> Any:
+        if cid in record.early_signals:
+            return record.early_signals.pop(cid)
+        future = asyncio.get_running_loop().create_future()
+        record.open_gates[cid] = future
+        try:
+            if timeout_s is None:
+                return await future
+            try:
+                return await asyncio.wait_for(future, float(timeout_s))
+            except asyncio.TimeoutError:
+                return {"approved": False, "reason": "timeout", "input": value}
+        finally:
+            record.open_gates.pop(cid, None)
+
+    def _finalize(
+        self,
+        record: _LocalRun,
+        *,
+        status: str,
+        result: Any,
+        error: Optional[str] = None,
+        cause: Optional[str] = None,
+        secrets: Optional[Mapping[str, str]] = None,
+    ) -> None:
+        captured = _capture_value(result, secrets) if status == "completed" else None
+        event: dict[str, Any] = {
+            "eventId": "__terminal__",
+            "type": EventType.DID.value if status == "completed" else EventType.FAILED.value,
+            "node": "__run__",
+            "cid": f"{record.run_id}:terminal",
+            "ts": time.time(),
+            "causes": [] if cause is None else [cause],
+            "attrs": {"terminal": True, "status": status, "local": True},
+        }
+        if error is not None:
+            event["error"] = error
+        event = _redact_projection_metadata(event, secrets)
+        safe_error = event.get("error")
+        terminal = _normalise_event(
+            event,
+            run_id=record.run_id,
+            workflow_id=record.workflow_id,
+            segment_seq=record.segment_seq,
+            value_ref=None if captured is None else captured.value_ref,
+        )
+        self._store.finalize_run(
+            run_id=record.run_id,
+            workflow_id=record.workflow_id,
+            segment_seq=record.segment_seq,
+            status=status,
+            terminal_event=terminal,
+            result_payload=None if captured is None else captured.payload,
+            result_byte_len=0 if captured is None else captured.byte_len,
+            result_oversize=False if captured is None else captured.oversize,
+            error=None if safe_error is None else str(safe_error),
+            finished_at=time.time(),
+        )
+
+    async def cancel(self, workflow_id: str) -> None:
+        await self._stop(workflow_id, "canceled")
+
+    async def terminate(self, workflow_id: str) -> None:
+        await self._stop(workflow_id, "terminated")
+
+    async def _stop(self, workflow_id: str, status: str) -> None:
+        record = self._runs.get(workflow_id)
+        if record is None:
+            raise KeyError(workflow_id)
+        record.stop_status = status
+        if record.task is not None and not record.task.done():
+            record.task.cancel()
+            try:
+                await record.task
+            except asyncio.CancelledError:
+                pass
+
+    async def describe(self, workflow_id: str) -> str:
+        record = self._runs.get(workflow_id)
+        return "not_found" if record is None else record.status
+
+    async def signal(self, workflow_id: str, name: str, arg: Any) -> None:
+        if name != "submitHuman":
+            raise ValueError(f"unsupported local signal {name!r}")
+        record = self._runs.get(workflow_id)
+        if record is None:
+            raise KeyError(workflow_id)
+        if not isinstance(arg, Mapping) or not isinstance(arg.get("cid"), str):
+            raise ValueError("submitHuman needs a string cid")
+        cid = str(arg["cid"])
+        value = arg.get("value")
+        future = record.open_gates.get(cid)
+        if future is None:
+            record.early_signals[cid] = value
+        elif not future.done():
+            future.set_result(value)
+
+    async def query(self, workflow_id: str, name: str) -> Any:
+        record = self._runs.get(workflow_id)
+        if record is None:
+            raise KeyError(workflow_id)
+        if name == "openGates":
+            return sorted(record.open_gates)
+        if name == "projection":
+            projection = record.projection
+            return [] if projection is None else [event.to_json() for event in projection.events()]
+        raise ValueError(f"unsupported local query {name!r}")
+
+    async def close(self) -> None:
+        tasks: list[asyncio.Task[None]] = []
+        for record in self._runs.values():
+            task = record.task
+            if task is not None and not task.done():
+                record.stop_status = "canceled"
+                task.cancel()
+                tasks.append(task)
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        if self._artifact_store_url is not None:
+            if self._previous_artifact_store_url is None:
+                os.environ.pop("JULEP_ARTIFACT_STORE_URL", None)
+            else:
+                os.environ["JULEP_ARTIFACT_STORE_URL"] = (
+                    self._previous_artifact_store_url
+                )
+        if self._previous_context is not None:
+            effects.configure(self._previous_context)
+        self._context = None
+        self._previous_context = None
+        self._previous_artifact_store_url = None
+        self._started = False
+
+
+def create_local_app(
+    project_root: str | Path = ".",
+    host: str = "127.0.0.1",
+    context_factory: Optional[ContextFactory] = None,
+) -> FastAPI:
+    """Build a zero-daemon API server with process-local execution state."""
+
+    root = Path(project_root).resolve()
+    env = dict(os.environ)
+    # Parse ordinary API-key/project configuration without imposing Temporal's
+    # payload-codec prerequisite on a server that never connects to Temporal.
+    env["TEMPORAL_PAYLOAD_ENCRYPTION_REQUIRED"] = "false"
+    settings = ServerSettings.from_env(env, root=root)
+    api_keys = settings.api_keys
+    if not api_keys:
+        try:
+            loopback = ipaddress.ip_address(host).is_loopback
+        except ValueError:
+            loopback = host.strip().lower() == "localhost"
+        if not loopback:
+            raise ValueError(
+                "local mode needs configured API keys when binding a non-loopback host"
+            )
+        api_keys = (ApiKey("local-dev", "local-dev", role="admin"),)
+
+    artifact_root = root / ".julep" / "artifacts"
+    settings = replace(
+        settings,
+        api_keys=api_keys,
+        host=host,
+        execution_store_dsn=None,
+        artifact_store_url=artifact_root.as_uri(),
+        payload_encryption_required=context_factory is not None,
+        helm_chart=None,
+        reconcile_interval_s=0.0,
+    )
+    store = InMemoryExecutionStore()
+    gateway = LocalExecutionGateway(
+        store,
+        context_factory=context_factory,
+        artifact_store_url=artifact_root.as_uri(),
+    )
+    app = create_app(
+        settings=settings,
+        store=store,
+        gateway=gateway,
+        artifacts=LocalDirArtifactStore(artifact_root),
+        reconciler=None,
+        enable_reconciler=False,
+        keyring=KeyRing(api_keys, reload_source=lambda: api_keys),
+        vault_cipher=VaultCipher(
+            {"local-ephemeral": _secrets.token_bytes(32)},
+            active_key_id="local-ephemeral",
+        ),
+    )
+    app.state.local_mode = True
+    app.state.local_echo_mode = context_factory is None
+    return app
+
+
+__all__ = ["LocalExecutionGateway", "create_local_app"]

--- a/julep/server/local.py
+++ b/julep/server/local.py
@@ -12,6 +12,7 @@ import inspect
 import ipaddress
 import os
 import secrets as _secrets
+import threading
 import time
 import uuid
 from dataclasses import dataclass, replace
@@ -60,6 +61,29 @@ from .auth import ApiKey, KeyRing
 from .settings import ServerSettings
 
 ContextFactory = str | Callable[[], WorkerContext | Any]
+
+
+_PROCESS_STATE_LOCK = threading.Lock()
+_PROCESS_STATE_OWNER: object | None = None
+
+
+def _claim_process_state(owner: object) -> None:
+    """Reserve the process-wide effect and artifact configuration for one app."""
+
+    global _PROCESS_STATE_OWNER
+    with _PROCESS_STATE_LOCK:
+        if _PROCESS_STATE_OWNER is not None:
+            raise RuntimeError(
+                "only one local Julep app lifespan may run in a process at a time"
+            )
+        _PROCESS_STATE_OWNER = owner
+
+
+def _release_process_state(owner: object) -> None:
+    global _PROCESS_STATE_OWNER
+    with _PROCESS_STATE_LOCK:
+        if _PROCESS_STATE_OWNER is owner:
+            _PROCESS_STATE_OWNER = None
 
 
 class _ExecutionProjectionSink(ProjectionSink):
@@ -492,6 +516,8 @@ class LocalExecutionGateway:
         self._previous_context: Optional[WorkerContext] = None
         self._artifact_store_url = artifact_store_url
         self._previous_artifact_store_url: Optional[str] = None
+        self._process_state_owner = object()
+        self._owns_process_state = False
         self._started = False
         self._effects_lock = asyncio.Lock()
         self._runs: dict[str, _LocalRun] = {}
@@ -500,15 +526,17 @@ class LocalExecutionGateway:
     async def start(self) -> None:
         if self._started:
             return
+        _claim_process_state(self._process_state_owner)
+        self._owns_process_state = True
         self._started = True
-        if self._artifact_store_url is not None:
-            self._previous_artifact_store_url = os.environ.get(
-                "JULEP_ARTIFACT_STORE_URL"
-            )
-            os.environ["JULEP_ARTIFACT_STORE_URL"] = self._artifact_store_url
-        if self._context_factory is None:
-            return
         try:
+            if self._artifact_store_url is not None:
+                self._previous_artifact_store_url = os.environ.get(
+                    "JULEP_ARTIFACT_STORE_URL"
+                )
+                os.environ["JULEP_ARTIFACT_STORE_URL"] = self._artifact_store_url
+            if self._context_factory is None:
+                return
             factory: Callable[[], Any]
             if isinstance(self._context_factory, str):
                 from ..execution.serve import load_context_factory
@@ -525,6 +553,11 @@ class LocalExecutionGateway:
             effects.configure(context)
             self._context = context
         except BaseException:
+            self._restore_process_state()
+            raise
+
+    def _restore_process_state(self) -> None:
+        try:
             if self._artifact_store_url is not None:
                 if self._previous_artifact_store_url is None:
                     os.environ.pop("JULEP_ARTIFACT_STORE_URL", None)
@@ -534,11 +567,14 @@ class LocalExecutionGateway:
                     )
             if self._previous_context is not None:
                 effects.configure(self._previous_context)
+        finally:
             self._context = None
             self._previous_context = None
             self._previous_artifact_store_url = None
             self._started = False
-            raise
+            if self._owns_process_state:
+                _release_process_state(self._process_state_owner)
+                self._owns_process_state = False
 
     async def ready(self) -> bool:
         return True
@@ -703,7 +739,13 @@ class LocalExecutionGateway:
         except asyncio.CancelledError:
             status = record.stop_status or "canceled"
             record.status = status
-            self._finalize(record, status=status, result=None, cause=last_event_id)
+            self._finalize(
+                record,
+                status=status,
+                result=None,
+                cause=last_event_id,
+                secrets=secrets,
+            )
             return
         except Exception as exc:  # noqa: BLE001 - persist a terminal local run
             record.status = "failed"
@@ -778,18 +820,45 @@ class LocalExecutionGateway:
             segment_seq=record.segment_seq,
             value_ref=None if captured is None else captured.value_ref,
         )
-        self._store.finalize_run(
-            run_id=record.run_id,
-            workflow_id=record.workflow_id,
-            segment_seq=record.segment_seq,
-            status=status,
-            terminal_event=terminal,
-            result_payload=None if captured is None else captured.payload,
-            result_byte_len=0 if captured is None else captured.byte_len,
-            result_oversize=False if captured is None else captured.oversize,
-            error=None if safe_error is None else str(safe_error),
-            finished_at=time.time(),
-        )
+        try:
+            self._store.finalize_run(
+                run_id=record.run_id,
+                workflow_id=record.workflow_id,
+                segment_seq=record.segment_seq,
+                status=status,
+                terminal_event=terminal,
+                result_payload=None if captured is None else captured.payload,
+                result_byte_len=0 if captured is None else captured.byte_len,
+                result_oversize=False if captured is None else captured.oversize,
+                error=None if safe_error is None else str(safe_error),
+                finished_at=time.time(),
+            )
+        finally:
+            self._scrub_live_projection(record, secrets)
+
+    @staticmethod
+    def _scrub_live_projection(
+        record: _LocalRun,
+        secrets: Optional[Mapping[str, str]],
+    ) -> None:
+        """Retain queryable event metadata without retaining raw interpreter values."""
+
+        raw_projection = record.projection
+        # Fail closed: detach the raw value store before attempting any redaction.
+        record.projection = None
+        if raw_projection is None:
+            return
+        safe_projection = InMemoryProjection()
+        for event in raw_projection.events():
+            candidate = _redact_projection_metadata(event.to_json(), secrets)
+            if candidate.get("attrs") is None:
+                candidate.pop("attrs", None)
+            # The interpreter reference hashes the raw value. Persisted projection
+            # refs are independently derived from the redacted value, so the live
+            # query view must not retain or expose the raw reference.
+            candidate.pop("valueRef", None)
+            safe_projection.append(ProjectionEvent.from_json(candidate))
+        record.projection = safe_projection
 
     async def cancel(self, workflow_id: str) -> None:
         await self._stop(workflow_id, "canceled")
@@ -841,28 +910,20 @@ class LocalExecutionGateway:
         raise ValueError(f"unsupported local query {name!r}")
 
     async def close(self) -> None:
+        if not self._started:
+            return
         tasks: list[asyncio.Task[None]] = []
-        for record in self._runs.values():
-            task = record.task
-            if task is not None and not task.done():
-                record.stop_status = "canceled"
-                task.cancel()
-                tasks.append(task)
-        if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
-        if self._artifact_store_url is not None:
-            if self._previous_artifact_store_url is None:
-                os.environ.pop("JULEP_ARTIFACT_STORE_URL", None)
-            else:
-                os.environ["JULEP_ARTIFACT_STORE_URL"] = (
-                    self._previous_artifact_store_url
-                )
-        if self._previous_context is not None:
-            effects.configure(self._previous_context)
-        self._context = None
-        self._previous_context = None
-        self._previous_artifact_store_url = None
-        self._started = False
+        try:
+            for record in self._runs.values():
+                task = record.task
+                if task is not None and not task.done():
+                    record.stop_status = "canceled"
+                    task.cancel()
+                    tasks.append(task)
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
+        finally:
+            self._restore_process_state()
 
 
 def create_local_app(
@@ -880,6 +941,10 @@ def create_local_app(
     settings = ServerSettings.from_env(env, root=root)
     api_keys = settings.api_keys
     if not api_keys:
+        if context_factory is not None:
+            raise ValueError(
+                "local configured-context execution requires explicitly configured API keys"
+            )
         try:
             loopback = ipaddress.ip_address(host).is_loopback
         except ValueError:

--- a/julep/server/local.py
+++ b/julep/server/local.py
@@ -411,7 +411,7 @@ class _LocalEffectsEnv(InMemoryEnv):
         )
         for alias in set(contracts) | (grants or set()):
             wire = aliases.get(alias, alias)
-            limit = self._max_calls.get(alias, self._max_calls.get(wire))
+            limit = self._max_calls.get(wire)
             if limit is None:
                 continue
             contract = contracts.setdefault(alias, {})
@@ -470,15 +470,19 @@ class _LocalEffectsEnv(InMemoryEnv):
             granted=grants,
             granted_subflows=granted_subflows,
             contracts=contracts,
+            tool_count_keys=aliases,
             tool_schemas=schemas,
             state=AgentState(last=value, call_counts=dict(self.call_counts)),
             get_pure=self.get_pure,
         )
         carried_counts = result.get("callCounts")
         if isinstance(carried_counts, Mapping):
-            self.call_counts.update(
-                {str(tool): int(count) for tool, count in carried_counts.items()}
-            )
+            for tool, raw_count in carried_counts.items():
+                key = str(tool)
+                self.call_counts[key] = max(
+                    self.call_counts.get(key, 0),
+                    int(raw_count),
+                )
         return result
 
     async def human_gate(self, value: Any, cid: str, timeout_s: Optional[int]) -> Any:

--- a/julep/server/routes/runs.py
+++ b/julep/server/routes/runs.py
@@ -27,7 +27,7 @@ from ..auth import ApiKey, merge_principal, owner_scoped, require_client
 from ..sse import EVENT_PAGE_LIMIT, event_sequence, run_event_response
 from ..temporal import TemporalGateway, TemporalStartAmbiguous
 from . import execution_store, require_owned_run, temporal_gateway
-from .releases import load_release, rehydrate_release
+from .releases import load_release, normalize_release_hash, rehydrate_release
 
 router = APIRouter(prefix="/runs", tags=["runs"])
 _RESULT_TERMINAL_STATUSES = TERMINAL_RUN_STATUSES | {"start_failed"}
@@ -144,6 +144,45 @@ def _run_json_response(row: Mapping[str, Any], status_code: int) -> JSONResponse
     return JSONResponse(status_code=status_code, content=dict(row))
 
 
+def _assert_idempotency_retry_matches(
+    existing: Mapping[str, Any],
+    *,
+    pipeline: str,
+    requested_release: Optional[str],
+) -> None:
+    """Reject an idempotency-key collision that is not an execution retry.
+
+    An omitted release deliberately does not participate in the comparison: a
+    retry must remain attached to its original release even if active routing
+    has changed since submission.  An explicit release is normalized before
+    this helper is called so ``<digest>`` and ``sha256:<digest>`` compare equal.
+    """
+
+    if existing.get("pipeline") != pipeline:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "idempotency_conflict",
+                "field": "pipeline",
+                "message": "idempotency key was already used for a different pipeline",
+            },
+        )
+    requested_release_hash = (
+        normalize_release_hash(requested_release)
+        if requested_release is not None
+        else None
+    )
+    if requested_release_hash is not None and existing.get("release_hash") != requested_release_hash:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "idempotency_conflict",
+                "field": "release",
+                "message": "idempotency key was already used for a different release",
+            },
+        )
+
+
 @router.post("")
 async def start_run(
     body: RunRequest,
@@ -198,11 +237,20 @@ async def start_run(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="idempotency key or runId is already in use",
             )
+        if idempotency_key is not None:
+            _assert_idempotency_retry_matches(
+                existing,
+                pipeline=body.pipeline,
+                requested_release=body.release,
+            )
         return _run_json_response(existing, 200)
 
+    requested_release_hash = (
+        normalize_release_hash(body.release) if body.release is not None else None
+    )
     _release_row, release, pipeline = _resolve_pipeline(
         request,
-        body.release,
+        requested_release_hash,
         body.pipeline,
     )
     if body.secrets and pipeline.mcp_preflight_policy is None:
@@ -246,6 +294,15 @@ async def start_run(
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="idempotency key or runId is already in use",
+            )
+        if (
+            idempotency_key is not None
+            and created.get("idempotency_key") == idempotency_key
+        ):
+            _assert_idempotency_retry_matches(
+                created,
+                pipeline=body.pipeline,
+                requested_release=requested_release_hash,
             )
         return _run_json_response(created, 200)
 

--- a/julep/server/routes/runs.py
+++ b/julep/server/routes/runs.py
@@ -144,43 +144,29 @@ def _run_json_response(row: Mapping[str, Any], status_code: int) -> JSONResponse
     return JSONResponse(status_code=status_code, content=dict(row))
 
 
+def _raise_idempotency_conflict(field: Literal["pipeline", "release"]) -> None:
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail={
+            "error": "idempotency_conflict",
+            "field": field,
+            "message": f"idempotency key was already used for a different {field}",
+        },
+    )
+
+
 def _assert_idempotency_retry_matches(
     existing: Mapping[str, Any],
     *,
     pipeline: str,
-    requested_release: Optional[str],
+    requested_release_hash: str,
 ) -> None:
-    """Reject an idempotency-key collision that is not an execution retry.
-
-    An omitted release deliberately does not participate in the comparison: a
-    retry must remain attached to its original release even if active routing
-    has changed since submission.  An explicit release is normalized before
-    this helper is called so ``<digest>`` and ``sha256:<digest>`` compare equal.
-    """
+    """Require the effective pipeline and release to match the original run."""
 
     if existing.get("pipeline") != pipeline:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "error": "idempotency_conflict",
-                "field": "pipeline",
-                "message": "idempotency key was already used for a different pipeline",
-            },
-        )
-    requested_release_hash = (
-        normalize_release_hash(requested_release)
-        if requested_release is not None
-        else None
-    )
-    if requested_release_hash is not None and existing.get("release_hash") != requested_release_hash:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "error": "idempotency_conflict",
-                "field": "release",
-                "message": "idempotency key was already used for a different release",
-            },
-        )
+        _raise_idempotency_conflict("pipeline")
+    if existing.get("release_hash") != requested_release_hash:
+        _raise_idempotency_conflict("release")
 
 
 @router.post("")
@@ -238,10 +224,17 @@ async def start_run(
                 detail="idempotency key or runId is already in use",
             )
         if idempotency_key is not None:
+            if existing.get("pipeline") != body.pipeline:
+                _raise_idempotency_conflict("pipeline")
+            effective_release_hash = (
+                normalize_release_hash(body.release)
+                if body.release is not None
+                else _active_release_for_pipeline(request, body.pipeline)[1].release_hash
+            )
             _assert_idempotency_retry_matches(
                 existing,
                 pipeline=body.pipeline,
-                requested_release=body.release,
+                requested_release_hash=effective_release_hash,
             )
         return _run_json_response(existing, 200)
 
@@ -302,7 +295,7 @@ async def start_run(
             _assert_idempotency_retry_matches(
                 created,
                 pipeline=body.pipeline,
-                requested_release=requested_release_hash,
+                requested_release_hash=release.release_hash,
             )
         return _run_json_response(created, 200)
 

--- a/julep/server/routes/runs.py
+++ b/julep/server/routes/runs.py
@@ -154,6 +154,11 @@ async def start_run(
     if not body.pipeline.strip():
         raise HTTPException(status_code=400, detail="pipeline must be non-empty")
     if body.secrets:
+        if bool(getattr(request.app.state, "local_echo_mode", False)):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="local echo execution does not accept run secrets",
+            )
         settings = request.app.state.settings
         if not settings.payload_encryption_required:
             raise HTTPException(

--- a/julep/turn.py
+++ b/julep/turn.py
@@ -132,6 +132,7 @@ def controller_turn(
     granted: Optional[set[str]],
     granted_subflows: Optional[set[str]],
     contracts: Optional[AgentContractMap],
+    tool_count_keys: Optional[Mapping[str, str]] = None,
     tool_schemas: Optional[Mapping[str, dict[str, Any]]] = None,
     mode: EnforcementMode,
     prod_gap: list[str],
@@ -175,6 +176,11 @@ def controller_turn(
         if error is None:
             return None
         return f"tool {tool!r} input failed frozen JSON-Schema validation: {error}"
+
+    def tool_count_key(tool: str) -> str:
+        if tool_count_keys is None:
+            return tool
+        return tool_count_keys.get(tool, tool)
 
     async def step(state: AgentState) -> StepResult:
         payload: dict[str, Any] = {
@@ -315,12 +321,20 @@ def controller_turn(
                 return state
             for entry in calls:
                 tool = cast(str, entry["tool"])
-                denial = charge_tool_call(state, tool, contracts)
+                count_key = tool_count_key(tool)
+                denial = charge_tool_call(
+                    state,
+                    tool,
+                    contracts,
+                    count_key=count_key,
+                )
                 halt = denial_to_halt(denial)
                 if halt is not None:
                     return halt
                 if denial is not None:
-                    state.call_counts[tool] = state.call_counts.get(tool, 0) + 1
+                    state.call_counts[count_key] = (
+                        state.call_counts.get(count_key, 0) + 1
+                    )
 
             async def execute_entry(index: int, entry: dict[str, Any]) -> CallManyResult:
                 tool = cast(str, entry["tool"])
@@ -402,12 +416,20 @@ def controller_turn(
                 )
                 state.round += 1
                 return state
-            denial = charge_tool_call(state, tool, contracts)
+            count_key = tool_count_key(tool)
+            denial = charge_tool_call(
+                state,
+                tool,
+                contracts,
+                count_key=count_key,
+            )
             halt = denial_to_halt(denial)
             if halt is not None:
                 return halt
             if denial is not None:  # DEV warn-but-allow: still count the call
-                state.call_counts[tool] = state.call_counts.get(tool, 0) + 1
+                state.call_counts[count_key] = (
+                    state.call_counts.get(count_key, 0) + 1
+                )
             error: Optional[str] = None
             try:
                 out = await call_tool(tool, call_input)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 
 [project.optional-dependencies]
 # Durable execution on Temporal (workflows, activities, worker, client helpers).
-temporal = ["temporalio>=1.21", "cryptography>=42"]
+temporal = ["temporalio>=1.20", "cryptography>=42"]
 # Durable execution on DBOS (steps, flow workflow, chaining runner).
 # dbos requires Python >=3.11; the marker keeps the extra resolvable on 3.10,
 # where importing the backend raises a clear ImportError instead.
@@ -54,7 +54,7 @@ server = [
     "uvicorn>=0.30",
     "sse-starlette>=2",
     "psycopg[binary,pool]>=3.2",
-    "temporalio>=1.21",
+    "temporalio>=1.20",
     "cryptography>=42",
     "httpx>=0.24",
 ]
@@ -68,6 +68,9 @@ yglu = ["yglu>=1.0"]
 # any-llm-sdk requires Python >=3.11; on 3.10 the LlmCaller raises a clear
 # ImportError at call time instead (the marker keeps the extra resolvable).
 providers = ["any-llm-sdk>=1.17; python_version >= '3.11'"]
+# Multi-provider LlmCaller for projects already standardized on LiteLLM.
+# The adapter imports LiteLLM lazily; core authoring remains dependency-light.
+litellm = ["litellm>=1.61,<2"]
 # OpenTelemetry span export of the projection.
 otel = ["opentelemetry-api>=1.20", "opentelemetry-sdk>=1.20"]
 # Langfuse OTLP/HTTP export of the projection.
@@ -113,7 +116,7 @@ test-no-temporal = [
 # here (dev) rather than in core; end users pull the slim ``providers`` extra.
 dev = [
     "julep[test-no-temporal]",
-    "temporalio>=1.21",
+    "temporalio>=1.20",
 ]
 
 [project.urls]

--- a/scripts/check_rename_inventory.py
+++ b/scripts/check_rename_inventory.py
@@ -169,6 +169,11 @@ def _is_excluded(relative: Path) -> bool:
     relative_text = relative.as_posix()
     if relative_text in _EXCLUDED_PATHS:
         return True
+    if relative.parts[:2] in {
+        ("docs-site", ".next"),
+        ("docs-site", "out"),
+    }:
+        return True
     if relative.parts[:2] in {("docs", "plans"), ("docs", "superpowers")}:
         return True
     if relative.suffix.casefold() in _BINARY_SUFFIXES:

--- a/tests/cli/test_dev_up.py
+++ b/tests/cli/test_dev_up.py
@@ -177,6 +177,36 @@ def test_run_dev_stack_starts_one_worker_per_queue_and_cleans_up(
     assert all(process.terminated for process in processes)
 
 
+def test_run_dev_stack_surfaces_worker_failure_and_stops_healthy_children(
+    tmp_path: Path,
+) -> None:
+    plan = _plan(tmp_path, start_temporal=False)
+    processes: list[_Process] = []
+
+    def popen(_argv: Any, *, cwd: Path, env: dict[str, str]) -> _Process:
+        assert cwd == tmp_path
+        process = _Process()
+        process.environment = env
+        if env.get("TEMPORAL_TASK_QUEUE") == "summary-rabc":
+            process.returncode = 17
+        processes.append(process)
+        return process
+
+    with pytest.raises(DevStackError, match="worker:summary exited with status 17"):
+        run_dev_stack(
+            plan,
+            popen=popen,
+            publish=lambda _plan: (("summary", "summary-rabc"),),
+            wait_temporal=lambda *_args, **_kwargs: None,
+            wait_api=lambda *_args, **_kwargs: None,
+            poll_interval_s=0,
+        )
+
+    assert len(processes) == 2
+    assert processes[0].terminated  # API is always cleaned up on worker failure.
+    assert not processes[1].terminated  # The failed worker already exited.
+
+
 def _write_project(tmp_path: Path) -> None:
     (tmp_path / "julep.toml").write_text(
         "\n".join(

--- a/tests/cli/test_dev_up.py
+++ b/tests/cli/test_dev_up.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from julep.cli.config import EnvConfig, JulepConfig
+from julep.cli.dev import (
+    DevStackError,
+    build_dev_stack_plan,
+    render_dev_stack_plan,
+    run_dev_stack,
+)
+from julep.cli.keygen import generate_dev_environment
+from julep.cli.main import app
+
+
+def _source_env() -> dict[str, str]:
+    counter = 0
+
+    def random_bytes(_size: int) -> bytes:
+        nonlocal counter
+        counter += 1
+        return bytes([counter]) * 32
+
+    values = generate_dev_environment(random_bytes=random_bytes)
+    values["JULEP_EXECUTION_STORE_DSN"] = "postgresql://localhost/julep"
+    return values
+
+
+def _plan(tmp_path: Path, **kwargs: Any):
+    source = _source_env()
+    cfg = JulepConfig(root=tmp_path, envs={})
+    env = EnvConfig(
+        name="local",
+        release_store=(tmp_path / "artifacts").as_uri(),
+        worker_context_factory="project.worker:context",
+    )
+    return build_dev_stack_plan(
+        cfg,
+        env,
+        api_url="http://127.0.0.1:8600",
+        api_key=source["JULEP_API_KEY"],
+        source_env=source,
+        python="python",
+        **kwargs,
+    )
+
+
+def test_build_dev_stack_plan_wires_shared_contract_and_redacts_key(tmp_path: Path) -> None:
+    source = _source_env()
+    cfg = JulepConfig(root=tmp_path, envs={})
+    env = EnvConfig(
+        name="local",
+        release_store=(tmp_path / "artifacts").as_uri(),
+        worker_context_factory="project.worker:context",
+    )
+    plan = build_dev_stack_plan(
+        cfg,
+        env,
+        api_url="http://127.0.0.1:8600",
+        api_key=source["JULEP_API_KEY"],
+        source_env=source,
+        python="python",
+    )
+    assert plan.temporal is not None
+    assert plan.temporal.argv[-2:] == ("--port", "7233")
+    assert plan.api.environment["JULEP_ARTIFACT_STORE_URL"] == env.release_store
+    assert plan.worker.environment["WORKER_CONTEXT_FACTORY"] == "project.worker:context"
+    assert plan.worker.environment["JULEP_API_URL"] == "http://127.0.0.1:8600"
+    assert plan.worker.environment["JULEP_API_KEY"] == source["JULEP_WORKER_API_KEY"]
+    assert "JULEP_API_KEY" not in plan.api.environment
+    rendered = render_dev_stack_plan(plan)
+    assert "--api-key" not in rendered
+    assert source["JULEP_API_KEY"] not in rendered
+
+
+def test_build_dev_stack_plan_rejects_non_admin_key(tmp_path: Path) -> None:
+    source = _source_env()
+    source["JULEP_API_KEYS"] = "client:" + source["JULEP_API_KEY"] + ":client"
+    cfg = JulepConfig(root=tmp_path, envs={})
+    env = EnvConfig(
+        name="local",
+        release_store=(tmp_path / "artifacts").as_uri(),
+        worker_context_factory="project.worker:context",
+    )
+    with pytest.raises(DevStackError, match="admin"):
+        build_dev_stack_plan(
+            cfg,
+            env,
+            api_url="http://127.0.0.1:8600",
+            api_key=source["JULEP_API_KEY"],
+            source_env=source,
+        )
+
+
+def test_build_dev_stack_plan_rejects_non_worker_vault_key(tmp_path: Path) -> None:
+    source = _source_env()
+    source["JULEP_WORKER_API_KEY"] = source["JULEP_API_KEY"]
+    cfg = JulepConfig(root=tmp_path, envs={})
+    env = EnvConfig(
+        name="local",
+        release_store=(tmp_path / "artifacts").as_uri(),
+        worker_context_factory="project.worker:context",
+    )
+    with pytest.raises(DevStackError, match="worker entry"):
+        build_dev_stack_plan(
+            cfg,
+            env,
+            api_url="http://127.0.0.1:8600",
+            api_key=source["JULEP_API_KEY"],
+            source_env=source,
+        )
+
+
+class _Process:
+    def __init__(self) -> None:
+        self.returncode: int | None = None
+        self.environment: dict[str, str] = {}
+        self.terminated = False
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self.returncode = 0
+
+    def kill(self) -> None:
+        self.returncode = -9
+
+    def wait(self, timeout: float | None = None) -> int:
+        return self.returncode or 0
+
+
+def test_run_dev_stack_starts_one_worker_per_queue_and_cleans_up(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = _plan(tmp_path, start_temporal=False)
+    processes: list[_Process] = []
+
+    def popen(_argv: Any, *, cwd: Path, env: dict[str, str]) -> _Process:
+        assert cwd == tmp_path
+        process = _Process()
+        process.environment = env
+        processes.append(process)
+        return process
+
+    calls = 0
+
+    def sleep(_seconds: float) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr("julep.cli.dev.time.sleep", sleep)
+    run_dev_stack(
+        plan,
+        popen=popen,
+        publish=lambda _plan: (
+            ("summary", "summary-rabc"),
+            ("write", "write-rabc"),
+        ),
+        wait_temporal=lambda *_args, **_kwargs: None,
+        wait_api=lambda *_args, **_kwargs: None,
+    )
+    assert len(processes) == 3  # API + one worker for each lane.
+    assert [process.environment.get("TEMPORAL_TASK_QUEUE") for process in processes] == [
+        None,
+        "summary-rabc",
+        "write-rabc",
+    ]
+    assert all(process.terminated for process in processes)
+
+
+def _write_project(tmp_path: Path) -> None:
+    (tmp_path / "julep.toml").write_text(
+        "\n".join(
+            (
+                "[env.local]",
+                f'release_store = "{(tmp_path / "artifacts").as_uri()}"',
+                'worker_context_factory = "project.worker:context"',
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_dev_up_cli_dry_run_uses_generated_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_project(tmp_path)
+    source = _source_env()
+    source["JULEP_EXECUTION_STORE_DSN"] = "postgresql://localhost/julep"
+    for name, value in source.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(app, ["dev", "up", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "temporal server start-dev" in result.output
+    assert "serve api --migrate" in result.output
+    assert "publish  env=local" in result.output
+    assert "one per published queue" in result.output
+    assert source["JULEP_API_KEY"] not in result.output
+
+
+def test_dev_up_cli_runs_validated_plan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_project(tmp_path)
+    source = _source_env()
+    source["JULEP_EXECUTION_STORE_DSN"] = "postgresql://localhost/julep"
+    for name, value in source.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.chdir(tmp_path)
+    captured: list[Any] = []
+    monkeypatch.setattr("julep.cli.dev.run_dev_stack", captured.append)
+
+    result = CliRunner().invoke(
+        app,
+        ["dev", "up", "--no-start-temporal", "--no-publish", "--no-worker"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(captured) == 1
+    assert captured[0].temporal is None
+    assert captured[0].publish_release is False
+    assert captured[0].start_workers is False

--- a/tests/cli/test_dev_up.py
+++ b/tests/cli/test_dev_up.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import signal
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -85,6 +87,71 @@ def test_build_dev_stack_plan_wires_shared_contract_and_redacts_key(tmp_path: Pa
     rendered = render_dev_stack_plan(plan)
     assert "--api-key" not in rendered
     assert source["JULEP_API_KEY"] not in rendered
+
+
+def test_build_dev_stack_plan_partitions_child_environments_by_role(
+    tmp_path: Path,
+) -> None:
+    source = _source_env()
+    source.update({"PATH": "/bin", "AMBIENT_PROVIDER_SECRET": "do-not-propagate"})
+    cfg = JulepConfig(root=tmp_path, envs={})
+    env = EnvConfig(
+        name="local",
+        release_store=(tmp_path / "artifacts").as_uri(),
+        worker_context_factory="project.worker:context",
+        worker_environment={
+            "WORKER_PROVIDER_SECRET": "worker-only",
+            "JULEP_API_KEYS": "must-not-override",
+        },
+    )
+
+    plan = build_dev_stack_plan(
+        cfg,
+        env,
+        api_url="http://127.0.0.1:8600",
+        api_key=source["JULEP_API_KEY"],
+        source_env=source,
+        python="python",
+    )
+
+    assert plan.temporal is not None
+    environments = {
+        "api": plan.api.environment,
+        "worker": plan.worker.environment,
+        "publisher": plan.publication_environment,
+        "temporal": plan.temporal.environment,
+    }
+    assert all(environment.get("PATH") == "/bin" for environment in environments.values())
+    assert all(
+        "AMBIENT_PROVIDER_SECRET" not in environment
+        for environment in environments.values()
+    )
+    assert environments["worker"]["WORKER_PROVIDER_SECRET"] == "worker-only"
+    assert all(
+        "WORKER_PROVIDER_SECRET" not in environment
+        for role, environment in environments.items()
+        if role != "worker"
+    )
+    assert "JULEP_API_KEYS" in environments["api"]
+    assert all(
+        "JULEP_API_KEYS" not in environment
+        for role, environment in environments.items()
+        if role != "api"
+    )
+    assert "JULEP_EXECUTION_STORE_DSN" in environments["api"]
+    assert "JULEP_EXECUTION_STORE_DSN" in environments["worker"]
+    assert "JULEP_EXECUTION_STORE_DSN" not in environments["publisher"]
+    assert "JULEP_EXECUTION_STORE_DSN" not in environments["temporal"]
+    assert "JULEP_BUNDLE_SIGNING_KEY" in environments["publisher"]
+    assert all(
+        "JULEP_BUNDLE_SIGNING_KEY" not in environment
+        for role, environment in environments.items()
+        if role != "publisher"
+    )
+    assert "TEMPORAL_PAYLOAD_KEYS" in environments["api"]
+    assert "TEMPORAL_PAYLOAD_KEYS" in environments["worker"]
+    assert "TEMPORAL_PAYLOAD_KEYS" not in environments["publisher"]
+    assert "TEMPORAL_PAYLOAD_KEYS" not in environments["temporal"]
 
 
 def test_build_dev_stack_plan_rejects_non_admin_key(tmp_path: Path) -> None:
@@ -215,6 +282,99 @@ def test_run_dev_stack_surfaces_worker_failure_and_stops_healthy_children(
     assert len(processes) == 2
     assert processes[0].terminated  # API is always cleaned up on worker failure.
     assert not processes[1].terminated  # The failed worker already exited.
+
+
+def test_run_dev_stack_sigterm_unwinds_and_cleans_children(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = _plan(tmp_path, start_temporal=False)
+    processes: list[_Process] = []
+
+    def popen(_argv: Any, *, cwd: Path, env: dict[str, str]) -> _Process:
+        assert cwd == tmp_path
+        process = _Process()
+        process.environment = env
+        processes.append(process)
+        return process
+
+    def terminate_process(_seconds: float) -> None:
+        signal.raise_signal(signal.SIGTERM)
+
+    monkeypatch.setattr("julep.cli.dev.time.sleep", terminate_process)
+
+    run_dev_stack(
+        plan,
+        popen=popen,
+        publish=lambda _plan: (("summary", "summary-rabc"),),
+        wait_temporal=lambda *_args, **_kwargs: None,
+        wait_api=lambda *_args, **_kwargs: None,
+    )
+
+    assert len(processes) == 2
+    assert all(process.terminated for process in processes)
+
+
+def test_run_dev_stack_cleanup_continues_after_one_child_raises(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = _plan(tmp_path, start_temporal=False)
+
+    class BrokenTerminate(_Process):
+        def terminate(self) -> None:
+            raise OSError("cannot terminate")
+
+        def wait(self, timeout: float | None = None) -> int:
+            raise subprocess.TimeoutExpired("api", timeout or 0)
+
+    processes: list[_Process] = []
+
+    def popen(_argv: Any, *, cwd: Path, env: dict[str, str]) -> _Process:
+        assert cwd == tmp_path
+        process: _Process = BrokenTerminate() if not processes else _Process()
+        process.environment = env
+        processes.append(process)
+        return process
+
+    def interrupt(_seconds: float) -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("julep.cli.dev.time.sleep", interrupt)
+
+    run_dev_stack(
+        plan,
+        popen=popen,
+        publish=lambda _plan: (("summary", "summary-rabc"),),
+        wait_temporal=lambda *_args, **_kwargs: None,
+        wait_api=lambda *_args, **_kwargs: None,
+    )
+
+    assert processes[0].returncode == -9
+    assert processes[1].terminated
+
+
+def test_run_dev_stack_reports_zero_workers_when_disabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    plan = _plan(tmp_path, start_temporal=False, start_workers=False)
+
+    def interrupt(_seconds: float) -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("julep.cli.dev.time.sleep", interrupt)
+
+    run_dev_stack(
+        plan,
+        popen=lambda *_args, **_kwargs: _Process(),
+        publish=lambda _plan: (("summary", "summary-rabc"),),
+        wait_temporal=lambda *_args, **_kwargs: None,
+        wait_api=lambda *_args, **_kwargs: None,
+    )
+
+    assert "(0 workers)" in capsys.readouterr().out
 
 
 def _write_project(tmp_path: Path) -> None:

--- a/tests/cli/test_dev_up.py
+++ b/tests/cli/test_dev_up.py
@@ -72,6 +72,16 @@ def test_build_dev_stack_plan_wires_shared_contract_and_redacts_key(tmp_path: Pa
     assert plan.worker.environment["JULEP_API_URL"] == "http://127.0.0.1:8600"
     assert plan.worker.environment["JULEP_API_KEY"] == source["JULEP_WORKER_API_KEY"]
     assert "JULEP_API_KEY" not in plan.api.environment
+    assert "JULEP_API_KEYS" not in plan.worker.environment
+    assert "JULEP_VAULT_KEYS" not in plan.worker.environment
+    assert "JULEP_BUNDLE_SIGNING_KEY" not in plan.worker.environment
+    assert "JULEP_BUNDLE_SIGNING_KEY" not in plan.api.environment
+    assert (
+        plan.publication_environment["JULEP_BUNDLE_SIGNING_KEY"]
+        == source["JULEP_BUNDLE_SIGNING_KEY"]
+    )
+    assert plan.temporal is not None
+    assert "TEMPORAL_PAYLOAD_KEYS" not in plan.temporal.environment
     rendered = render_dev_stack_plan(plan)
     assert "--api-key" not in rendered
     assert source["JULEP_API_KEY"] not in rendered

--- a/tests/cli/test_dev_up.py
+++ b/tests/cli/test_dev_up.py
@@ -8,15 +8,20 @@ from typing import Any
 import pytest
 from typer.testing import CliRunner
 
-from julep.cli.config import EnvConfig, JulepConfig
-from julep.cli.dev import (
+from julep import HAVE_TEMPORAL
+
+if not HAVE_TEMPORAL:
+    pytest.skip("temporalio not installed", allow_module_level=True)
+
+from julep.cli.config import EnvConfig, JulepConfig  # noqa: E402
+from julep.cli.dev import (  # noqa: E402
     DevStackError,
     build_dev_stack_plan,
     render_dev_stack_plan,
     run_dev_stack,
 )
-from julep.cli.keygen import generate_dev_environment
-from julep.cli.main import app
+from julep.cli.keygen import generate_dev_environment  # noqa: E402
+from julep.cli.main import app  # noqa: E402
 
 
 def _source_env() -> dict[str, str]:

--- a/tests/cli/test_keygen.py
+++ b/tests/cli/test_keygen.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+import pytest
+from typer.testing import CliRunner
+
+from julep.bundle import bundle_signer_public_key
+from julep.cli.main import app
+from julep.cli.keygen import generate_dev_environment, render_dev_environment
+from julep.execution.codec import parse_aes_gcm_keyring
+from julep.secrets import parse_vault_keyring
+
+
+def _deterministic_bytes() -> Callable[[int], bytes]:
+    values = iter((b"p" * 32, b"v" * 32, b"s" * 32, b"a" * 32, b"w" * 32))
+
+    def generate(size: int) -> bytes:
+        assert size == 32
+        return next(values)
+
+    return generate
+
+
+def test_generate_dev_environment_is_ready_for_api_and_worker() -> None:
+    values = generate_dev_environment(random_bytes=_deterministic_bytes())
+    payload = parse_aes_gcm_keyring(values["TEMPORAL_PAYLOAD_KEYS"])
+    vault = parse_vault_keyring(values["JULEP_VAULT_KEYS"])
+    assert payload == {"dev": "70" * 32}
+    assert vault == {"dev": b"v" * 32}
+    assert set(payload.values()).isdisjoint(value.hex() for value in vault.values())
+    assert values["JULEP_BUNDLE_ALLOWED_SIGNERS"] == bundle_signer_public_key(
+        values["JULEP_BUNDLE_SIGNING_KEY"]
+    )
+    admin, worker = values["JULEP_API_KEYS"].split(",")
+    assert admin.split(":", 2) == [
+        "local-admin",
+        values["JULEP_API_KEY"],
+        "admin",
+    ]
+    assert worker.split(":", 2) == [
+        "local-worker",
+        values["JULEP_WORKER_API_KEY"],
+        "worker",
+    ]
+
+
+def test_render_dev_environment_supports_shell_and_json() -> None:
+    values = {"A": "plain", "B": "has spaces"}
+    assert render_dev_environment(values) == "export A=plain\nexport B='has spaces'\n"
+    assert json.loads(render_dev_environment(values, format="json")) == values
+    with pytest.raises(ValueError, match="env.*json"):
+        render_dev_environment(values, format="yaml")
+
+
+def test_generate_dev_environment_rejects_reused_random_material() -> None:
+    with pytest.raises(ValueError, match="distinct"):
+        generate_dev_environment(random_bytes=lambda _size: b"x" * 32)
+
+
+def test_keygen_cli_prints_json_without_persisting(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(app, ["keygen", "--format", "json"])
+    assert result.exit_code == 0, result.output
+    values = json.loads(result.output)
+    assert values["JULEP_API_KEY"]
+    assert values["JULEP_WORKER_API_KEY"]
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_keygen_cli_writes_private_file_and_refuses_implicit_overwrite(
+    tmp_path,
+) -> None:
+    destination = tmp_path / "julep.env"
+    runner = CliRunner()
+    first = runner.invoke(app, ["keygen", "--output", str(destination)])
+    assert first.exit_code == 0, first.output
+    assert destination.stat().st_mode & 0o777 == 0o600
+    original = destination.read_text(encoding="utf-8")
+
+    second = runner.invoke(app, ["keygen", "--output", str(destination)])
+    assert second.exit_code == 2
+    assert "already exists" in second.output
+    assert destination.read_text(encoding="utf-8") == original
+
+    forced = runner.invoke(
+        app,
+        ["keygen", "--output", str(destination), "--force"],
+    )
+    assert forced.exit_code == 0, forced.output
+    assert destination.read_text(encoding="utf-8") != original

--- a/tests/cli/test_keygen.py
+++ b/tests/cli/test_keygen.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
 from collections.abc import Callable
+from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
@@ -90,3 +92,29 @@ def test_keygen_cli_writes_private_file_and_refuses_implicit_overwrite(
     )
     assert forced.exit_code == 0, forced.output
     assert destination.read_text(encoding="utf-8") != original
+
+
+def test_keygen_force_replaces_from_already_private_temporary_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "julep.env"
+    destination.write_text("old", encoding="utf-8")
+    destination.chmod(0o666)
+    real_replace = os.replace
+    source_modes: list[int] = []
+
+    def checked_replace(source: str | Path, target: str | Path) -> None:
+        source_modes.append(Path(source).stat().st_mode & 0o777)
+        real_replace(source, target)
+
+    monkeypatch.setattr("julep.cli.keygen.os.replace", checked_replace)
+
+    result = CliRunner().invoke(
+        app,
+        ["keygen", "--output", str(destination), "--force"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert source_modes == [0o600]
+    assert destination.stat().st_mode & 0o777 == 0o600

--- a/tests/cli/test_keygen.py
+++ b/tests/cli/test_keygen.py
@@ -11,7 +11,6 @@ from typer.testing import CliRunner
 from julep.bundle import bundle_signer_public_key
 from julep.cli.main import app
 from julep.cli.keygen import generate_dev_environment, render_dev_environment
-from julep.execution.codec import parse_aes_gcm_keyring
 from julep.secrets import parse_vault_keyring
 
 
@@ -27,7 +26,8 @@ def _deterministic_bytes() -> Callable[[int], bytes]:
 
 def test_generate_dev_environment_is_ready_for_api_and_worker() -> None:
     values = generate_dev_environment(random_bytes=_deterministic_bytes())
-    payload = parse_aes_gcm_keyring(values["TEMPORAL_PAYLOAD_KEYS"])
+    payload_key_id, payload_key = values["TEMPORAL_PAYLOAD_KEYS"].split("=", 1)
+    payload = {payload_key_id: payload_key}
     vault = parse_vault_keyring(values["JULEP_VAULT_KEYS"])
     assert payload == {"dev": "70" * 32}
     assert vault == {"dev": b"v" * 32}

--- a/tests/cli/test_lint.py
+++ b/tests/cli/test_lint.py
@@ -8,6 +8,7 @@ from julep.cli.config import load_config
 from julep.cli.lint import lint_agents
 from julep.cli.main import main
 from julep.dotctx import MissingOutputSchemaWarning, load_dotctx
+from julep.registry import DEFAULT_REGISTRY
 
 
 def test_lint_clean_module_passes(sample_module):
@@ -90,6 +91,11 @@ def test_ctx_pipeline_lint_is_offline_and_has_no_deployment_side_effects(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     _write_ctx_pipeline(tmp_path, output_schema=True, tools=True)
+    registry_state = {
+        "reasoners": dict(DEFAULT_REGISTRY.reasoners),
+        "renderers": dict(DEFAULT_REGISTRY.renderers),
+        "tool_expectations": dict(DEFAULT_REGISTRY.tool_expectations),
+    }
 
     def forbidden(*args: object, **kwargs: object) -> object:
         raise AssertionError("lint attempted a network or deployment side effect")
@@ -101,6 +107,9 @@ def test_ctx_pipeline_lint_is_offline_and_has_no_deployment_side_effects(
     assert main(["lint"]) == 0
     assert capsys.readouterr().out.strip() == "clean"
     assert not (tmp_path / ".julep").exists()
+    assert DEFAULT_REGISTRY.reasoners == registry_state["reasoners"]
+    assert DEFAULT_REGISTRY.renderers == registry_state["renderers"]
+    assert DEFAULT_REGISTRY.tool_expectations == registry_state["tool_expectations"]
 
 
 def test_ctx_pipeline_load_failure_is_actionable_exit_two(
@@ -119,3 +128,57 @@ def test_ctx_pipeline_load_failure_is_actionable_exit_two(
     assert "ERROR" in output
     assert "broken: CTX_LOAD" in output
     assert "dotctx path does not exist" in output
+
+
+def test_ctx_pipeline_lint_preserves_cross_pipeline_registration_conflicts(
+    tmp_path: Path,
+) -> None:
+    for pipeline, model in (("one", "openai/gpt-one"), ("two", "openai/gpt-two")):
+        package = tmp_path / f"{pipeline}.ctx"
+        package.mkdir()
+        (package / "settings.yaml").write_text(
+            f'name: "shared-reasoner"\nmodel: "{model}"\n',
+            encoding="utf-8",
+        )
+        (package / "prompt.j2").write_text("Summarize {{ text }}.\n", encoding="utf-8")
+        (package / "schema.pyi").write_text(
+            "class Input:\n    text: str\n\nclass Output:\n    summary: str\n",
+            encoding="utf-8",
+        )
+    (tmp_path / "julep.toml").write_text(
+        '[pipeline.one]\nctx = "one.ctx"\n'
+        '[pipeline.two]\nctx = "two.ctx"\n',
+        encoding="utf-8",
+    )
+
+    findings, exit_code = lint_agents(
+        load_config(tmp_path),
+        ["one", "two"],
+        fail_severity="error",
+    )
+
+    assert exit_code == 2
+    assert [(finding.agent, finding.code) for finding in findings] == [("two", "CTX_LOAD")]
+    assert "already registered" in findings[0].message
+
+
+def test_lint_cli_merges_worker_environment_into_ctx_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "julep.toml").write_text(
+        '[env.local.vars]\nSHARED = "vars"\nONLY_VARS = "yes"\n'
+        '[env.local.worker_environment]\nSHARED = "worker"\nONLY_WORKER = "yes"\n',
+        encoding="utf-8",
+    )
+    captured: dict[str, str] = {}
+
+    def fake_lint_agents(*args: object, **kwargs: object) -> tuple[list[object], int]:
+        captured.update(kwargs["env_vars"])  # type: ignore[arg-type]
+        return [], 0
+
+    monkeypatch.setattr(import_module("julep.cli.main"), "lint_agents", fake_lint_agents)
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["lint"]) == 0
+    assert captured == {"SHARED": "worker", "ONLY_VARS": "yes", "ONLY_WORKER": "yes"}

--- a/tests/cli/test_lint.py
+++ b/tests/cli/test_lint.py
@@ -1,6 +1,13 @@
 # tests/cli/test_lint.py
+from importlib import import_module
+from pathlib import Path
+
+import pytest
+
 from julep.cli.config import load_config
 from julep.cli.lint import lint_agents
+from julep.cli.main import main
+from julep.dotctx import MissingOutputSchemaWarning, load_dotctx
 
 
 def test_lint_clean_module_passes(sample_module):
@@ -14,3 +21,101 @@ def test_fail_severity_threshold_gates(sample_module):
     # With an impossibly strict floor, any warning would gate; clean module still 0.
     _, exit_code = lint_agents(cfg, ["triage"], fail_severity="warning")
     assert exit_code in (0, 1)
+
+
+def _write_ctx_pipeline(
+    root: Path,
+    *,
+    output_schema: bool,
+    tools: bool = False,
+) -> Path:
+    package = root / "prompts" / "summary.ctx"
+    package.mkdir(parents=True)
+    (package / "settings.yaml").write_text(
+        f'name: "{root.name}.summary"\nmodel: "openai/gpt-test"\n',
+        encoding="utf-8",
+    )
+    (package / "prompt.j2").write_text("Summarize {{ text }}.\n", encoding="utf-8")
+    schema = "class Input:\n    text: str\n"
+    if output_schema:
+        schema += "\nclass Output:\n    summary: str\n"
+    (package / "schema.pyi").write_text(schema, encoding="utf-8")
+    if tools:
+        (package / "tools.pyi").write_text(
+            "def lookup(query: str) -> list[dict]: ...\n",
+            encoding="utf-8",
+        )
+
+    config = '[pipeline.summary]\nctx = "prompts/summary.ctx"\n'
+    if tools:
+        config += (
+            "\n[pipeline.summary.tools]\n"
+            'lookup = "memory:lookup"\n'
+            "\n[mcp.servers.memory]\n"
+            'url = "https://mcp.example.test"\n'
+        )
+    (root / "julep.toml").write_text(config, encoding="utf-8")
+    return package
+
+
+def test_load_dotctx_warns_when_output_schema_is_missing(tmp_path: Path) -> None:
+    package = _write_ctx_pipeline(tmp_path, output_schema=False)
+
+    with pytest.warns(MissingOutputSchemaWarning, match=r"class Output.*not be schema-validated"):
+        reasoner = load_dotctx(str(package))
+
+    assert reasoner.reply_schema is None
+
+
+def test_lint_includes_configured_ctx_pipeline_and_warning_obeys_gate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_ctx_pipeline(tmp_path, output_schema=False)
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["lint"]) == 0
+    output = capsys.readouterr().out
+    assert "WARNING summary: CTX_OUTPUT_SCHEMA_MISSING" in output
+    assert "class Output" in output
+
+    assert main(["lint", "summary", "--fail-severity", "warning"]) == 1
+    assert "CTX_OUTPUT_SCHEMA_MISSING" in capsys.readouterr().out
+
+
+def test_ctx_pipeline_lint_is_offline_and_has_no_deployment_side_effects(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_ctx_pipeline(tmp_path, output_schema=True, tools=True)
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        raise AssertionError("lint attempted a network or deployment side effect")
+
+    monkeypatch.setattr("julep.mcp_snapshot.snapshot_servers", forbidden)
+    monkeypatch.setattr(import_module("julep.deploy"), "deploy", forbidden)
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["lint"]) == 0
+    assert capsys.readouterr().out.strip() == "clean"
+    assert not (tmp_path / ".julep").exists()
+
+
+def test_ctx_pipeline_load_failure_is_actionable_exit_two(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    (tmp_path / "julep.toml").write_text(
+        '[pipeline.broken]\nctx = "missing.ctx"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["lint"]) == 2
+    output = capsys.readouterr().out
+    assert "ERROR" in output
+    assert "broken: CTX_LOAD" in output
+    assert "dotctx path does not exist" in output

--- a/tests/cli/test_remote_cli.py
+++ b/tests/cli/test_remote_cli.py
@@ -30,7 +30,11 @@ def _event(run_id: str, event_id: str, event_type: str) -> dict[str, object]:
         "shape": None,
         "cost": None,
         "error": None,
-        "attrs": {"terminal": True} if event_type == "Did" else {},
+        "attrs": (
+            {"terminal": True, "llm.model": "openai/gpt-test"}
+            if event_type == "Did"
+            else {}
+        ),
     }
 
 
@@ -69,7 +73,10 @@ def test_remote_status_and_trace(
         assert "completed" in status_output
 
         assert main(["trace", "--remote", run_id]) == 0
-        assert "root" in capsys.readouterr().out
+        trace_output = capsys.readouterr().out
+        assert "root" in trace_output
+        assert "cost=unknown" in trace_output
+        assert "$2.0000" not in trace_output
 
 
 def test_remote_status_requires_api_url(

--- a/tests/cli/test_server_cmd.py
+++ b/tests/cli/test_server_cmd.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import importlib
 import subprocess
 import sys
+from pathlib import Path
 from typing import Any
 
-from julep.cli.main import db_reencrypt_secrets, serve_api
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from julep.cli.main import app, db_reencrypt_secrets, serve_api
 from julep.server.settings import ServerSettings
 
 
@@ -32,7 +38,7 @@ def test_serve_api_applies_overrides_and_optional_migration(monkeypatch) -> None
 
     monkeypatch.setattr(
         "julep.server.settings.ServerSettings.from_env",
-        lambda: settings,
+        lambda *_args: settings,
     )
     monkeypatch.setattr(
         "julep.server.settings.ServerSettings.build_store",
@@ -47,7 +53,13 @@ def test_serve_api_applies_overrides_and_optional_migration(monkeypatch) -> None
         lambda app, *, host, port: captured.update(app=app, host=host, port=port),
     )
 
-    serve_api(host="0.0.0.0", port=9090, migrate=True)
+    serve_api(
+        host="0.0.0.0",
+        port=9090,
+        migrate=True,
+        local=False,
+        context_factory=None,
+    )
 
     assert store.migrated is True
     assert store.closed is True
@@ -56,6 +68,109 @@ def test_serve_api_applies_overrides_and_optional_migration(monkeypatch) -> None
     assert captured["app"] is api
     assert captured["host"] == "0.0.0.0"
     assert captured["port"] == 9090
+
+
+def test_serve_api_local_builds_zero_daemon_app(monkeypatch, tmp_path) -> None:
+    settings = ServerSettings(host="127.0.0.1", port=8080)
+    captured: dict[str, Any] = {}
+    api = object()
+    factory = object()
+
+    def fake_create_local_app(*, project_root: Path, host: str, context_factory: object) -> object:
+        captured.update(
+            project_root=project_root,
+            local_host=host,
+            context_factory=context_factory,
+        )
+        return api
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "julep.server.settings.ServerSettings.from_env",
+        lambda *_args: settings,
+    )
+    serve_module = importlib.import_module("julep.execution.serve")
+    monkeypatch.setattr(
+        serve_module,
+        "load_context_factory",
+        lambda spec: factory if spec == "example:make_context" else None,
+    )
+    monkeypatch.setattr(
+        "julep.server.create_local_app",
+        fake_create_local_app,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "uvicorn.run",
+        lambda app, *, host, port: captured.update(app=app, host=host, port=port),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "serve",
+            "api",
+            "--local",
+            "--host",
+            "127.0.0.2",
+            "--port",
+            "9091",
+            "--context-factory",
+            "example:make_context",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured == {
+        "project_root": tmp_path,
+        "local_host": "127.0.0.2",
+        "context_factory": factory,
+        "app": api,
+        "host": "127.0.0.2",
+        "port": 9091,
+    }
+
+
+def test_serve_api_local_rejects_migration(monkeypatch, capsys) -> None:
+    called = False
+
+    def fake_create_local_app(**_kwargs) -> object:
+        nonlocal called
+        called = True
+        return object()
+
+    monkeypatch.setattr(
+        "julep.server.create_local_app",
+        fake_create_local_app,
+        raising=False,
+    )
+
+    with pytest.raises(typer.Exit) as exc_info:
+        serve_api(
+            host=None,
+            port=None,
+            migrate=True,
+            local=True,
+            context_factory=None,
+        )
+
+    assert exc_info.value.exit_code == 2
+    assert called is False
+    assert "--migrate cannot be used with --local" in capsys.readouterr().err
+
+
+def test_serve_api_context_factory_requires_local(capsys) -> None:
+    with pytest.raises(typer.Exit) as exc_info:
+        serve_api(
+            host=None,
+            port=None,
+            migrate=False,
+            local=False,
+            context_factory="example:make_context",
+        )
+
+    assert exc_info.value.exit_code == 2
+    assert "--context-factory requires --local" in capsys.readouterr().err
 
 
 def test_core_and_cli_import_without_loading_server_dependencies() -> None:

--- a/tests/cli/test_tracetree.py
+++ b/tests/cli/test_tracetree.py
@@ -13,3 +13,37 @@ def test_renders_parent_child(capsys):
     assert "n0" in tree and "n1" in tree
     assert "└─" in tree or "├─" in tree   # box-drawing tree structure
     assert "ok" in tree                    # status rendered
+
+
+def test_generation_without_reported_cost_renders_unknown():
+    projection = InMemoryProjection()
+    emitter = ProjectionEmitter(projection)
+    planned = emitter.plan("think", "c0")
+    emitter.did(
+        "think",
+        "c0",
+        value="answer",
+        causes=[planned],
+        attrs={"llm.model": "openai/gpt-test", "llm.usage": {"total": 4}},
+    )
+
+    tree = render_tree(projection.events())
+
+    assert "cost=unknown" in tree
+    assert "$2.0000" not in tree
+
+
+def test_generation_preserves_real_zero_cost():
+    projection = InMemoryProjection()
+    emitter = ProjectionEmitter(projection)
+    planned = emitter.plan("think", "c0")
+    emitter.did(
+        "think",
+        "c0",
+        value="answer",
+        cost=0.0,
+        causes=[planned],
+        attrs={"llm.model": "local/free"},
+    )
+
+    assert "$0.0000" in render_tree(projection.events())

--- a/tests/invariants/test_rename_inventory.py
+++ b/tests/invariants/test_rename_inventory.py
@@ -4,8 +4,16 @@ import subprocess
 import sys
 from pathlib import Path
 
+from scripts.check_rename_inventory import _is_excluded
+
 
 ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_generated_docs_output_is_not_scanned() -> None:
+    assert _is_excluded(Path("docs-site/.next/server/page.rsc"))
+    assert _is_excluded(Path("docs-site/out/docs/page.txt"))
+    assert not _is_excluded(Path("docs-site/content/docs/page.md"))
 
 
 def test_retired_names_do_not_reenter_the_tree() -> None:

--- a/tests/invariants/test_tool_decorator.py
+++ b/tests/invariants/test_tool_decorator.py
@@ -16,6 +16,11 @@ from julep import (
     validate,
 )
 from julep.derived import check_race_admission
+from julep.registry import (
+    DEFAULT_REGISTRY,
+    ToolSchemaExpectation,
+    scoped_tool_expectation_key,
+)
 
 
 def test_tool_contract_mapping() -> None:
@@ -92,6 +97,30 @@ def test_tool_snapshot_freezes_native_and_race_validates_clean() -> None:
     race_frozen = freeze(race(call(native("web_search")), call(native("lookup"))), snap)
     assert not blocking(validate(race_frozen.flow, race_frozen.manifest))
     assert not blocking(check_race_admission(race_frozen.flow, race_frozen.manifest))
+
+
+def test_scoped_dotctx_expectation_does_not_bind_unrelated_native_tool() -> None:
+    name = "scoped_expectation_native_collision"
+    scope = "scoped-expectation-controller"
+    scoped_key = scoped_tool_expectation_key(scope, name)
+    expectation = ToolSchemaExpectation(
+        key=name,
+        input_schema={"type": "object", "required": ["query"]},
+        ctx_path="scoped.ctx",
+    )
+    DEFAULT_REGISTRY.register_tool_expectation(expectation, scope=scope)
+
+    @tool(effect="read", idempotent=True, name=name)
+    def native_collision(value: str) -> str:
+        return value
+
+    try:
+        frozen = freeze(call(native(name)), snapshot_from_tools([native_collision]))
+        assert len(frozen.manifest) == 1
+    finally:
+        DEFAULT_REGISTRY.tool_expectations.pop(scoped_key, None)
+        DEFAULT_REGISTRY.tool_expectations.pop(name, None)
+        DEFAULT_REGISTRY.scoped_tool_fallbacks.discard(name)
 
 
 def test_tool_name_override() -> None:

--- a/tests/server/test_client.py
+++ b/tests/server/test_client.py
@@ -7,6 +7,7 @@ import httpx
 import pytest
 from starlette.testclient import TestClient
 
+import julep.server as server
 from julep.client import (
     AsyncJulepClient,
     JulepClient,
@@ -86,6 +87,21 @@ def test_start_run_requires_idempotency_or_run_id() -> None:
     client = JulepClient(client=TestClient(lambda scope, receive, send: None))
     with pytest.raises(ValueError, match="idempotency_key or run_id"):
         client.start_run(pipeline="summary")
+
+
+def test_async_client_keeps_the_sync_public_method_surface() -> None:
+    sync_methods = {
+        name
+        for name, value in vars(JulepClient).items()
+        if not name.startswith("_") and callable(value)
+    }
+    async_methods = {
+        name
+        for name, value in vars(AsyncJulepClient).items()
+        if not name.startswith("_") and callable(value)
+    }
+
+    assert async_methods - {"aclose"} == sync_methods
 
 
 def test_publish_release_registers_manifest_as_admin(server_factory) -> None:
@@ -193,6 +209,45 @@ def test_sync_start_and_wait_raises_typed_terminal_error() -> None:
     assert caught.value.error == "provider unavailable"
 
 
+@pytest.mark.parametrize(
+    ("status", "terminal_detail"),
+    [
+        ("canceled", None),
+        ("terminated", {"reason": "operator request"}),
+        ("start_failed", "Temporal unavailable"),
+    ],
+)
+def test_sync_wait_covers_every_non_failure_terminal_status(
+    status: str,
+    terminal_detail: object,
+) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "run": {
+                    "run_id": "run-terminal",
+                    "status": status,
+                    "detail": terminal_detail,
+                },
+                "result": None,
+            },
+        )
+
+    transport = httpx.Client(
+        base_url="https://julep.invalid",
+        transport=httpx.MockTransport(handler),
+    )
+    client = JulepClient(client=transport)
+
+    with pytest.raises(JulepRunFailed) as caught:
+        client.wait_for_run("run-terminal", deadline_s=5)
+
+    assert caught.value.run_id == "run-terminal"
+    assert caught.value.status == status
+    assert caught.value.detail == terminal_detail
+
+
 def test_sync_wait_deadline_expires_before_an_unbounded_poll() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.method == "POST"
@@ -285,3 +340,62 @@ def test_async_run_and_wait_honors_deadline() -> None:
         asyncio.run(exercise())
 
     assert caught.value.run_id == "run-async-slow"
+
+
+def test_run_and_wait_executes_against_local_api_end_to_end(tmp_path) -> None:
+    """The adoption client and zero-daemon API compose without consumer glue."""
+
+    from julep import deploy, ident
+    from julep.app_deploy import ApplicationRelease, PipelineRelease
+    from julep.freeze import McpSnapshot
+
+    app = server.create_local_app(project_root=tmp_path)
+    deployment = deploy(ident(), McpSnapshot())
+    release = ApplicationRelease(
+        application="client-local-acceptance",
+        application_artifact_hash="sha256:" + "a" * 64,
+        worker_image="registry.invalid/client-local@sha256:" + "b" * 64,
+        pipelines=(
+            PipelineRelease(
+                name="summary",
+                lane="local",
+                artifact_hash=deployment.artifact_hash,
+                flow_json=deployment.flow_json,
+                manifest_json=deployment.manifest_json,
+                pinned_pures={},
+                bundle_ref=None,
+                eval_packages=(),
+                max_call_limits={},
+                mcp_preflight_policy="pin",
+            ),
+        ),
+    )
+    payload = {"question": "can the client execute this locally?"}
+
+    with TestClient(app) as transport_client:
+        client = JulepClient(api_key="local-dev", client=transport_client)
+        published = client.publish_release(release.manifest_bytes)
+        assert published["release_hash"] == release.release_hash
+
+        first = client.run_and_wait(
+            pipeline="summary",
+            input=payload,
+            release=release.release_hash,
+            idempotency_key="client-local-acceptance",
+            deadline_s=2,
+            poll_wait_s=0.1,
+        )
+        retry = client.run_and_wait(
+            pipeline="summary",
+            input=payload,
+            release=release.release_hash,
+            idempotency_key="client-local-acceptance",
+            deadline_s=2,
+            poll_wait_s=0.1,
+        )
+
+        assert first == payload
+        assert retry == payload
+        runs = client.list_runs()["items"]
+        assert len(runs) == 1
+        assert runs[0]["pipeline"] == "summary"

--- a/tests/server/test_client.py
+++ b/tests/server/test_client.py
@@ -1,16 +1,22 @@
 from __future__ import annotations
 
+import asyncio
 import time
 
+import httpx
 import pytest
-
-pytest.importorskip("fastapi")
-pytest.importorskip("httpx")
-
 from starlette.testclient import TestClient
 
-from julep.client import JulepClient, JulepClientError
+from julep.client import (
+    AsyncJulepClient,
+    JulepClient,
+    JulepClientError,
+    JulepRunFailed,
+    JulepRunTimeout,
+)
 from julep.projection import EventType, ProjectionEvent
+
+pytest.importorskip("fastapi")
 
 
 def _seed_run(store, run_id: str) -> None:
@@ -105,3 +111,177 @@ def test_publish_release_requires_admin_key(server_factory) -> None:
             client.publish_release(release.manifest_bytes)
         assert caught.value.status_code == 403
 
+
+def test_sync_run_and_wait_submits_polls_and_unwraps_result() -> None:
+    requests: list[httpx.Request] = []
+    results = [
+        httpx.Response(202, json={"run": {"run_id": "run-1", "status": "running"}}),
+        httpx.Response(
+            200,
+            json={
+                "run": {"run_id": "run-1", "status": "completed"},
+                "result": {"summary": "done"},
+            },
+        ),
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.method == "POST":
+            return httpx.Response(201, json={"run_id": "run-1", "status": "accepted"})
+        return results.pop(0)
+
+    transport = httpx.Client(
+        base_url="https://julep.invalid",
+        transport=httpx.MockTransport(handler),
+    )
+    client = JulepClient(api_key="secret", client=transport)
+
+    value = client.run_and_wait(
+        pipeline="summary",
+        input={"value": 1},
+        release="sha256:" + "a" * 64,
+        idempotency_key="request-1",
+        deadline_s=5,
+        poll_wait_s=2,
+    )
+
+    assert value == {"summary": "done"}
+    assert [request.url.path for request in requests] == [
+        "/v1/runs",
+        "/v1/runs/run-1/result",
+        "/v1/runs/run-1/result",
+    ]
+    assert all(
+        0 < float(request.url.params["wait_s"]) <= 2 for request in requests[1:]
+    )
+    assert requests[0].headers["Idempotency-Key"] == "request-1"
+    assert requests[0].headers["Authorization"] == "Bearer secret"
+
+
+def test_sync_start_and_wait_raises_typed_terminal_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            return httpx.Response(201, json={"run_id": "run-failed"})
+        return httpx.Response(
+            200,
+            json={
+                "run": {
+                    "run_id": "run-failed",
+                    "status": "failed",
+                    "error": "provider unavailable",
+                },
+                "result": None,
+            },
+        )
+
+    transport = httpx.Client(
+        base_url="https://julep.invalid",
+        transport=httpx.MockTransport(handler),
+    )
+    client = JulepClient(client=transport)
+
+    with pytest.raises(JulepRunFailed) as caught:
+        client.start_and_wait(
+            pipeline="summary",
+            idempotency_key="failed",
+            deadline_s=5,
+        )
+
+    assert caught.value.run_id == "run-failed"
+    assert caught.value.status == "failed"
+    assert caught.value.error == "provider unavailable"
+
+
+def test_sync_wait_deadline_expires_before_an_unbounded_poll() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        return httpx.Response(201, json={"run_id": "run-slow"})
+
+    transport = httpx.Client(
+        base_url="https://julep.invalid",
+        transport=httpx.MockTransport(handler),
+    )
+    client = JulepClient(client=transport)
+
+    with pytest.raises(JulepRunTimeout) as caught:
+        client.run_and_wait(
+            pipeline="summary",
+            idempotency_key="slow",
+            deadline_s=0,
+        )
+
+    assert caught.value.run_id == "run-slow"
+    assert caught.value.deadline_s == 0
+
+
+def test_async_start_and_wait_submits_polls_and_unwraps_result() -> None:
+    requests: list[httpx.Request] = []
+    results = [
+        httpx.Response(202, json={"run": {"run_id": "run-a", "status": "accepted"}}),
+        httpx.Response(
+            200,
+            json={
+                "run": {"run_id": "run-a", "status": "completed"},
+                "result": ["done"],
+            },
+        ),
+    ]
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.method == "POST":
+            return httpx.Response(201, json={"run_id": "run-a"})
+        return results.pop(0)
+
+    transport = httpx.AsyncClient(
+        base_url="https://julep.invalid",
+        transport=httpx.MockTransport(handler),
+    )
+    client = AsyncJulepClient(api_key="secret", client=transport)
+
+    async def exercise() -> object:
+        try:
+            return await client.start_and_wait(
+                pipeline="summary",
+                idempotency_key="async-request",
+                deadline_s=5,
+                poll_wait_s=1,
+            )
+        finally:
+            await transport.aclose()
+
+    value = asyncio.run(exercise())
+
+    assert value == ["done"]
+    assert len(requests) == 3
+    assert all(
+        0 < float(request.url.params["wait_s"]) <= 1 for request in requests[1:]
+    )
+
+
+def test_async_run_and_wait_honors_deadline() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        return httpx.Response(201, json={"run_id": "run-async-slow"})
+
+    transport = httpx.AsyncClient(
+        base_url="https://julep.invalid",
+        transport=httpx.MockTransport(handler),
+    )
+    client = AsyncJulepClient(client=transport)
+
+    async def exercise() -> None:
+        try:
+            await client.run_and_wait(
+                pipeline="summary",
+                idempotency_key="async-slow",
+                deadline_s=0,
+            )
+        finally:
+            await transport.aclose()
+
+    with pytest.raises(JulepRunTimeout) as caught:
+        asyncio.run(exercise())
+
+    assert caught.value.run_id == "run-async-slow"

--- a/tests/server/test_local_mode.py
+++ b/tests/server/test_local_mode.py
@@ -724,3 +724,68 @@ def test_configured_agent_inherits_parent_max_calls(tmp_path: Path) -> None:
     assert finished["result"]["status"] == "denied"
     assert finished["result"]["reason"] == "tool 'srv/echo' exceeded maxCalls=1"
     assert effect_calls == 1
+
+
+def test_local_effects_agent_preserves_native_count_and_uses_wire_alias_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import asyncio
+
+    from julep import agent_loop
+    from julep.execution import effects
+    from julep.execution.harness import ExecutionPolicy
+    from julep.projection import InMemoryProjection, ProjectionEmitter
+    from julep.server.local import _LocalEffectsEnv
+
+    captured: dict[str, Any] = {}
+
+    async def resolve_agent_spec(_input: Any) -> dict[str, Any]:
+        return {}
+
+    async def drive_agent_loop(**kwargs: Any) -> dict[str, Any]:
+        captured.update(kwargs)
+        return {
+            "status": "done",
+            "output": "ok",
+            "callCounts": {"search": 1, "srv/search": 1},
+        }
+
+    async def gate(value: Any, _cid: str, _timeout_s: int | None) -> Any:
+        return value
+
+    monkeypatch.setattr(effects, "resolveAgentSpec", resolve_agent_spec)
+    monkeypatch.setattr(agent_loop, "drive_agent_loop", drive_agent_loop)
+    counts = {"search": 1}
+    env = _LocalEffectsEnv(
+        manifest={},
+        emitter=ProjectionEmitter(InMemoryProjection()),
+        session_id="local-alias",
+        manifest_json={},
+        policy=ExecutionPolicy(),
+        gate=gate,
+        max_calls={"search": 10, "srv/search": 1},
+        principal=None,
+        secrets=None,
+        runtime_declarations_ref=None,
+        root_run_id="local-alias",
+        segment_seq=0,
+        call_counts=counts,
+    )
+
+    result = asyncio.run(
+        env.run_agent(
+            "controller",
+            {},
+            "cid",
+            {
+                "tools": ["search"],
+                "toolAliases": {"search": "srv/search"},
+                "toolContracts": {"search": {}},
+            },
+        )
+    )
+
+    assert captured["contracts"]["search"]["maxCalls"] == 1
+    assert captured["state"].call_counts == {"search": 1}
+    assert result["output"] == "ok"
+    assert counts == {"search": 1, "srv/search": 1}

--- a/tests/server/test_local_mode.py
+++ b/tests/server/test_local_mode.py
@@ -450,6 +450,79 @@ def test_configured_context_factory_executes_real_mcp_effect(tmp_path: Path) -> 
     assert effect_calls[0]["input_schema_validated"] is True
 
 
+def test_configured_context_surfaces_typed_preflight_refusal(tmp_path: Path) -> None:
+    _configure_context_auth(tmp_path)
+    app = server.create_local_app(
+        project_root=tmp_path,
+        context_factory=WorkerContext,
+    )
+    release = _release(ident(), mcp_preflight_policy="off")
+
+    with TestClient(app) as client:
+        _publish_and_activate(client, release, headers=CONFIGURED_HEADERS)
+        started = _start(
+            client,
+            key="configured-unused-secret",
+            input={"message": "preflight first"},
+            secrets={"unused": "must-not-leak"},
+            headers=CONFIGURED_HEADERS,
+        )
+        assert started.status_code == 201, started.text
+        finished = _wait_for_result(
+            client,
+            started.json()["run_id"],
+            headers=CONFIGURED_HEADERS,
+        )
+
+    assert finished["run"]["status"] == "failed"
+    error = finished["run"]["error"]
+    assert error.startswith("invalid_run_secret_binding: ")
+    assert '"error": "invalid_run_secret_binding"' in error
+    assert '"names": ["unused"]' in error
+    assert "must-not-leak" not in error
+
+
+def test_configured_context_scrubs_operator_secret_from_preflight_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from julep.secrets import register_secret_value
+
+    operator_secret = "local-operator-value:/must-not-leak"
+    register_secret_value(operator_secret)
+
+    async def failing_preflight(_payload: Any) -> dict[str, Any]:
+        raise RuntimeError(f"preflight echoed {operator_secret}")
+
+    monkeypatch.setattr("julep.server.local.preflight_mcp", failing_preflight)
+    _configure_context_auth(tmp_path)
+    app = server.create_local_app(
+        project_root=tmp_path,
+        context_factory=WorkerContext,
+    )
+    release = _release(ident(), mcp_preflight_policy="off")
+
+    with TestClient(app) as client:
+        _publish_and_activate(client, release, headers=CONFIGURED_HEADERS)
+        started = _start(
+            client,
+            key="configured-preflight-operator-secret",
+            input={"message": "preflight first"},
+            headers=CONFIGURED_HEADERS,
+        )
+        assert started.status_code == 201, started.text
+        finished = _wait_for_result(
+            client,
+            started.json()["run_id"],
+            headers=CONFIGURED_HEADERS,
+        )
+
+    assert finished["run"]["status"] == "failed"
+    error = finished["run"]["error"]
+    assert error.startswith("RuntimeError: preflight echoed ")
+    assert operator_secret not in error
+
+
 def test_local_control_plane_state_is_ephemeral_but_artifacts_persist(
     tmp_path: Path,
 ) -> None:

--- a/tests/server/test_local_mode.py
+++ b/tests/server/test_local_mode.py
@@ -23,6 +23,17 @@ from conftest import read_snapshot
 
 
 LOCAL_HEADERS = {"Authorization": "Bearer local-dev"}
+CONFIGURED_HEADERS = {"Authorization": "Bearer configured-token"}
+
+
+def _configure_context_auth(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[tool.julep.server]
+api_keys = ["configured-local:configured-token:admin"]
+""".strip(),
+        encoding="utf-8",
+    )
 
 
 def _release(
@@ -64,18 +75,23 @@ def _continue_twice(value: dict[str, int]) -> Any:
 register_pure("tests.local.continue_twice", _continue_twice)
 
 
-def _publish_and_activate(client: TestClient, release: ApplicationRelease) -> None:
+def _publish_and_activate(
+    client: TestClient,
+    release: ApplicationRelease,
+    *,
+    headers: dict[str, str] = LOCAL_HEADERS,
+) -> None:
     published = client.post(
         "/v1/releases",
         content=release.manifest_bytes,
-        headers={**LOCAL_HEADERS, "Content-Type": "application/json"},
+        headers={**headers, "Content-Type": "application/json"},
     )
     assert published.status_code == 201, published.text
 
     activated = client.post(
         "/v1/deployments",
         json={"lane": "local", "release": release.release_hash},
-        headers=LOCAL_HEADERS,
+        headers=headers,
     )
     assert activated.status_code == 200, activated.text
 
@@ -86,6 +102,7 @@ def _start(
     key: str,
     input: Any,
     secrets: dict[str, str] | None = None,
+    headers: dict[str, str] = LOCAL_HEADERS,
 ) -> Any:
     body: dict[str, Any] = {"pipeline": "main", "input": input}
     if secrets is not None:
@@ -93,7 +110,7 @@ def _start(
     return client.post(
         "/v1/runs",
         json=body,
-        headers={**LOCAL_HEADERS, "Idempotency-Key": key},
+        headers={**headers, "Idempotency-Key": key},
     )
 
 
@@ -110,10 +127,15 @@ def _wait_for_gates(client: TestClient, run_id: str) -> list[str]:
     pytest.fail("local run did not open its human gate")
 
 
-def _wait_for_result(client: TestClient, run_id: str) -> dict[str, Any]:
+def _wait_for_result(
+    client: TestClient,
+    run_id: str,
+    *,
+    headers: dict[str, str] = LOCAL_HEADERS,
+) -> dict[str, Any]:
     response = client.get(
         f"/v1/runs/{run_id}/result?wait_s=2",
-        headers=LOCAL_HEADERS,
+        headers=headers,
     )
     assert response.status_code == 200, response.text
     return cast(dict[str, Any], response.json())
@@ -152,6 +174,48 @@ def test_local_dev_key_is_loopback_only(tmp_path: Path) -> None:
         server.create_local_app(project_root=tmp_path, host="0.0.0.0")
 
 
+def test_configured_context_requires_explicit_api_keys(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="explicitly configured API keys"):
+        server.create_local_app(
+            project_root=tmp_path,
+            context_factory=lambda: WorkerContext(),
+        )
+
+
+def test_local_app_lifespans_reject_overlap_without_stealing_process_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_root = tmp_path / "first"
+    second_root = tmp_path / "second"
+    first_root.mkdir()
+    second_root.mkdir()
+    monkeypatch.setenv("JULEP_ARTIFACT_STORE_URL", "file:///before-local")
+    first_app = server.create_local_app(project_root=first_root)
+    second_app = server.create_local_app(project_root=second_root)
+
+    with TestClient(first_app) as first_client:
+        assert (
+            os.environ["JULEP_ARTIFACT_STORE_URL"] == (first_root / ".julep" / "artifacts").as_uri()
+        )
+        with pytest.raises(RuntimeError, match="only one local Julep app lifespan"):
+            with TestClient(second_app):
+                pass
+        assert (
+            os.environ["JULEP_ARTIFACT_STORE_URL"] == (first_root / ".julep" / "artifacts").as_uri()
+        )
+        assert first_client.get("/v1/ready", headers=LOCAL_HEADERS).status_code == 200
+
+    assert os.environ["JULEP_ARTIFACT_STORE_URL"] == "file:///before-local"
+    with TestClient(second_app) as second_client:
+        assert second_client.get("/v1/ready", headers=LOCAL_HEADERS).status_code == 200
+        assert (
+            os.environ["JULEP_ARTIFACT_STORE_URL"]
+            == (second_root / ".julep" / "artifacts").as_uri()
+        )
+    assert os.environ["JULEP_ARTIFACT_STORE_URL"] == "file:///before-local"
+
+
 def test_echo_flow_runs_through_publish_activate_and_run_api(tmp_path: Path) -> None:
     app = server.create_local_app(project_root=tmp_path)
     release = _release(ident())
@@ -179,6 +243,33 @@ def test_echo_flow_runs_through_publish_activate_and_run_api(tmp_path: Path) -> 
         assert any(row["type"] == "Planned" for row in rows)
         assert any(row["type"] == "Did" for row in rows)
         assert rows[-1]["attrs"]["terminal"] is True
+
+
+def test_terminal_local_run_does_not_retain_raw_projection_values(
+    tmp_path: Path,
+) -> None:
+    app = server.create_local_app(project_root=tmp_path)
+    release = _release(ident())
+    secret = "raw-local-secret-value"
+
+    with TestClient(app) as client:
+        _publish_and_activate(client, release)
+        started = _start(
+            client,
+            key="local-projection-scrub",
+            input={"api_key": secret},
+        )
+        assert started.status_code == 201, started.text
+        finished = _wait_for_result(client, started.json()["run_id"])
+        assert finished["result"] == {"api_key": "[REDACTED]"}
+
+        gateway = app.state.gateway
+        record = gateway._runs[started.json()["workflow_id"]]
+        assert record.projection is not None
+        assert vars(record.projection.values)["_values"] == {}
+        projection_json = [event.to_json() for event in record.projection.events()]
+        assert secret not in repr(projection_json)
+        assert all("valueRef" not in event for event in projection_json)
 
 
 def test_local_events_are_visible_while_waiting_for_human_signal(tmp_path: Path) -> None:
@@ -287,6 +378,7 @@ def test_echo_mode_rejects_run_secrets(tmp_path: Path) -> None:
 
 
 def test_configured_context_factory_executes_real_mcp_effect(tmp_path: Path) -> None:
+    _configure_context_auth(tmp_path)
     factory_calls = 0
     effect_calls: list[dict[str, Any]] = []
 
@@ -329,10 +421,19 @@ def test_configured_context_factory_executes_real_mcp_effect(tmp_path: Path) -> 
     payload = {"message": "use the configured caller"}
 
     with TestClient(app) as client:
-        _publish_and_activate(client, release)
-        started = _start(client, key="configured-context", input=payload)
+        _publish_and_activate(client, release, headers=CONFIGURED_HEADERS)
+        started = _start(
+            client,
+            key="configured-context",
+            input=payload,
+            headers=CONFIGURED_HEADERS,
+        )
         assert started.status_code == 201, started.text
-        finished = _wait_for_result(client, started.json()["run_id"])
+        finished = _wait_for_result(
+            client,
+            started.json()["run_id"],
+            headers=CONFIGURED_HEADERS,
+        )
 
     assert factory_calls == 1
     assert finished["result"] == {
@@ -344,7 +445,7 @@ def test_configured_context_factory_executes_real_mcp_effect(tmp_path: Path) -> 
     assert effect_calls[0]["tool"] == "echo"
     assert effect_calls[0]["value"] == payload
     assert effect_calls[0]["cid"]
-    assert effect_calls[0]["principal"] == {"key": "local-dev"}
+    assert effect_calls[0]["principal"] == {"key": "configured-local"}
     assert effect_calls[0]["secrets"] is None
     assert effect_calls[0]["input_schema_validated"] is True
 
@@ -419,6 +520,7 @@ def test_echo_continuations_cannot_reset_max_calls(tmp_path: Path) -> None:
 
 
 def test_configured_subflow_continuations_settle_locally(tmp_path: Path) -> None:
+    _configure_context_auth(tmp_path)
     child = arr("tests.local.continue_twice")
 
     def context_factory() -> WorkerContext:
@@ -439,16 +541,26 @@ def test_configured_subflow_continuations_settle_locally(tmp_path: Path) -> None
     release = _release(sub("child"), snapshot=McpSnapshot())
 
     with TestClient(app) as client:
-        _publish_and_activate(client, release)
-        started = _start(client, key="subflow-continuation", input={"n": 0})
+        _publish_and_activate(client, release, headers=CONFIGURED_HEADERS)
+        started = _start(
+            client,
+            key="subflow-continuation",
+            input={"n": 0},
+            headers=CONFIGURED_HEADERS,
+        )
         assert started.status_code == 201, started.text
-        finished = _wait_for_result(client, started.json()["run_id"])
+        finished = _wait_for_result(
+            client,
+            started.json()["run_id"],
+            headers=CONFIGURED_HEADERS,
+        )
 
     assert finished["run"]["status"] == "completed"
     assert finished["result"] == {"done": 2}
 
 
 def test_configured_app_can_reenter_its_lifespan(tmp_path: Path) -> None:
+    _configure_context_auth(tmp_path)
     factory_calls = 0
 
     async def configured_mcp(
@@ -477,17 +589,31 @@ def test_configured_app_can_reenter_its_lifespan(tmp_path: Path) -> None:
         mcp_preflight_policy="off",
     )
     with TestClient(app) as first:
-        _publish_and_activate(first, release)
-        started = _start(first, key="first-lifespan", input={"run": 1})
-        assert _wait_for_result(first, started.json()["run_id"])["result"] == {
-            "run": 1
-        }
+        _publish_and_activate(first, release, headers=CONFIGURED_HEADERS)
+        started = _start(
+            first,
+            key="first-lifespan",
+            input={"run": 1},
+            headers=CONFIGURED_HEADERS,
+        )
+        assert _wait_for_result(
+            first,
+            started.json()["run_id"],
+            headers=CONFIGURED_HEADERS,
+        )["result"] == {"run": 1}
 
     with TestClient(app) as second:
-        started = _start(second, key="second-lifespan", input={"run": 2})
-        assert _wait_for_result(second, started.json()["run_id"])["result"] == {
-            "run": 2
-        }
+        started = _start(
+            second,
+            key="second-lifespan",
+            input={"run": 2},
+            headers=CONFIGURED_HEADERS,
+        )
+        assert _wait_for_result(
+            second,
+            started.json()["run_id"],
+            headers=CONFIGURED_HEADERS,
+        )["result"] == {"run": 2}
 
     assert factory_calls == 2
 
@@ -496,6 +622,7 @@ def test_failed_context_startup_is_transactional(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _configure_context_auth(tmp_path)
     factory_calls = 0
 
     def context_factory() -> WorkerContext:
@@ -517,7 +644,7 @@ def test_failed_context_startup_is_transactional(
     assert os.environ["JULEP_ARTIFACT_STORE_URL"] == "file:///before-local"
 
     with TestClient(app) as client:
-        ready = client.get("/v1/ready", headers=LOCAL_HEADERS)
+        ready = client.get("/v1/ready", headers=CONFIGURED_HEADERS)
         assert ready.status_code == 200, ready.text
 
     assert factory_calls == 2
@@ -525,6 +652,7 @@ def test_failed_context_startup_is_transactional(
 
 
 def test_configured_agent_inherits_parent_max_calls(tmp_path: Path) -> None:
+    _configure_context_auth(tmp_path)
     effect_calls = 0
     registry = Registry()
     registry.register_reasoner(Reasoner("local.agent", "test:model"))
@@ -578,10 +706,19 @@ def test_configured_agent_inherits_parent_max_calls(tmp_path: Path) -> None:
     )
 
     with TestClient(app) as client:
-        _publish_and_activate(client, release)
-        started = _start(client, key="agent-max-calls", input={"value": 1})
+        _publish_and_activate(client, release, headers=CONFIGURED_HEADERS)
+        started = _start(
+            client,
+            key="agent-max-calls",
+            input={"value": 1},
+            headers=CONFIGURED_HEADERS,
+        )
         assert started.status_code == 201, started.text
-        finished = _wait_for_result(client, started.json()["run_id"])
+        finished = _wait_for_result(
+            client,
+            started.json()["run_id"],
+            headers=CONFIGURED_HEADERS,
+        )
 
     assert finished["run"]["status"] == "completed"
     assert finished["result"]["status"] == "denied"

--- a/tests/server/test_local_mode.py
+++ b/tests/server/test_local_mode.py
@@ -806,7 +806,7 @@ def test_local_effects_agent_preserves_native_count_and_uses_wire_alias_limit(
 
     from julep import agent_loop
     from julep.execution import effects
-    from julep.execution.harness import ExecutionPolicy
+    from julep.execution.policy import ExecutionPolicy
     from julep.projection import InMemoryProjection, ProjectionEmitter
     from julep.server.local import _LocalEffectsEnv
 

--- a/tests/server/test_local_mode.py
+++ b/tests/server/test_local_mode.py
@@ -1,0 +1,589 @@
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any, Literal, cast
+
+import pytest
+from starlette.testclient import TestClient
+
+import julep.server as server
+from julep import Budget, arr, call, deploy, human_gate, ident, mcp, register_pure, seq, sub
+from julep.app_deploy import ApplicationRelease, PipelineRelease
+from julep.execution.effects import WorkerContext
+from julep.execution.projection_store import InMemoryExecutionStore
+from julep.freeze import McpSnapshot
+from julep.dotctx import Reasoner
+from julep.dsl import app as agent_app
+from julep.registry import Registry
+from julep.server.settings import ServerSettings
+
+from conftest import read_snapshot
+
+
+LOCAL_HEADERS = {"Authorization": "Bearer local-dev"}
+
+
+def _release(
+    flow: Any,
+    *,
+    snapshot: McpSnapshot | None = None,
+    mcp_preflight_policy: Literal["pin", "names", "off"] = "pin",
+    max_call_limits: dict[str, int] | None = None,
+) -> ApplicationRelease:
+    deployment = deploy(flow, snapshot or McpSnapshot())
+    return ApplicationRelease(
+        application="local-test",
+        application_artifact_hash="sha256:" + "a" * 64,
+        worker_image="registry.example/local-test@sha256:" + "b" * 64,
+        pipelines=(
+            PipelineRelease(
+                name="main",
+                lane="local",
+                artifact_hash=deployment.artifact_hash,
+                flow_json=deployment.flow_json,
+                manifest_json=deployment.manifest_json,
+                pinned_pures={},
+                bundle_ref=None,
+                eval_packages=(),
+                max_call_limits=max_call_limits or {},
+                mcp_preflight_policy=mcp_preflight_policy,
+            ),
+        ),
+    )
+
+
+def _continue_twice(value: dict[str, int]) -> Any:
+    from julep.continuation import continue_with
+
+    n = value.get("n", 0)
+    return continue_with({"n": n + 1}) if n < 2 else {"done": n}
+
+
+register_pure("tests.local.continue_twice", _continue_twice)
+
+
+def _publish_and_activate(client: TestClient, release: ApplicationRelease) -> None:
+    published = client.post(
+        "/v1/releases",
+        content=release.manifest_bytes,
+        headers={**LOCAL_HEADERS, "Content-Type": "application/json"},
+    )
+    assert published.status_code == 201, published.text
+
+    activated = client.post(
+        "/v1/deployments",
+        json={"lane": "local", "release": release.release_hash},
+        headers=LOCAL_HEADERS,
+    )
+    assert activated.status_code == 200, activated.text
+
+
+def _start(
+    client: TestClient,
+    *,
+    key: str,
+    input: Any,
+    secrets: dict[str, str] | None = None,
+) -> Any:
+    body: dict[str, Any] = {"pipeline": "main", "input": input}
+    if secrets is not None:
+        body["secrets"] = secrets
+    return client.post(
+        "/v1/runs",
+        json=body,
+        headers={**LOCAL_HEADERS, "Idempotency-Key": key},
+    )
+
+
+def _wait_for_gates(client: TestClient, run_id: str) -> list[str]:
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        response = client.get(f"/v1/runs/{run_id}/gates", headers=LOCAL_HEADERS)
+        assert response.status_code == 200, response.text
+        gates = response.json()["gates"]
+        if gates:
+            assert all(isinstance(cid, str) for cid in gates)
+            return cast(list[str], gates)
+        time.sleep(0.01)
+    pytest.fail("local run did not open its human gate")
+
+
+def _wait_for_result(client: TestClient, run_id: str) -> dict[str, Any]:
+    response = client.get(
+        f"/v1/runs/{run_id}/result?wait_s=2",
+        headers=LOCAL_HEADERS,
+    )
+    assert response.status_code == 200, response.text
+    return cast(dict[str, Any], response.json())
+
+
+def test_create_local_app_needs_no_postgres_or_temporal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_store(_settings: ServerSettings) -> Any:
+        raise AssertionError("local mode must not construct a PostgreSQL store")
+
+    async def unexpected_gateway(_settings: ServerSettings) -> Any:
+        raise AssertionError("local mode must not connect to Temporal")
+
+    monkeypatch.setattr(ServerSettings, "build_store", unexpected_store)
+    monkeypatch.setattr(ServerSettings, "build_gateway", unexpected_gateway)
+
+    app = server.create_local_app(project_root=tmp_path, host="127.0.0.1")
+    assert isinstance(app.state.store, InMemoryExecutionStore)
+
+    with TestClient(app) as client:
+        assert client.get("/v1/health").json() == {"status": "ok"}
+        ready = client.get("/v1/ready", headers=LOCAL_HEADERS)
+
+    assert ready.status_code == 200, ready.text
+    assert ready.json() == {
+        "status": "ready",
+        "checks": {"store": "ok", "artifacts": "ok", "temporal": "ok"},
+    }
+    assert (tmp_path / ".julep" / "artifacts").is_dir()
+
+
+def test_local_dev_key_is_loopback_only(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="(?i)(loopback|API key)"):
+        server.create_local_app(project_root=tmp_path, host="0.0.0.0")
+
+
+def test_echo_flow_runs_through_publish_activate_and_run_api(tmp_path: Path) -> None:
+    app = server.create_local_app(project_root=tmp_path)
+    release = _release(ident())
+    payload = {"question": "can this run locally?"}
+
+    with TestClient(app) as client:
+        _publish_and_activate(client, release)
+        started = _start(client, key="local-ident", input=payload)
+        assert started.status_code == 201, started.text
+        run = started.json()
+        assert run["release_hash"] == release.release_hash
+        assert run["pipeline"] == "main"
+        assert run["temporal_run_id"].startswith("local-")
+
+        finished = _wait_for_result(client, run["run_id"])
+        assert finished["run"]["status"] == "completed"
+        assert finished["result"] == payload
+
+        events = client.get(
+            f"/v1/runs/{run['run_id']}/events",
+            headers={**LOCAL_HEADERS, "Accept": "application/json"},
+        )
+        assert events.status_code == 200, events.text
+        rows = events.json()["items"]
+        assert any(row["type"] == "Planned" for row in rows)
+        assert any(row["type"] == "Did" for row in rows)
+        assert rows[-1]["attrs"]["terminal"] is True
+
+
+def test_local_events_are_visible_while_waiting_for_human_signal(tmp_path: Path) -> None:
+    app = server.create_local_app(project_root=tmp_path)
+    release = _release(human_gate(prompt="approve local run", timeout_s=None))
+
+    with TestClient(app) as client:
+        _publish_and_activate(client, release)
+        started = _start(client, key="local-gate", input={"draft": 1})
+        assert started.status_code == 201, started.text
+        run_id = started.json()["run_id"]
+        cid = _wait_for_gates(client, run_id)[0]
+
+        active = client.get(
+            f"/v1/runs/{run_id}/events",
+            headers={**LOCAL_HEADERS, "Accept": "application/json"},
+        )
+        assert active.status_code == 200, active.text
+        before = active.json()["items"]
+        assert before
+        assert any(row["type"] == "Planned" for row in before)
+        assert not any(row.get("attrs", {}).get("terminal") is True for row in before)
+
+        signal_value = {"approved": True, "reviewer": "local"}
+        signaled = client.post(
+            f"/v1/runs/{run_id}/signals/human",
+            json={"cid": cid, "value": signal_value},
+            headers=LOCAL_HEADERS,
+        )
+        assert signaled.status_code == 200, signaled.text
+
+        finished = _wait_for_result(client, run_id)
+        assert finished["run"]["status"] == "completed"
+        assert finished["result"] == signal_value
+
+        after = client.get(
+            f"/v1/runs/{run_id}/events",
+            headers={**LOCAL_HEADERS, "Accept": "application/json"},
+        ).json()["items"]
+        assert len(after) > len(before)
+        assert after[-1]["attrs"]["terminal"] is True
+
+
+@pytest.mark.parametrize(
+    ("operation", "terminal_status"),
+    [("cancel", "canceled"), ("terminate", "terminated")],
+)
+def test_local_blocked_run_can_be_stopped(
+    tmp_path: Path,
+    operation: str,
+    terminal_status: str,
+) -> None:
+    app = server.create_local_app(project_root=tmp_path)
+    release = _release(human_gate(prompt="wait forever", timeout_s=None))
+
+    with TestClient(app) as client:
+        _publish_and_activate(client, release)
+        started = _start(client, key=f"local-{operation}", input={"pending": True})
+        assert started.status_code == 201, started.text
+        run_id = started.json()["run_id"]
+        _wait_for_gates(client, run_id)
+
+        stopped = client.post(
+            f"/v1/runs/{run_id}/{operation}",
+            headers=LOCAL_HEADERS,
+        )
+        assert stopped.status_code == 200, stopped.text
+
+        finished = _wait_for_result(client, run_id)
+        assert finished["run"]["status"] == terminal_status
+        assert finished["result"] is None
+
+
+def test_echo_mode_simulates_the_frozen_mcp_surface(tmp_path: Path) -> None:
+    app = server.create_local_app(project_root=tmp_path)
+    release = _release(call(mcp("srv", "echo")), snapshot=read_snapshot("echo"))
+    payload = {"message": "MCP stays offline"}
+
+    with TestClient(app) as client:
+        _publish_and_activate(client, release)
+        started = _start(client, key="local-mcp", input=payload)
+        assert started.status_code == 201, started.text
+        finished = _wait_for_result(client, started.json()["run_id"])
+
+    assert finished["run"]["status"] == "completed"
+    assert finished["result"] == payload
+
+
+def test_echo_mode_rejects_run_secrets(tmp_path: Path) -> None:
+    app = server.create_local_app(project_root=tmp_path)
+    release = _release(call(mcp("srv", "echo")), snapshot=read_snapshot("echo"))
+
+    with TestClient(app) as client:
+        _publish_and_activate(client, release)
+        response = _start(
+            client,
+            key="local-secret",
+            input={"message": "do not run"},
+            secrets={"tracker-token": "test-only-value"},
+        )
+
+    assert response.status_code == 400, response.text
+    detail = response.json()["detail"].lower()
+    assert "local" in detail
+    assert "secret" in detail
+
+
+def test_configured_context_factory_executes_real_mcp_effect(tmp_path: Path) -> None:
+    factory_calls = 0
+    effect_calls: list[dict[str, Any]] = []
+
+    async def configured_mcp(
+        server_name: str,
+        tool_name: str,
+        value: Any,
+        cid: str,
+        principal: dict[str, Any] | None,
+        secrets: dict[str, str] | None,
+        input_schema_validated: bool,
+    ) -> Any:
+        effect_calls.append(
+            {
+                "server": server_name,
+                "tool": tool_name,
+                "value": value,
+                "cid": cid,
+                "principal": principal,
+                "secrets": secrets,
+                "input_schema_validated": input_schema_validated,
+            }
+        )
+        return {"source": "configured-context", "input": value}
+
+    def context_factory() -> WorkerContext:
+        nonlocal factory_calls
+        factory_calls += 1
+        return WorkerContext(mcp_call=configured_mcp)
+
+    app = server.create_local_app(
+        project_root=tmp_path,
+        context_factory=context_factory,
+    )
+    release = _release(
+        call(mcp("srv", "echo")),
+        snapshot=read_snapshot("echo"),
+        mcp_preflight_policy="off",
+    )
+    payload = {"message": "use the configured caller"}
+
+    with TestClient(app) as client:
+        _publish_and_activate(client, release)
+        started = _start(client, key="configured-context", input=payload)
+        assert started.status_code == 201, started.text
+        finished = _wait_for_result(client, started.json()["run_id"])
+
+    assert factory_calls == 1
+    assert finished["result"] == {
+        "source": "configured-context",
+        "input": payload,
+    }
+    assert len(effect_calls) == 1
+    assert effect_calls[0]["server"] == "srv"
+    assert effect_calls[0]["tool"] == "echo"
+    assert effect_calls[0]["value"] == payload
+    assert effect_calls[0]["cid"]
+    assert effect_calls[0]["principal"] == {"key": "local-dev"}
+    assert effect_calls[0]["secrets"] is None
+    assert effect_calls[0]["input_schema_validated"] is True
+
+
+def test_local_control_plane_state_is_ephemeral_but_artifacts_persist(
+    tmp_path: Path,
+) -> None:
+    first_app = server.create_local_app(project_root=tmp_path)
+    release = _release(ident())
+
+    with TestClient(first_app) as client:
+        _publish_and_activate(client, release)
+        started = _start(client, key="before-restart", input={"value": 7})
+        assert started.status_code == 201, started.text
+        run_id = started.json()["run_id"]
+        assert _wait_for_result(client, run_id)["result"] == {"value": 7}
+
+    digest = release.release_hash.removeprefix("sha256:")
+    assert first_app.state.artifacts.has(digest)
+
+    second_app = server.create_local_app(project_root=tmp_path)
+    assert second_app.state.artifacts.has(digest)
+    with TestClient(second_app) as client:
+        releases = client.get("/v1/releases", headers=LOCAL_HEADERS)
+        assert releases.status_code == 200, releases.text
+        assert releases.json()["items"] == []
+
+        missing_run = client.get(f"/v1/runs/{run_id}", headers=LOCAL_HEADERS)
+        assert missing_run.status_code == 404
+
+
+def test_configured_api_keys_replace_loopback_local_dev_fallback(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[tool.julep.server]
+api_keys = ["custom:custom-token:admin"]
+""".strip(),
+        encoding="utf-8",
+    )
+    app = server.create_local_app(project_root=tmp_path, host="0.0.0.0")
+
+    with TestClient(app) as client:
+        fallback = client.get("/v1/ready", headers=LOCAL_HEADERS)
+        configured = client.get(
+            "/v1/ready",
+            headers={"Authorization": "Bearer custom-token"},
+        )
+
+    assert fallback.status_code == 401
+    assert configured.status_code == 200, configured.text
+
+
+def test_echo_continuations_cannot_reset_max_calls(tmp_path: Path) -> None:
+    app = server.create_local_app(project_root=tmp_path)
+    flow = seq(call(mcp("srv", "echo")), arr("std.continue_with"))
+    release = _release(
+        flow,
+        snapshot=read_snapshot("echo"),
+        max_call_limits={"srv/echo": 1},
+    )
+
+    with TestClient(app) as client:
+        _publish_and_activate(client, release)
+        started = _start(client, key="continuation-max-calls", input={"n": 0})
+        assert started.status_code == 201, started.text
+        finished = _wait_for_result(client, started.json()["run_id"])
+
+    assert finished["run"]["status"] == "failed"
+    assert "maxCalls=1" in finished["run"]["error"]
+
+
+def test_configured_subflow_continuations_settle_locally(tmp_path: Path) -> None:
+    child = arr("tests.local.continue_twice")
+
+    def context_factory() -> WorkerContext:
+        return WorkerContext(
+            subflows={
+                "child": {
+                    "flowJson": child.to_json(),
+                    "manifestJson": {},
+                    "pinnedPures": {},
+                }
+            }
+        )
+
+    app = server.create_local_app(
+        project_root=tmp_path,
+        context_factory=context_factory,
+    )
+    release = _release(sub("child"), snapshot=McpSnapshot())
+
+    with TestClient(app) as client:
+        _publish_and_activate(client, release)
+        started = _start(client, key="subflow-continuation", input={"n": 0})
+        assert started.status_code == 201, started.text
+        finished = _wait_for_result(client, started.json()["run_id"])
+
+    assert finished["run"]["status"] == "completed"
+    assert finished["result"] == {"done": 2}
+
+
+def test_configured_app_can_reenter_its_lifespan(tmp_path: Path) -> None:
+    factory_calls = 0
+
+    async def configured_mcp(
+        _server: str,
+        _tool: str,
+        value: Any,
+        _cid: str,
+        _principal: dict[str, Any] | None,
+        _secrets: dict[str, str] | None,
+        _input_schema_validated: bool,
+    ) -> Any:
+        return value
+
+    def context_factory() -> WorkerContext:
+        nonlocal factory_calls
+        factory_calls += 1
+        return WorkerContext(mcp_call=configured_mcp)
+
+    app = server.create_local_app(
+        project_root=tmp_path,
+        context_factory=context_factory,
+    )
+    release = _release(
+        call(mcp("srv", "echo")),
+        snapshot=read_snapshot("echo"),
+        mcp_preflight_policy="off",
+    )
+    with TestClient(app) as first:
+        _publish_and_activate(first, release)
+        started = _start(first, key="first-lifespan", input={"run": 1})
+        assert _wait_for_result(first, started.json()["run_id"])["result"] == {
+            "run": 1
+        }
+
+    with TestClient(app) as second:
+        started = _start(second, key="second-lifespan", input={"run": 2})
+        assert _wait_for_result(second, started.json()["run_id"])["result"] == {
+            "run": 2
+        }
+
+    assert factory_calls == 2
+
+
+def test_failed_context_startup_is_transactional(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    factory_calls = 0
+
+    def context_factory() -> WorkerContext:
+        nonlocal factory_calls
+        factory_calls += 1
+        if factory_calls == 1:
+            raise RuntimeError("factory unavailable")
+        return WorkerContext()
+
+    monkeypatch.setenv("JULEP_ARTIFACT_STORE_URL", "file:///before-local")
+    app = server.create_local_app(
+        project_root=tmp_path,
+        context_factory=context_factory,
+    )
+
+    with pytest.raises(RuntimeError, match="factory unavailable"):
+        with TestClient(app):
+            pass
+    assert os.environ["JULEP_ARTIFACT_STORE_URL"] == "file:///before-local"
+
+    with TestClient(app) as client:
+        ready = client.get("/v1/ready", headers=LOCAL_HEADERS)
+        assert ready.status_code == 200, ready.text
+
+    assert factory_calls == 2
+    assert os.environ["JULEP_ARTIFACT_STORE_URL"] == "file:///before-local"
+
+
+def test_configured_agent_inherits_parent_max_calls(tmp_path: Path) -> None:
+    effect_calls = 0
+    registry = Registry()
+    registry.register_reasoner(Reasoner("local.agent", "test:model"))
+
+    async def configured_mcp(
+        _server: str,
+        _tool: str,
+        value: Any,
+        _cid: str,
+        _principal: dict[str, Any] | None,
+        _secrets: dict[str, str] | None,
+        _input_schema_validated: bool,
+    ) -> Any:
+        nonlocal effect_calls
+        effect_calls += 1
+        return value
+
+    async def configured_llm(
+        _reasoner: Reasoner,
+        value: Any,
+        _principal: dict[str, Any] | None,
+        _transcript: Any,
+        _dispatch: Any,
+    ) -> Any:
+        return {"tool": "srv/echo", "input": value["input"]}
+
+    def context_factory() -> WorkerContext:
+        return WorkerContext(
+            mcp_call=configured_mcp,
+            llm=configured_llm,
+            registry=registry,
+        )
+
+    flow = seq(
+        call(mcp("srv", "echo")),
+        agent_app(
+            "local.agent",
+            tools=["srv/echo"],
+            budget=Budget(cost=1000),
+        ),
+    )
+    app = server.create_local_app(
+        project_root=tmp_path,
+        context_factory=context_factory,
+    )
+    release = _release(
+        flow,
+        snapshot=read_snapshot("echo"),
+        mcp_preflight_policy="off",
+        max_call_limits={"srv/echo": 1},
+    )
+
+    with TestClient(app) as client:
+        _publish_and_activate(client, release)
+        started = _start(client, key="agent-max-calls", input={"value": 1})
+        assert started.status_code == 201, started.text
+        finished = _wait_for_result(client, started.json()["run_id"])
+
+    assert finished["run"]["status"] == "completed"
+    assert finished["result"]["status"] == "denied"
+    assert finished["result"]["reason"] == "tool 'srv/echo' exceeded maxCalls=1"
+    assert effect_calls == 1

--- a/tests/server/test_local_no_temporal.py
+++ b/tests/server/test_local_no_temporal.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def test_local_preflight_runs_without_temporalio(tmp_path: Path) -> None:
+    script = textwrap.dedent(
+        """
+        import asyncio
+        import importlib.abc
+        import importlib.util
+        import sys
+        from pathlib import Path
+
+        real_find_spec = importlib.util.find_spec
+        importlib.util.find_spec = lambda name, package=None: (
+            None
+            if name == "temporalio" or name.startswith("temporalio.")
+            else real_find_spec(name, package)
+        )
+
+        class BlockTemporal(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "temporalio" or fullname.startswith("temporalio."):
+                    raise ModuleNotFoundError(
+                        f"No module named {fullname!r}",
+                        name=fullname,
+                    )
+                return None
+
+        for name in tuple(sys.modules):
+            if name == "temporalio" or name.startswith("temporalio."):
+                del sys.modules[name]
+        sys.meta_path.insert(0, BlockTemporal())
+
+        from julep.execution import effects
+        from julep.execution.mcp_preflight import McpPreflightError, preflight_mcp
+        from julep.server.local import create_local_app
+
+        assert "julep.execution.harness" not in sys.modules
+        effects.configure(effects.WorkerContext())
+        result = asyncio.run(
+            preflight_mcp(
+                {
+                    "workflowId": "local-no-temporal",
+                    "manifestJson": {},
+                    "policy": "off",
+                }
+            )
+        )
+        assert result == {
+            "policy": "off",
+            "completed": True,
+            "surfaceDigest": None,
+        }
+        try:
+            asyncio.run(
+                preflight_mcp(
+                    {
+                        "workflowId": "local-no-temporal-refusal",
+                        "manifestJson": {},
+                        "policy": "off",
+                        "secrets": {"unused": "never-rendered"},
+                    }
+                )
+            )
+        except McpPreflightError as exc:
+            assert exc.type == "invalid_run_secret_binding"
+            assert "never-rendered" not in exc.detail
+        else:
+            raise AssertionError("unused local secret was accepted")
+
+        app = create_local_app(project_root=Path(sys.argv[1]), host="127.0.0.1")
+        assert app.state.local_mode is True
+        assert "julep.execution.harness" not in sys.modules
+        """
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script, str(tmp_path)],
+        cwd=Path(__file__).parents[2],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr

--- a/tests/server/test_runs.py
+++ b/tests/server/test_runs.py
@@ -128,6 +128,133 @@ def test_run_submission_is_idempotent_and_starts_once(server_factory) -> None:
         assert len(harness.gateway.starts) == 1
 
 
+def test_run_retry_rejects_pipeline_or_explicit_release_mismatch(server_factory) -> None:
+    harness = server_factory()
+    release = make_release(marker="a")
+    other_release = make_release(marker="b")
+    with TestClient(harness.app) as client:
+        _publish(client, release)
+        first = _start(client, release.release_hash, key="stable-request")
+        assert first.status_code == 201, first.text
+
+        wrong_pipeline = client.post(
+            "/v1/runs",
+            json={"release": release.release_hash, "pipeline": "other"},
+            headers={**ALICE_HEADERS, "Idempotency-Key": "stable-request"},
+        )
+        assert wrong_pipeline.status_code == 409
+        assert wrong_pipeline.json()["detail"] == {
+            "error": "idempotency_conflict",
+            "field": "pipeline",
+            "message": "idempotency key was already used for a different pipeline",
+        }
+
+        wrong_release = client.post(
+            "/v1/runs",
+            json={"release": other_release.release_hash, "pipeline": "summary"},
+            headers={**ALICE_HEADERS, "Idempotency-Key": "stable-request"},
+        )
+        assert wrong_release.status_code == 409
+        assert wrong_release.json()["detail"] == {
+            "error": "idempotency_conflict",
+            "field": "release",
+            "message": "idempotency key was already used for a different release",
+        }
+
+        # A hash without the optional scheme is the same explicit release, and
+        # omitting release entirely preserves the original routing-stable retry.
+        same_release = client.post(
+            "/v1/runs",
+            json={
+                "release": release.release_hash.removeprefix("sha256:"),
+                "pipeline": "summary",
+            },
+            headers={**ALICE_HEADERS, "Idempotency-Key": "stable-request"},
+        )
+        assert same_release.status_code == 200
+        assert same_release.json() == first.json()
+
+        unpinned_retry = client.post(
+            "/v1/runs",
+            json={"pipeline": "summary"},
+            headers={**ALICE_HEADERS, "Idempotency-Key": "stable-request"},
+        )
+        assert unpinned_retry.status_code == 200
+        assert unpinned_retry.json() == first.json()
+        assert len(harness.gateway.starts) == 1
+
+
+def test_run_retry_conflict_check_is_repeated_for_atomic_create_loser(
+    server_factory,
+) -> None:
+    class FastPathMissStore(InMemoryExecutionStore):
+        hide_next_lookup = True
+
+        def get_run_by_idempotency_key(self, idempotency_key):
+            if self.hide_next_lookup:
+                self.hide_next_lookup = False
+                return None
+            return super().get_run_by_idempotency_key(idempotency_key)
+
+    store = FastPathMissStore()
+    release = make_release()
+    assert store.create_run(
+        run_id="race-winner",
+        idempotency_key="raced-request",
+        workflow_id="run-race-winner",
+        session_id="run-race-winner",
+        release_hash=release.release_hash,
+        pipeline="other",
+        application=release.application,
+        principal={"key": "alice"},
+        input_ref=None,
+        status="submitting",
+        started_at=time.time(),
+    ) == "created"
+    harness = server_factory(store=store)
+
+    with TestClient(harness.app) as client:
+        _publish(client, release)
+        response = _start(client, release.release_hash, key="raced-request")
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["error"] == "idempotency_conflict"
+    assert harness.gateway.starts == []
+
+
+def test_explicit_run_id_retry_semantics_do_not_gain_payload_conflict_checks(
+    server_factory,
+) -> None:
+    harness = server_factory()
+    release = make_release()
+    with TestClient(harness.app) as client:
+        _publish(client, release)
+        first = client.post(
+            "/v1/runs",
+            json={
+                "runId": "caller-run-id",
+                "release": release.release_hash,
+                "pipeline": "summary",
+            },
+            headers=ALICE_HEADERS,
+        )
+        assert first.status_code == 201, first.text
+
+        retry = client.post(
+            "/v1/runs",
+            json={
+                "runId": "caller-run-id",
+                "release": "not-a-release-hash",
+                "pipeline": "different-pipeline",
+            },
+            headers=ALICE_HEADERS,
+        )
+
+    assert retry.status_code == 200
+    assert retry.json() == first.json()
+    assert len(harness.gateway.starts) == 1
+
+
 def test_run_submission_builds_release_pinned_queue_map_when_omitted(
     server_factory,
 ) -> None:

--- a/tests/server/test_runs.py
+++ b/tests/server/test_runs.py
@@ -128,7 +128,7 @@ def test_run_submission_is_idempotent_and_starts_once(server_factory) -> None:
         assert len(harness.gateway.starts) == 1
 
 
-def test_run_retry_rejects_pipeline_or_explicit_release_mismatch(server_factory) -> None:
+def test_run_retry_rejects_pipeline_or_effective_release_mismatch(server_factory) -> None:
     harness = server_factory()
     release = make_release(marker="a")
     other_release = make_release(marker="b")
@@ -161,8 +161,7 @@ def test_run_retry_rejects_pipeline_or_explicit_release_mismatch(server_factory)
             "message": "idempotency key was already used for a different release",
         }
 
-        # A hash without the optional scheme is the same explicit release, and
-        # omitting release entirely preserves the original routing-stable retry.
+        # A hash without the optional scheme is the same explicit release.
         same_release = client.post(
             "/v1/runs",
             json={
@@ -174,6 +173,10 @@ def test_run_retry_rejects_pipeline_or_explicit_release_mismatch(server_factory)
         assert same_release.status_code == 200
         assert same_release.json() == first.json()
 
+        harness.store.activate_deployment(
+            "summary", release.release_hash, time.time(), "admin"
+        )
+        # An omitted release resolves through active routing before comparison.
         unpinned_retry = client.post(
             "/v1/runs",
             json={"pipeline": "summary"},
@@ -181,6 +184,18 @@ def test_run_retry_rejects_pipeline_or_explicit_release_mismatch(server_factory)
         )
         assert unpinned_retry.status_code == 200
         assert unpinned_retry.json() == first.json()
+
+        _publish(client, other_release)
+        harness.store.activate_deployment(
+            "summary", other_release.release_hash, time.time(), "admin"
+        )
+        rerouted_retry = client.post(
+            "/v1/runs",
+            json={"pipeline": "summary"},
+            headers={**ALICE_HEADERS, "Idempotency-Key": "stable-request"},
+        )
+        assert rerouted_retry.status_code == 409
+        assert rerouted_retry.json()["detail"]["field"] == "release"
         assert len(harness.gateway.starts) == 1
 
 
@@ -197,14 +212,15 @@ def test_run_retry_conflict_check_is_repeated_for_atomic_create_loser(
             return super().get_run_by_idempotency_key(idempotency_key)
 
     store = FastPathMissStore()
-    release = make_release()
+    release = make_release(marker="a")
+    other_release = make_release(marker="b")
     assert store.create_run(
         run_id="race-winner",
         idempotency_key="raced-request",
         workflow_id="run-race-winner",
         session_id="run-race-winner",
         release_hash=release.release_hash,
-        pipeline="other",
+        pipeline="summary",
         application=release.application,
         principal={"key": "alice"},
         input_ref=None,
@@ -215,10 +231,12 @@ def test_run_retry_conflict_check_is_repeated_for_atomic_create_loser(
 
     with TestClient(harness.app) as client:
         _publish(client, release)
-        response = _start(client, release.release_hash, key="raced-request")
+        _publish(client, other_release)
+        response = _start(client, other_release.release_hash, key="raced-request")
 
     assert response.status_code == 409
     assert response.json()["detail"]["error"] == "idempotency_conflict"
+    assert response.json()["detail"]["field"] == "release"
     assert harness.gateway.starts == []
 
 

--- a/tests/test_agent_manifest_helpers.py
+++ b/tests/test_agent_manifest_helpers.py
@@ -63,3 +63,12 @@ def test_max_call_limits_from_contracts_roundtrip() -> None:
         _manifest(), None, max_call_limits={"srv/double": 1, "srv/inc": 5}
     )
     assert max_call_limits_from_contracts(contracts) == {"srv/double": 1, "srv/inc": 5}
+
+
+def test_alias_limits_canonicalize_fail_closed() -> None:
+    aliases = {"a": "srv/t", "b": "srv/t"}
+
+    assert max_call_limits_from_contracts(
+        {"a": {"maxCalls": 3}, "b": {"maxCalls": 2}},
+        aliases,
+    ) == {"srv/t": 2}

--- a/tests/test_dbos_pure.py
+++ b/tests/test_dbos_pure.py
@@ -23,7 +23,7 @@ if HAVE_DBOS:
         decode_policy_error,
         encode_policy_error,
     )
-    from julep.execution.harness import ExecutionPolicy
+    from julep.execution.policy import ExecutionPolicy
     from julep.projection import InMemoryProjection, ProjectionEmitter
 
 

--- a/tests/test_dbos_pure.py
+++ b/tests/test_dbos_pure.py
@@ -2,6 +2,8 @@
 retry-variant choice. Needs dbos importable (decorators at module import)."""
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from julep.execution import HAVE_DBOS
@@ -14,12 +16,15 @@ if HAVE_DBOS:
     from julep.dsl import app
     from julep.errors import CapabilityDenied, UnsupportedShapeError
     from julep.execution.dbos_backend import (
+        DbosEnv,
         assert_dbos_executable,
         callToolIdempotent,
         callToolNoRetry,
         decode_policy_error,
         encode_policy_error,
     )
+    from julep.execution.harness import ExecutionPolicy
+    from julep.projection import InMemoryProjection, ProjectionEmitter
 
 
 def test_scan_accepts_pipeline_shapes():
@@ -57,3 +62,55 @@ def test_decode_passes_plain_values_through():
     assert decode_policy_error({"hits": 3}) == {"hits": 3}
     assert decode_policy_error(None) is None
     assert decode_policy_error([1, 2]) == [1, 2]
+
+
+def test_dbos_env_preserves_native_parent_count_and_uses_wire_alias_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from julep.execution import dbos_backend
+
+    submitted = []
+
+    async def fake_run_agent_chain(payload, *, base_id):  # noqa: ANN001
+        submitted.append((payload, base_id))
+        return {
+            "status": "done",
+            "output": "ok",
+            "callCounts": {"search": 1, "srv/search": 1},
+        }
+
+    monkeypatch.setattr(dbos_backend, "_run_agent_chain", fake_run_agent_chain)
+    env = DbosEnv(
+        manifest={},
+        emitter=ProjectionEmitter(InMemoryProjection()),
+        session_id="dbos-alias",
+        manifest_json={},
+        policy=ExecutionPolicy(),
+        max_call_limits={"search": 10, "srv/search": 1},
+        call_counts={"search": 1},
+    )
+    reply_schema = {"type": "object"}
+
+    out = asyncio.run(
+        env.run_agent(
+            "controller",
+            {},
+            "cid",
+            {
+                "tools": ["search"],
+                "toolAliases": {"search": "srv/search"},
+                "toolContracts": {"search": {"maxCalls": 5}},
+                "replySchema": reply_schema,
+                "outputRetries": 3,
+            },
+        )
+    )
+
+    payload, base_id = submitted[0]
+    assert base_id == "dbos-alias-agent-cid"
+    assert payload["grantedContracts"] == {"search": {"maxCalls": 1}}
+    assert payload["state"]["callCounts"] == {"search": 1}
+    assert payload["config"]["replySchema"] == reply_schema
+    assert payload["config"]["outputRetries"] == 3
+    assert out["output"] == "ok"
+    assert env.call_counts_snapshot() == {"search": 1, "srv/search": 1}

--- a/tests/test_debounce.py
+++ b/tests/test_debounce.py
@@ -22,6 +22,7 @@ if HAVE_TEMPORAL:
 
     from julep import call, each, freeze, manifest_to_json, mcp
     from julep.contracts import McpAnnotations
+    from julep.dispatch import BatchWindow, dispatch_debounced
     from julep.execution.activities import WorkerContext
     from julep.execution.debounce import submit_debounced
     from julep.execution.worker import build_worker
@@ -95,9 +96,14 @@ async def _quiet_window_collates_a_burst(env):
         with env.auto_time_skipping_disabled():
             handle = None
             for item in (1, 2, 3):
-                handle = await submit_debounced(
-                    env.client, flow_json, manifest_json,
-                    key=key, item=item, quiet_s=600, task_queue="julep-debounce",
+                handle = await dispatch_debounced(
+                    env.client,
+                    flow_json,
+                    manifest_json,
+                    key=key,
+                    item=item,
+                    window=BatchWindow(quiet_s=600),
+                    task_queue="julep-debounce",
                 )
             assert sorted(await handle.query("pending")) == [1, 2, 3]
         await env.sleep(601)

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import asyncio
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from julep.dispatch import (
+    BatchTrigger,
+    BatchWindow,
+    SignalWithStartRequest,
+    build_debounce_request,
+    dedup_workflow_id,
+    signal_with_start,
+)
+from julep.execution import HAVE_TEMPORAL
+
+
+NOW = datetime(2026, 7, 23, 12, 0, tzinfo=timezone.utc)
+
+
+def test_dedup_workflow_id_is_canonical_opaque_and_bounded() -> None:
+    first = dedup_workflow_id(
+        "episode summary / prod",
+        {"store_id": 42, "nested": {"b": 2, "a": 1}},
+        "generation-7",
+        max_length=52,
+    )
+    reordered = dedup_workflow_id(
+        "episode summary / prod",
+        {"nested": {"a": 1, "b": 2}, "store_id": 42},
+        "generation-7",
+        max_length=52,
+    )
+
+    assert first == reordered
+    assert len(first) <= 52
+    assert re.fullmatch(r"[A-Za-z0-9_.-]+:[0-9a-f]{32}", first)
+    assert "42" not in first
+    assert "generation" not in first
+    assert first != dedup_workflow_id(
+        "episode summary / prod",
+        {"store_id": 42, "nested": {"b": 2, "a": 1}},
+        "generation-8",
+        max_length=52,
+    )
+
+
+def test_dedup_workflow_id_rejects_ambiguous_inputs() -> None:
+    with pytest.raises(ValueError, match="namespace"):
+        dedup_workflow_id("", "x")
+    with pytest.raises(ValueError, match="at least 34"):
+        dedup_workflow_id("dispatch", "x", max_length=33)
+    with pytest.raises(TypeError, match="finite JSON"):
+        dedup_workflow_id("dispatch", {"not_json": object()})
+    with pytest.raises(TypeError, match="finite JSON"):
+        dedup_workflow_id("dispatch", float("nan"))
+
+
+def test_batch_window_reports_empty_wait_quiet_and_cap() -> None:
+    window = BatchWindow(quiet_s=10, max_items=3, max_wait_s=30)
+
+    empty = window.evaluate(
+        item_count=0,
+        opened_at=None,
+        last_arrival_at=None,
+        now=NOW,
+    )
+    assert not empty.fire
+    assert empty.trigger is None
+    assert empty.deadline is None
+    assert empty.wait_s is None
+
+    waiting = window.evaluate(
+        item_count=2,
+        opened_at=NOW - timedelta(seconds=5),
+        last_arrival_at=NOW - timedelta(seconds=4),
+        now=NOW,
+    )
+    assert not waiting.fire
+    assert waiting.trigger is BatchTrigger.QUIET
+    assert waiting.deadline == NOW + timedelta(seconds=6)
+    assert waiting.wait_s == 6
+
+    quiet = window.evaluate(
+        item_count=2,
+        opened_at=NOW - timedelta(seconds=20),
+        last_arrival_at=NOW - timedelta(seconds=10),
+        now=NOW,
+    )
+    assert quiet.fire
+    assert quiet.trigger is BatchTrigger.QUIET
+    assert quiet.wait_s == 0
+
+    capped = window.evaluate(
+        item_count=3,
+        opened_at=NOW,
+        last_arrival_at=NOW,
+        now=NOW,
+    )
+    assert capped.fire
+    assert capped.trigger is BatchTrigger.MAX_ITEMS
+
+
+def test_batch_window_uses_max_wait_when_it_is_earlier() -> None:
+    decision = BatchWindow(quiet_s=60, max_wait_s=15).evaluate(
+        item_count=1,
+        opened_at=NOW - timedelta(seconds=15),
+        last_arrival_at=NOW,
+        now=NOW,
+    )
+
+    assert decision.fire
+    assert decision.trigger is BatchTrigger.MAX_WAIT
+    assert decision.deadline == NOW
+
+
+@pytest.mark.parametrize(
+    ("window", "message"),
+    [
+        (lambda: BatchWindow(quiet_s=-1), "quiet_s"),
+        (lambda: BatchWindow(quiet_s=float("nan")), "quiet_s"),
+        (lambda: BatchWindow(quiet_s=1, max_items=0), "max_items"),
+        (lambda: BatchWindow(quiet_s=1, max_items=True), "max_items"),
+        (lambda: BatchWindow(quiet_s=1, max_wait_s=-1), "max_wait_s"),
+        (lambda: BatchWindow(quiet_s=1, max_wait_s=float("inf")), "max_wait_s"),
+    ],
+)
+def test_batch_window_validates_configuration(window: Any, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        window()
+
+
+@pytest.mark.skipif(not HAVE_TEMPORAL, reason="temporalio not installed")
+def test_build_debounce_request_keys_by_configuration_not_item() -> None:
+    first = build_debounce_request(
+        {"op": "id", "meta": {"b": 2, "a": 1}},
+        {"tools": []},
+        key="store-42",
+        item={"event": 1},
+        window=BatchWindow(quiet_s=5, max_items=10, max_wait_s=60),
+        scope={"pipeline": "record", "release": "abc"},
+        principal={"store_id": 42},
+    )
+    second = build_debounce_request(
+        {"meta": {"a": 1, "b": 2}, "op": "id"},
+        {"tools": []},
+        key="store-42",
+        item={"event": 2},
+        window=BatchWindow(quiet_s=5, max_items=10, max_wait_s=60),
+        scope={"release": "abc", "pipeline": "record"},
+        principal={"store_id": 42},
+    )
+    changed = build_debounce_request(
+        {"op": "id", "meta": {"a": 1, "b": 2}},
+        {"tools": []},
+        key="store-42",
+        item={"event": 3},
+        window=BatchWindow(quiet_s=6, max_items=10, max_wait_s=60),
+        scope={"pipeline": "record", "release": "abc"},
+        principal={"store_id": 42},
+    )
+
+    assert first.workflow_id == second.workflow_id
+    assert changed.workflow_id != first.workflow_id
+    assert first.workflow == "DebounceCollector"
+    assert first.signal == "submit"
+    assert first.signal_args == ({"event": 1},)
+    assert first.input.key == "store-42"
+    assert first.input.quiet_s == 5
+    assert "store-42" not in first.workflow_id
+
+
+@pytest.mark.skipif(not HAVE_TEMPORAL, reason="temporalio not installed")
+def test_signal_with_start_executes_managed_dedup_policies() -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeClient:
+        async def start_workflow(
+            self,
+            workflow: Any,
+            arg: Any,
+            **kwargs: Any,
+        ) -> str:
+            captured.update(workflow=workflow, arg=arg, kwargs=kwargs)
+            return "handle"
+
+    request = SignalWithStartRequest(
+        workflow="Collector",
+        input={"configuration": True},
+        workflow_id="collector:abc",
+        task_queue="background",
+        signal="submit",
+        signal_args=({"event": 1},),
+        start_options={"memo": {"owner": "test"}},
+    )
+    result = asyncio.run(signal_with_start(FakeClient(), request))
+
+    assert result == "handle"
+    assert captured["workflow"] == "Collector"
+    assert captured["arg"] == {"configuration": True}
+    kwargs = captured["kwargs"]
+    assert kwargs["id"] == "collector:abc"
+    assert kwargs["task_queue"] == "background"
+    assert kwargs["start_signal"] == "submit"
+    assert kwargs["start_signal_args"] == [{"event": 1}]
+    assert kwargs["id_reuse_policy"].name == "ALLOW_DUPLICATE"
+    assert kwargs["id_conflict_policy"].name == "USE_EXISTING"
+    assert kwargs["memo"] == {"owner": "test"}
+
+
+def test_signal_with_start_rejects_managed_option_override() -> None:
+    with pytest.raises(ValueError, match="cannot override.*id"):
+        SignalWithStartRequest(
+            workflow="Collector",
+            input=None,
+            workflow_id="collector:abc",
+            task_queue="background",
+            signal="submit",
+            start_options={"id": "other"},
+        )

--- a/tests/test_dotctx_agent_rfc.py
+++ b/tests/test_dotctx_agent_rfc.py
@@ -9,11 +9,12 @@ import pytest
 from julep import HAVE_TEMPORAL
 from julep.declarations import declarations_blob, load_declarations
 from julep.dotctx import Reasoner, reasoner_from_settings, reasoner_to_flow
-from julep.dsl import app
+from julep.dsl import app, think
 from julep.errors import FreezeError
 from julep.freeze import McpServerSnapshot, McpSnapshot, McpToolSpec, freeze
 from julep.ir import canonical_json
 from julep.registry import (
+    DEFAULT_REGISTRY,
     Registry,
     ToolSchemaExpectation,
     scoped_tool_expectation_key,
@@ -129,6 +130,98 @@ def test_freeze_rejects_non_exact_tools_pyi_schema() -> None:
                 "search": ToolSchemaExpectation("search", EXPECTED, "prompt.ctx")
             },
         )
+
+
+def test_think_reasoner_honors_explicit_unscoped_tool_expectation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    name = "explicit-unscoped-schema-reasoner"
+    tool_key = "tracker/search-posts"
+    monkeypatch.setitem(
+        DEFAULT_REGISTRY.reasoners,
+        name,
+        Reasoner(name, "test:model", tools=(tool_key,)),
+    )
+    snapshot = McpSnapshot(
+        servers={
+            "tracker": McpServerSnapshot(
+                "tracker",
+                {
+                    "search-posts": McpToolSpec(
+                        input_schema={
+                            **EXPECTED,
+                            "additionalProperties": False,
+                        }
+                    )
+                },
+            )
+        }
+    )
+
+    with pytest.raises(FreezeError, match="TOOL_SCHEMA_DRIFT.*tracker/search-posts"):
+        freeze(
+            think(name),
+            snapshot,
+            expected_tool_schemas={
+                tool_key: ToolSchemaExpectation(
+                    tool_key,
+                    EXPECTED,
+                    "explicit-tools.pyi",
+                )
+            },
+        )
+
+
+def test_think_reasoner_ignores_unrelated_scoped_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner = "scoped-schema-owner"
+    consumer = "unrelated-schema-consumer"
+    tool_key = "review-scoped/tool"
+    expectation = ToolSchemaExpectation(
+        tool_key,
+        EXPECTED,
+        "owner-tools.pyi",
+    )
+    monkeypatch.setitem(
+        DEFAULT_REGISTRY.reasoners,
+        consumer,
+        Reasoner(consumer, "test:model", tools=(tool_key,)),
+    )
+    monkeypatch.setitem(
+        DEFAULT_REGISTRY.tool_expectations,
+        scoped_tool_expectation_key(owner, tool_key),
+        expectation,
+    )
+    monkeypatch.setitem(
+        DEFAULT_REGISTRY.tool_expectations,
+        tool_key,
+        expectation,
+    )
+    monkeypatch.setattr(
+        DEFAULT_REGISTRY,
+        "scoped_tool_fallbacks",
+        {*DEFAULT_REGISTRY.scoped_tool_fallbacks, tool_key},
+    )
+    snapshot = McpSnapshot(
+        servers={
+            "review-scoped": McpServerSnapshot(
+                "review-scoped",
+                {
+                    "tool": McpToolSpec(
+                        input_schema={
+                            **EXPECTED,
+                            "additionalProperties": False,
+                        }
+                    )
+                },
+            )
+        }
+    )
+
+    frozen = freeze(think(consumer), snapshot)
+
+    assert frozen.flow is not None
 
 
 def test_freeze_preserves_legacy_wire_grant_without_alias_map() -> None:

--- a/tests/test_dotctx_agent_rfc.py
+++ b/tests/test_dotctx_agent_rfc.py
@@ -239,6 +239,9 @@ def test_agent_workflow_dispatches_bare_alias_to_wire_tool(monkeypatch) -> None:
     monkeypatch.setattr(
         harness, "_agent_frozen_tool_input_validation_enabled", lambda: True
     )
+    monkeypatch.setattr(
+        harness, "_agent_canonical_tool_counts_enabled", lambda: True
+    )
 
     rounds = iter(
         [
@@ -299,6 +302,318 @@ def test_agent_workflow_dispatches_bare_alias_to_wire_tool(monkeypatch) -> None:
     }
     assert result["trace"][0]["callId"] == "tool-1"
     assert result["trace"][0]["arguments"] == {"query": "q"}
+
+
+@pytest.mark.skipif(not HAVE_TEMPORAL, reason="temporalio not installed")
+def test_agent_workflow_shares_max_calls_across_aliases_for_one_wire(
+    monkeypatch,
+) -> None:
+    from julep.execution import harness
+    from julep.execution.harness import AgentInput, AgentWorkflow
+
+    monkeypatch.setattr(
+        harness, "_agent_frozen_tool_input_validation_enabled", lambda: True
+    )
+    monkeypatch.setattr(
+        harness, "_agent_canonical_tool_counts_enabled", lambda: True
+    )
+    rounds = iter(
+        [
+            {
+                "tool_calls": [
+                    {"id": "tool-a", "tool": "a", "input": {"query": "a"}}
+                ]
+            },
+            {
+                "tool_calls": [
+                    {"id": "tool-b", "tool": "b", "input": {"query": "b"}}
+                ]
+            },
+            {"output": {"answer": "unexpected"}},
+        ]
+    )
+    calls = []
+
+    async def fake_execute_activity(fn, payload=None, **kwargs):
+        del kwargs
+        if fn.__name__ == "invokeReasoner":
+            return next(rounds)
+        if fn.__name__ == "validateJsonSchema":
+            return None
+        if fn.__name__ == "callTool":
+            calls.append(payload)
+            return []
+        return None
+
+    monkeypatch.setattr(harness.workflow, "execute_activity", fake_execute_activity)
+    contract = {
+        "effect": "read",
+        "idempotency": "native",
+        "asserted": True,
+        "maxCalls": 1,
+    }
+    inp = AgentInput(
+        controller="alias-agent",
+        session_id="alias-limit-run",
+        input={"query": "q"},
+        config={"maxRounds": 3, "nativeTools": True},
+        granted_tools=["a", "b"],
+        granted_contracts={"a": dict(contract), "b": dict(contract)},
+        tool_defs=[
+            {
+                "type": "function",
+                "function": {
+                    "name": alias,
+                    "description": "",
+                    "parameters": EXPECTED,
+                },
+            }
+            for alias in ("a", "b")
+        ],
+        tool_aliases={"a": "tracker/search-posts", "b": "tracker/search-posts"},
+        resolve_spec=False,
+    )
+
+    result = asyncio.run(AgentWorkflow().run(inp))
+
+    assert result["status"] == "denied"
+    assert result["reason"] == "tool 'b' exceeded maxCalls=1"
+    assert result["callCounts"] == {"tracker/search-posts": 1}
+    assert len(calls) == 1
+
+
+@pytest.mark.skipif(not HAVE_TEMPORAL, reason="temporalio not installed")
+def test_agent_workflow_honors_preconsumed_wire_call_count(monkeypatch) -> None:
+    from julep.agent_loop import AgentState
+    from julep.execution import harness
+    from julep.execution.harness import AgentInput, AgentWorkflow
+
+    monkeypatch.setattr(
+        harness, "_agent_frozen_tool_input_validation_enabled", lambda: True
+    )
+    monkeypatch.setattr(
+        harness, "_agent_canonical_tool_counts_enabled", lambda: True
+    )
+    calls = []
+
+    async def fake_execute_activity(fn, payload=None, **kwargs):
+        del kwargs
+        if fn.__name__ == "invokeReasoner":
+            return {
+                "tool_calls": [
+                    {"id": "tool-a", "tool": "a", "input": {"query": "a"}}
+                ]
+            }
+        if fn.__name__ == "validateJsonSchema":
+            return None
+        if fn.__name__ == "callTool":
+            calls.append(payload)
+            return []
+        return None
+
+    monkeypatch.setattr(harness.workflow, "execute_activity", fake_execute_activity)
+    inp = AgentInput(
+        controller="alias-agent",
+        session_id="preconsumed-limit-run",
+        input={"query": "q"},
+        config={"maxRounds": 2, "nativeTools": True},
+        granted_tools=["a"],
+        granted_contracts={
+            "a": {
+                "effect": "read",
+                "idempotency": "native",
+                "asserted": True,
+                "maxCalls": 1,
+            }
+        },
+        tool_defs=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "a",
+                    "description": "",
+                    "parameters": EXPECTED,
+                },
+            }
+        ],
+        tool_aliases={"a": "tracker/search-posts"},
+        state=AgentState(
+            last={"query": "q"},
+            call_counts={"tracker/search-posts": 1},
+        ).to_json(),
+        resolve_spec=False,
+    )
+
+    result = asyncio.run(AgentWorkflow().run(inp))
+
+    assert result["status"] == "denied"
+    assert result["reason"] == "tool 'a' exceeded maxCalls=1"
+    assert result["callCounts"] == {"tracker/search-posts": 1}
+    assert calls == []
+
+
+@pytest.mark.skipif(not HAVE_TEMPORAL, reason="temporalio not installed")
+def test_agent_workflow_preserves_native_parent_key_distinct_from_alias_wire(
+    monkeypatch,
+) -> None:
+    from julep.agent_loop import AgentState
+    from julep.execution import harness
+    from julep.execution.harness import AgentInput, AgentWorkflow
+
+    monkeypatch.setattr(
+        harness, "_agent_frozen_tool_input_validation_enabled", lambda: True
+    )
+    monkeypatch.setattr(
+        harness, "_agent_canonical_tool_counts_enabled", lambda: True
+    )
+    rounds = iter(
+        [
+            {
+                "tool_calls": [
+                    {
+                        "id": "mcp-search",
+                        "tool": "search",
+                        "input": {"query": "q"},
+                    }
+                ]
+            },
+            {"output": {"answer": "done"}},
+        ]
+    )
+    calls = []
+
+    async def fake_execute_activity(fn, payload=None, **kwargs):
+        del kwargs
+        if fn.__name__ == "invokeReasoner":
+            return next(rounds)
+        if fn.__name__ == "validateJsonSchema":
+            return None
+        if fn.__name__ == "callTool":
+            calls.append(payload)
+            return []
+        return None
+
+    monkeypatch.setattr(harness.workflow, "execute_activity", fake_execute_activity)
+    inp = AgentInput(
+        controller="search-agent",
+        session_id="native-parent-key-run",
+        input={"query": "q"},
+        config={"maxRounds": 3, "nativeTools": True},
+        granted_tools=["search"],
+        granted_contracts={
+            "search": {
+                "effect": "read",
+                "idempotency": "native",
+                "asserted": True,
+                "maxCalls": 1,
+            }
+        },
+        tool_defs=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "description": "",
+                    "parameters": EXPECTED,
+                },
+            }
+        ],
+        tool_aliases={"search": "tracker/search-posts"},
+        state=AgentState(
+            last={"query": "q"},
+            call_counts={"search": 1},
+        ).to_json(),
+        resolve_spec=False,
+    )
+
+    result = asyncio.run(AgentWorkflow().run(inp))
+
+    assert result["status"] == "done"
+    assert result["callCounts"] == {"search": 1, "tracker/search-posts": 1}
+    assert len(calls) == 1
+
+
+@pytest.mark.skipif(not HAVE_TEMPORAL, reason="temporalio not installed")
+def test_agent_subflow_inherits_canonical_wire_call_limit(monkeypatch) -> None:
+    from julep.execution import harness
+    from julep.execution.harness import AgentInput, AgentWorkflow
+
+    monkeypatch.setattr(
+        harness, "_agent_frozen_tool_input_validation_enabled", lambda: True
+    )
+    monkeypatch.setattr(
+        harness, "_agent_canonical_tool_counts_enabled", lambda: True
+    )
+    rounds = iter(
+        [
+            {
+                "tool_calls": [
+                    {"id": "tool-a", "tool": "a", "input": {"query": "a"}}
+                ]
+            },
+            {"sub": "child", "input": {"query": "child"}},
+            {"output": {"answer": "done"}},
+        ]
+    )
+    children = []
+
+    async def fake_execute_activity(fn, payload=None, **kwargs):
+        del kwargs
+        if fn.__name__ == "invokeReasoner":
+            return next(rounds)
+        if fn.__name__ == "validateJsonSchema":
+            return None
+        if fn.__name__ == "callTool":
+            return []
+        if fn.__name__ == "resolveSubflow":
+            return {}
+        return None
+
+    async def fake_execute_child_workflow(*args, **kwargs):
+        del kwargs
+        children.append(args[1])
+        return {"child": "done"}
+
+    monkeypatch.setattr(harness.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(
+        harness.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    inp = AgentInput(
+        controller="alias-sub-agent",
+        session_id="alias-sub-run",
+        input={"query": "q"},
+        config={"maxRounds": 4, "nativeTools": True},
+        granted_tools=["a"],
+        granted_subflows=["child"],
+        granted_contracts={
+            "a": {
+                "effect": "read",
+                "idempotency": "native",
+                "asserted": True,
+                "maxCalls": 1,
+            }
+        },
+        tool_defs=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "a",
+                    "description": "",
+                    "parameters": EXPECTED,
+                },
+            }
+        ],
+        tool_aliases={"a": "tracker/search-posts"},
+        resolve_spec=False,
+    )
+
+    result = asyncio.run(AgentWorkflow().run(inp))
+
+    assert result["status"] == "done"
+    assert children[0].max_call_limits == {"tracker/search-posts": 1}
+    assert children[0].call_counts == {"tracker/search-posts": 1}
 
 
 @pytest.mark.skipif(not HAVE_TEMPORAL, reason="temporalio not installed")

--- a/tests/test_dotctx_reply.py
+++ b/tests/test_dotctx_reply.py
@@ -8,8 +8,9 @@ import pytest
 
 from julep.deploy import _reasoner_identity
 from julep.dotctx import Reasoner
+from julep.ir import SubContract, canonical_json
+from julep.kinds import ContextScope, Shape
 from julep.registry import DEFAULT_REGISTRY
-from julep.ir import canonical_json
 
 
 @pytest.fixture
@@ -188,3 +189,79 @@ def test_reply_typeddict_nested_notrequired_field_resolves_under_future_annotati
 def test_reply_rejects_unsupported_type_with_supported_forms() -> None:
     with pytest.raises(TypeError, match="pydantic.*TypedDict"):
         Reasoner(name="reply.unsupported", model="openai:gpt-4o", reply=object)
+
+
+def test_reasoner_replace_is_lossless_and_can_override_every_field() -> None:
+    original = Reasoner(
+        name="replace.original",
+        model="openai:gpt-4o",
+        system="system",
+        reply=TypedReply,
+        tools=("search",),
+        temperature=0.25,
+        max_rounds=4,
+        is_agent=True,
+        sub_contract=SubContract(Shape.FEEDBACK),
+        context_scope=ContextScope.LOCAL,
+        system_render="render.system",
+        user_render="render.user",
+        max_tokens=512,
+        reasoning_effort="high",
+        output_retries=2,
+        require_tool_call=True,
+        response_format="json_object",
+        prompt_cache="5m",
+    )
+
+    assert original.replace() == original
+
+    replacement = original.replace(
+        name="replace.new",
+        model="anthropic:claude-sonnet-4",
+        system="new system",
+        reply={"type": "string"},
+        tools=("lookup",),
+        temperature=None,
+        max_rounds=None,
+        is_agent=False,
+        sub_contract=None,
+        context_scope=ContextScope.WHOLE_SESSION,
+        system_render=None,
+        user_render=None,
+        max_tokens=None,
+        reasoning_effort=None,
+        output_retries=0,
+        require_tool_call=False,
+        response_format=None,
+        prompt_cache=None,
+    )
+
+    assert replacement.name == "replace.new"
+    assert replacement.model == "anthropic:claude-sonnet-4"
+    assert replacement.system == "new system"
+    assert replacement.reply_schema == {"type": "string"}
+    assert replacement.tools == ("lookup",)
+    assert replacement.temperature is None
+    assert replacement.max_rounds is None
+    assert replacement.is_agent is False
+    assert replacement.sub_contract is None
+    assert replacement.context_scope is ContextScope.WHOLE_SESSION
+    assert replacement.system_render is None
+    assert replacement.user_render is None
+    assert replacement.max_tokens is None
+    assert replacement.reasoning_effort is None
+    assert replacement.output_retries == 0
+    assert replacement.require_tool_call is False
+    assert replacement.response_format is None
+    assert replacement.prompt_cache is None
+
+
+def test_reasoner_replace_reply_distinguishes_keep_clear_and_rematerialize(
+    decision_model: type[object],
+) -> None:
+    Decision = decision_model
+    original = Reasoner("replace.reply", "openai:gpt-4o", reply=TypedReply)
+
+    assert original.replace(model="openai:gpt-4.1").reply_schema == original.reply_schema
+    assert original.replace(reply=None).reply_schema is None
+    assert original.replace(reply=Decision).reply_schema == Decision.model_json_schema()

--- a/tests/test_dotctx_reply.py
+++ b/tests/test_dotctx_reply.py
@@ -265,3 +265,13 @@ def test_reasoner_replace_reply_distinguishes_keep_clear_and_rematerialize(
     assert original.replace(model="openai:gpt-4.1").reply_schema == original.reply_schema
     assert original.replace(reply=None).reply_schema is None
     assert original.replace(reply=Decision).reply_schema == Decision.model_json_schema()
+
+
+def test_reasoner_replace_preserves_future_extension_fields() -> None:
+    original = Reasoner("replace.future", "openai:gpt-4o")
+    object.__setattr__(original, "future_field", {"enabled": True})
+
+    replacement = original.replace(model="openai:gpt-5")
+
+    assert replacement.model == "openai:gpt-5"
+    assert vars(replacement)["future_field"] == {"enabled": True}

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -484,6 +484,86 @@ def test_app_runs_agent_handler():
     assert run(interpret(fr.flow, "go", env)).value == {"status": "done", "output": "go"}
 
 
+def test_in_memory_agent_enforces_release_max_calls_across_rounds():
+    model_calls = 0
+    effect_calls = 0
+
+    def controller(_value):
+        nonlocal model_calls
+        model_calls += 1
+        return {
+            "tool_calls": [
+                {"id": f"call-{model_calls}", "tool": "inc", "input": model_calls}
+            ]
+        }
+
+    def inc(value):
+        nonlocal effect_calls
+        effect_calls += 1
+        return value + 1
+
+    flow = app(
+        "controller",
+        tools=["inc"],
+        tool_aliases={"inc": "srv/inc"},
+        max_rounds=3,
+        native_tools=True,
+    )
+    fr = freeze(flow, read_snapshot("inc"))
+    env = InMemoryEnv(
+        fr.manifest,
+        ProjectionEmitter(InMemoryProjection()),
+        tools={"srv/inc": inc},
+        reasoners={"controller": controller},
+        max_calls={"srv/inc": 1},
+    )
+
+    out = run(interpret(fr.flow, 0, env))
+
+    assert out.value["status"] == "denied"
+    assert out.value["reason"] == "tool 'inc' exceeded maxCalls=1"
+    assert effect_calls == 1
+    assert env.call_counts == {"srv/inc": 1}
+
+
+def test_in_memory_agent_inherits_calls_made_before_agent():
+    effect_calls = 0
+
+    def controller(_value):
+        return {"tool_calls": [{"id": "agent-call", "tool": "inc", "input": 2}]}
+
+    def inc(value):
+        nonlocal effect_calls
+        effect_calls += 1
+        return value + 1
+
+    flow = seq(
+        call(mcp("srv", "inc")),
+        app(
+            "controller",
+            tools=["inc"],
+            tool_aliases={"inc": "srv/inc"},
+            max_rounds=2,
+            native_tools=True,
+        ),
+    )
+    fr = freeze(flow, read_snapshot("inc"))
+    env = InMemoryEnv(
+        fr.manifest,
+        ProjectionEmitter(InMemoryProjection()),
+        tools={"srv/inc": inc},
+        reasoners={"controller": controller},
+        max_calls={"srv/inc": 1},
+    )
+
+    out = run(interpret(fr.flow, 0, env))
+
+    assert out.value["status"] == "denied"
+    assert out.value["reason"] == "tool 'inc' exceeded maxCalls=1"
+    assert effect_calls == 1
+    assert env.call_counts == {"srv/inc": 1}
+
+
 def test_stage_compiles_then_runs_plan_with_late_binding():
     # The planner returns an UNFROZEN plan; the interpreter late-binds its calls
     # by tool ref (admission would have vetted them in the real pipeline).

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -12,6 +12,7 @@ from julep import (
 )
 from julep.errors import CapabilityDenied
 from julep.execution.interpreter import InMemoryEnv, _retry_backoff_for_call, interpret
+from julep.execution.llm_result import LlmCallMeta, LlmResult
 if HAVE_TEMPORAL:
     from julep.execution.harness import ExecutionPolicy, _TemporalEnv
 from julep.projection import EventType, InMemoryProjection, ProjectionEmitter
@@ -292,6 +293,48 @@ def test_reasoner_reported_cost_metadata_overrides_default():
     run(interpret(fr.flow, "doc", env))
 
     assert store.cost_by_shape()["Pipeline"] == pytest.approx(0.33)
+
+
+def test_unpriced_reasoner_projection_cost_is_unknown_not_estimator_default():
+    flow = think("unpriced")
+    fr, env, store = _env_and_store(
+        flow,
+        reasoners={"unpriced": lambda value: value},
+    )
+
+    run(interpret(fr.flow, "doc", env))
+
+    did = next(event for event in store.events() if event.type == EventType.DID)
+    assert did.cost is None
+    assert did.attrs["llm.cost.status"] == "unknown"
+    assert store.cost_by_shape() == {}
+
+
+def test_llm_result_reported_cost_reaches_projection():
+    flow = think("metered-meta")
+    fr, env, store = _env_and_store(
+        flow,
+        reasoners={
+            "metered-meta": lambda value: LlmResult(
+                value,
+                LlmCallMeta(
+                    served_model="openai/gpt-test",
+                    provider="openai",
+                    input_tokens=10,
+                    output_tokens=2,
+                    total_tokens=12,
+                    cost=0.00042,
+                ),
+            )
+        },
+    )
+
+    run(interpret(fr.flow, "doc", env))
+
+    did = next(event for event in store.events() if event.type == EventType.DID)
+    assert did.cost == pytest.approx(0.00042)
+    assert did.attrs["llm.cost.status"] == "reported"
+    assert store.cost_by_shape()["Pipeline"] == pytest.approx(0.00042)
 
 
 def test_alt_routes_by_pure_predicate():

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from julep import (
@@ -9,8 +11,9 @@ from julep import (
     arr, call, mcp, think, seq, par, alt, iter_up_to, stage, app,
     sub, race, quorum, human_gate, Contract, freeze, register_pure,
     HAVE_TEMPORAL, CapabilityOverrides, ToolContract, Effect, Idempotency,
+    snapshot_from_listings,
 )
-from julep.errors import CapabilityDenied
+from julep.errors import CapabilityDenied, ToolInputValidation
 from julep.execution.interpreter import InMemoryEnv, _retry_backoff_for_call, interpret
 from julep.execution.llm_result import LlmCallMeta, LlmResult
 if HAVE_TEMPORAL:
@@ -47,6 +50,19 @@ def test_pipeline_threads_value():
     assert out.value == 12  # (5+1)*2
 
 
+def test_in_memory_tool_awaits_async_result():
+    async def async_inc(value):
+        await asyncio.sleep(0)
+        return value + 1
+
+    flow = call(mcp("srv", "inc"))
+    fr, env = _env(flow, tools={"srv/inc": async_inc})
+
+    out = run(interpret(fr.flow, 5, env))
+
+    assert out.value == 6
+
+
 def test_mcp_call_seam_receives_identity_cid_and_principal():
     seen = {}
 
@@ -70,7 +86,7 @@ def test_mcp_call_seam_receives_identity_cid_and_principal():
     }
 
 
-def test_direct_mcp_call_does_not_claim_agent_schema_validation():
+def test_direct_frozen_mcp_call_reports_schema_validation():
     seen = {}
 
     async def mcp_call(
@@ -88,7 +104,44 @@ def test_direct_mcp_call_does_not_claim_agent_schema_validation():
     out = run(interpret(fr.flow, {"query": "hello"}, env))
 
     assert out.value == {"query": "hello"}
-    assert seen == {"run_secrets": None, "input_schema_validated": False}
+    assert seen == {"run_secrets": None, "input_schema_validated": True}
+
+
+def test_direct_frozen_mcp_call_rejects_invalid_input_before_dispatch():
+    calls = 0
+
+    async def mcp_call(
+        server, tool, value, cid, principal, run_secrets, input_schema_validated
+    ):
+        nonlocal calls
+        calls += 1
+        return value
+
+    snapshot = snapshot_from_listings(
+        {
+            "srv": {
+                "typed": {
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                        "required": ["query"],
+                    }
+                }
+            }
+        }
+    )
+    flow = call(mcp("srv", "typed"))
+    fr = freeze(flow, snapshot)
+    env = InMemoryEnv(
+        fr.manifest,
+        ProjectionEmitter(InMemoryProjection()),
+        mcp_call=mcp_call,
+    )
+
+    with pytest.raises(ToolInputValidation, match="srv/typed"):
+        run(interpret(fr.flow, {"query": 7}, env))
+
+    assert calls == 0
 
 
 def test_retryable_call_retries_to_success_with_backoff_sleeps():

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -526,6 +526,102 @@ def test_in_memory_agent_enforces_release_max_calls_across_rounds():
     assert env.call_counts == {"srv/inc": 1}
 
 
+def test_in_memory_agent_shares_max_calls_across_aliases_for_one_wire():
+    model_calls = 0
+    effect_inputs = []
+
+    def controller(_value):
+        nonlocal model_calls
+        model_calls += 1
+        if model_calls <= 2:
+            alias = "a" if model_calls == 1 else "b"
+            return {
+                "tool_calls": [
+                    {
+                        "id": f"call-{alias}",
+                        "tool": alias,
+                        "input": {"alias": alias},
+                    }
+                ]
+            }
+        return {"done": True, "output": "unexpected"}
+
+    def effect(value):
+        effect_inputs.append(value)
+        return value
+
+    flow = app(
+        "controller",
+        tools=["a", "b"],
+        tool_aliases={"a": "srv/t", "b": "srv/t"},
+        max_rounds=3,
+        native_tools=True,
+    )
+    fr = freeze(flow, read_snapshot("t"))
+    env = InMemoryEnv(
+        fr.manifest,
+        ProjectionEmitter(InMemoryProjection()),
+        tools={"srv/t": effect},
+        reasoners={"controller": controller},
+        max_calls={"srv/t": 1},
+    )
+
+    out = run(interpret(fr.flow, {}, env))
+
+    assert out.value["status"] == "denied"
+    assert out.value["reason"] == "tool 'b' exceeded maxCalls=1"
+    assert model_calls == 2
+    assert effect_inputs == [{"alias": "a"}]
+    assert env.call_counts == {"srv/t": 1}
+
+
+def test_in_memory_agent_uses_wire_limit_when_alias_matches_native_key():
+    model_calls = 0
+    effect_calls = 0
+
+    def controller(_value):
+        nonlocal model_calls
+        model_calls += 1
+        return {
+            "tool_calls": [
+                {
+                    "id": f"search-{model_calls}",
+                    "tool": "search",
+                    "input": {"query": "q"},
+                }
+            ]
+        }
+
+    def mcp_search(value):
+        nonlocal effect_calls
+        effect_calls += 1
+        return value
+
+    flow = app(
+        "controller",
+        tools=["search"],
+        tool_aliases={"search": "srv/search"},
+        max_rounds=3,
+        native_tools=True,
+    )
+    fr = freeze(flow, read_snapshot("search"))
+    env = InMemoryEnv(
+        fr.manifest,
+        ProjectionEmitter(InMemoryProjection()),
+        tools={"srv/search": mcp_search},
+        reasoners={"controller": controller},
+        max_calls={"search": 10, "srv/search": 1},
+    )
+    env.call_counts["search"] = 1
+
+    out = run(interpret(fr.flow, {}, env))
+
+    assert out.value["status"] == "denied"
+    assert out.value["reason"] == "tool 'search' exceeded maxCalls=1"
+    assert effect_calls == 1
+    assert env.call_counts == {"search": 1, "srv/search": 1}
+
+
 def test_in_memory_agent_inherits_calls_made_before_agent():
     effect_calls = 0
 
@@ -624,7 +720,9 @@ def test_temporal_env_inherits_call_counts_for_child_flows() -> None:
 
 
 @pytest.mark.skipif(not HAVE_TEMPORAL, reason="temporalio not installed")
-def test_temporal_env_merges_child_agent_call_counts(monkeypatch) -> None:
+def test_temporal_env_preserves_native_parent_count_and_uses_wire_alias_limit(
+    monkeypatch,
+) -> None:
     from julep.execution import harness
     from julep.execution.harness import ExecutionPolicy, _TemporalEnv
     from julep.projection import InMemoryProjection, ProjectionEmitter
@@ -632,17 +730,25 @@ def test_temporal_env_merges_child_agent_call_counts(monkeypatch) -> None:
     async def gate_waiter(value, cid, timeout_s):  # noqa: ANN001
         return value
 
+    child_inputs = []
+
     async def fake_execute_child_workflow(*args, **kwargs):  # noqa: ANN001
+        child_inputs.append(args[1])
         return {
             "status": "done",
             "output": "ok",
-            "callCounts": {"srv/inc": 2, "srv/other": "3"},
+            "callCounts": {"search": 1, "srv/search": 1},
         }
 
     monkeypatch.setattr(
         harness.workflow,
         "execute_child_workflow",
         fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(
+        harness,
+        "_agent_canonical_tool_counts_enabled",
+        lambda: True,
     )
 
     env = _TemporalEnv(
@@ -652,13 +758,26 @@ def test_temporal_env_merges_child_agent_call_counts(monkeypatch) -> None:
         manifest_json={},
         policy=ExecutionPolicy(),
         gate_waiter=gate_waiter,
-        max_call_limits={"srv/inc": 5, "srv/other": 5},
-        call_counts={"srv/inc": 1},
+        max_call_limits={"search": 10, "srv/search": 1},
+        call_counts={"search": 1},
     )
 
-    out = run(env.run_agent("controller", "value", "cid"))
+    out = run(
+        env.run_agent(
+            "controller",
+            "value",
+            "cid",
+            {
+                "tools": ["search"],
+                "toolAliases": {"search": "srv/search"},
+                "toolContracts": {"search": {}},
+            },
+        )
+    )
     assert out["output"] == "ok"
-    assert env.call_counts_snapshot() == {"srv/inc": 2, "srv/other": 3}
+    assert child_inputs[0].state["callCounts"] == {"search": 1}
+    assert child_inputs[0].granted_contracts["search"]["maxCalls"] == 1
+    assert env.call_counts_snapshot() == {"search": 1, "srv/search": 1}
 
 
 def test_inmemory_env_awaits_async_reasoner():

--- a/tests/test_litellm_adapter.py
+++ b/tests/test_litellm_adapter.py
@@ -220,6 +220,20 @@ def test_model_ladder_primary_suffix_wins_over_explicit_effort_on_fallback() -> 
     ]
 
 
+def test_model_ladder_deduplicates_equivalent_slug_spellings() -> None:
+    calls: list[str] = []
+
+    async def base(reasoner: Reasoner, *_args: Any) -> str:
+        calls.append(reasoner.model)
+        raise HttpError(503)
+
+    caller = with_model_ladder(base, models=["openai/gpt-5"])
+
+    with pytest.raises(ResilienceExhausted):
+        run(caller(Reasoner("r", "openai:gpt-5"), "value"))
+    assert calls == ["openai:gpt-5"]
+
+
 def test_model_ladder_fails_fast_on_configuration_error() -> None:
     calls: list[str] = []
 

--- a/tests/test_litellm_adapter.py
+++ b/tests/test_litellm_adapter.py
@@ -87,6 +87,40 @@ def test_litellm_caller_is_canonical_and_injectable() -> None:
     assert seen["parallel_tool_calls"] is False
 
 
+def test_model_ladder_and_litellm_adapter_fail_over_as_one_execution_seam() -> None:
+    payloads: list[dict[str, Any]] = []
+
+    async def fake_acompletion(**kwargs: Any) -> Any:
+        payloads.append(kwargs)
+        if len(payloads) == 1:
+            raise HttpError(503)
+        return _completion("fallback reply")
+
+    caller = with_model_ladder(
+        litellm_caller(acompletion=fake_acompletion),
+        models=["anthropic:claude-sonnet-4-6@medium"],
+    )
+    result = run(
+        caller(
+            Reasoner("summary", "openrouter:openai/gpt-5@high"),
+            {"text": "summarize me"},
+        )
+    )
+
+    assert result.reply == "fallback reply"
+    assert payloads[0]["model"] == "openrouter/openai/gpt-5"
+    assert payloads[0]["extra_body"] == {"reasoning": {"effort": "high"}}
+    assert payloads[1]["model"] == "anthropic/claude-sonnet-4-6"
+    assert payloads[1]["thinking"] == {
+        "type": "enabled",
+        "budget_tokens": 2048,
+    }
+    assert [attempt.outcome for attempt in result.meta.attempts] == [
+        "transient",
+        "ok",
+    ]
+
+
 class HttpError(Exception):
     def __init__(self, status_code: int) -> None:
         self.status_code = status_code

--- a/tests/test_litellm_adapter.py
+++ b/tests/test_litellm_adapter.py
@@ -41,6 +41,15 @@ def test_prepare_litellm_payload_maps_provider_reasoning_contracts() -> None:
     assert fireworks["model"] == "fireworks_ai/accounts/acme/deployments/model"
     assert fireworks["reasoning_effort"] == "low"
 
+    fireworks_slash = prepare_litellm_payload(
+        {"model": "fireworks/accounts/acme/deployments/model@high"}
+    )
+    assert fireworks_slash["model"] == "fireworks_ai/accounts/acme/deployments/model"
+    assert fireworks_slash["reasoning_effort"] == "high"
+
+    google_slash = prepare_litellm_payload({"model": "google/gemini-2.5-pro"})
+    assert google_slash["model"] == "gemini/gemini-2.5-pro"
+
 
 def test_prepare_litellm_payload_clamps_direct_openai_gpt5_temperature() -> None:
     prepared = prepare_litellm_payload(
@@ -85,6 +94,22 @@ def test_litellm_caller_is_canonical_and_injectable() -> None:
     assert seen["timeout"] == 17.0
     assert seen["tools"] == [{"type": "function", "function": {"name": "lookup"}}]
     assert seen["parallel_tool_calls"] is False
+
+
+def test_litellm_caller_normalizes_slash_slug_before_provider_dispatch() -> None:
+    seen: dict[str, Any] = {}
+
+    async def fake_acompletion(**kwargs: Any) -> Any:
+        seen.update(kwargs)
+        return _completion()
+
+    caller = litellm_caller(acompletion=fake_acompletion)
+    result = run(caller(Reasoner("summary", "openai/gpt-5@high"), "hello"))
+
+    assert result.reply == "ok"
+    assert seen["model"] == "openai/gpt-5"
+    assert seen["reasoning_effort"] == "high"
+    assert "thinking" not in seen
 
 
 def test_model_ladder_and_litellm_adapter_fail_over_as_one_execution_seam() -> None:
@@ -153,6 +178,46 @@ def test_model_ladder_advances_only_for_provider_transient_errors() -> None:
     ]
     assert [item.outcome for item in attempts] == ["transient", "ok"]
     assert [item.outcome for item in result.meta.attempts] == ["transient", "ok"]
+
+
+def test_model_ladder_inherits_effort_suffix_from_primary_on_fallback() -> None:
+    calls: list[tuple[str, str | None]] = []
+
+    async def base(reasoner: Reasoner, *_args: Any) -> str:
+        calls.append((reasoner.model, reasoner.reasoning_effort))
+        if len(calls) == 1:
+            raise HttpError(503)
+        return "ok"
+
+    caller = with_model_ladder(base, models=["anthropic:claude-sonnet-4-6"])
+    assert run(caller(Reasoner("r", "openai/gpt-5@high"), "value")) == "ok"
+    assert calls == [
+        ("openai:gpt-5", "high"),
+        ("anthropic:claude-sonnet-4-6", "high"),
+    ]
+
+
+def test_model_ladder_primary_suffix_wins_over_explicit_effort_on_fallback() -> None:
+    calls: list[tuple[str, str | None]] = []
+
+    async def base(reasoner: Reasoner, *_args: Any) -> str:
+        calls.append((reasoner.model, reasoner.reasoning_effort))
+        if len(calls) == 1:
+            raise HttpError(503)
+        return "ok"
+
+    caller = with_model_ladder(base, models=["anthropic:claude-sonnet-4-6"])
+    reasoner = Reasoner(
+        "r",
+        "openai/gpt-5@high",
+        reasoning_effort="low",
+    )
+
+    assert run(caller(reasoner, "value")) == "ok"
+    assert calls == [
+        ("openai:gpt-5", "high"),
+        ("anthropic:claude-sonnet-4-6", "high"),
+    ]
 
 
 def test_model_ladder_fails_fast_on_configuration_error() -> None:

--- a/tests/test_litellm_adapter.py
+++ b/tests/test_litellm_adapter.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from conftest import run
+from julep.dotctx import Reasoner
+from julep.errors import ResilienceExhausted
+from julep.execution.llm_result import LlmCallMeta, LlmResult
+from julep.llm import litellm_caller, prepare_litellm_payload, with_model_ladder
+from julep.qos import ReasonerDispatch
+from julep.resilience import AttemptRecord
+
+
+def _completion(content: str = "ok") -> Any:
+    message = SimpleNamespace(content=content, parsed=None)
+    choice = SimpleNamespace(message=message)
+    return SimpleNamespace(choices=[choice], usage=None, model="served")
+
+
+def test_prepare_litellm_payload_maps_provider_reasoning_contracts() -> None:
+    openrouter = prepare_litellm_payload(
+        {"model": "openrouter:openai/gpt-5@high", "reasoning_effort": "low"}
+    )
+    assert openrouter["model"] == "openrouter/openai/gpt-5"
+    assert openrouter["extra_body"] == {"reasoning": {"effort": "high"}}
+    assert "reasoning_effort" not in openrouter
+
+    anthropic = prepare_litellm_payload(
+        {"model": "anthropic:claude-sonnet-4-6", "reasoning_effort": "medium"}
+    )
+    assert anthropic["thinking"] == {"type": "enabled", "budget_tokens": 2048}
+    assert anthropic["temperature"] == 1.0
+    assert "reasoning_effort" not in anthropic
+
+    fireworks = prepare_litellm_payload(
+        {"model": "fireworks:accounts/acme/deployments/model", "reasoning_effort": "low"}
+    )
+    assert fireworks["model"] == "fireworks_ai/accounts/acme/deployments/model"
+    assert fireworks["reasoning_effort"] == "low"
+
+
+def test_prepare_litellm_payload_clamps_direct_openai_gpt5_temperature() -> None:
+    prepared = prepare_litellm_payload(
+        {
+            "model": "openai:gpt-5.4-mini",
+            "reasoning_effort": "high",
+            "temperature": 0.2,
+        }
+    )
+    assert prepared["model"] == "openai/gpt-5.4-mini"
+    assert prepared["temperature"] == 1.0
+    assert prepared["allowed_openai_params"] == ["reasoning_effort"]
+
+
+def test_litellm_caller_is_canonical_and_injectable() -> None:
+    seen: dict[str, Any] = {}
+
+    async def fake_acompletion(**kwargs: Any) -> Any:
+        seen.update(kwargs)
+        return _completion()
+
+    caller = litellm_caller(request_timeout_s=17.0, acompletion=fake_acompletion)
+    reasoner = Reasoner(
+        name="summary",
+        model="openrouter:openai/gpt-5",
+        reasoning_effort="high",
+    )
+    result = run(
+        caller(
+            reasoner,
+            {"text": "hello"},
+            None,
+            None,
+            ReasonerDispatch(),
+            tools=[{"type": "function", "function": {"name": "lookup"}}],
+            parallel_tool_calls=False,
+        )
+    )
+    assert result.reply == "ok"
+    assert seen["model"] == "openrouter/openai/gpt-5"
+    assert seen["extra_body"] == {"reasoning": {"effort": "high"}}
+    assert seen["timeout"] == 17.0
+    assert seen["tools"] == [{"type": "function", "function": {"name": "lookup"}}]
+    assert seen["parallel_tool_calls"] is False
+
+
+class HttpError(Exception):
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+        super().__init__(f"HTTP {status_code}")
+
+
+def test_model_ladder_advances_only_for_provider_transient_errors() -> None:
+    calls: list[tuple[str, str | None]] = []
+    attempts: list[AttemptRecord] = []
+
+    async def base(reasoner: Reasoner, *_args: Any) -> Any:
+        calls.append((reasoner.model, reasoner.reasoning_effort))
+        if len(calls) == 1:
+            raise HttpError(503)
+        return LlmResult(
+            "rescued",
+            LlmCallMeta(served_model=reasoner.model, provider="anthropic"),
+        )
+
+    caller = with_model_ladder(
+        base,
+        models=["anthropic:claude-sonnet-4-6@medium"],
+        on_attempt=attempts.append,
+    )
+    result = run(caller(Reasoner("r", "openai:gpt-5@low"), "value"))
+    assert result.reply == "rescued"
+    assert calls == [
+        ("openai:gpt-5", "low"),
+        ("anthropic:claude-sonnet-4-6", "medium"),
+    ]
+    assert [item.outcome for item in attempts] == ["transient", "ok"]
+    assert [item.outcome for item in result.meta.attempts] == ["transient", "ok"]
+
+
+def test_model_ladder_fails_fast_on_configuration_error() -> None:
+    calls: list[str] = []
+
+    async def base(reasoner: Reasoner, *_args: Any) -> Any:
+        calls.append(reasoner.model)
+        raise HttpError(401)
+
+    caller = with_model_ladder(base, models=["anthropic:fallback"])
+    with pytest.raises(HttpError):
+        run(caller(Reasoner("r", "openai:primary"), "value"))
+    assert calls == ["openai:primary"]
+
+
+def test_model_ladder_exhaustion_keeps_attempt_provenance() -> None:
+    async def base(_reasoner: Reasoner, *_args: Any) -> Any:
+        raise TimeoutError("slow")
+
+    caller = with_model_ladder(base, models=["anthropic:fallback"])
+    with pytest.raises(ResilienceExhausted) as excinfo:
+        run(caller(Reasoner("r", "openai:primary"), "value"))
+    assert [item.model for item in excinfo.value.attempts] == [
+        "openai:primary",
+        "anthropic:fallback",
+    ]
+
+
+def test_model_ladder_forwards_native_tool_options() -> None:
+    seen: dict[str, Any] = {}
+
+    async def base(_reasoner: Reasoner, _value: Any, *_args: Any, **kwargs: Any) -> str:
+        seen.update(kwargs)
+        return "ok"
+
+    caller = with_model_ladder(base, models=[])
+    result = run(
+        caller(
+            Reasoner("r", "openai:primary"),
+            "value",
+            tools=[{"type": "function", "function": {"name": "lookup"}}],
+            parallel_tool_calls=True,
+        )
+    )
+    assert result == "ok"
+    assert seen == {
+        "tools": [{"type": "function", "function": {"name": "lookup"}}],
+        "parallel_tool_calls": True,
+    }

--- a/tests/test_local_pipeline.py
+++ b/tests/test_local_pipeline.py
@@ -1,0 +1,433 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from conftest import run
+from julep.contracts import McpAnnotations
+from julep.dotctx import Reasoner
+from julep.execution.effects import WorkerContext
+from julep.freeze import McpServerSnapshot, McpSnapshot, McpToolSpec
+from julep.local import (
+    LocalExecutionConfigurationError,
+    LocalExecutionUnsupported,
+    LocalPipelineNotFound,
+    arun_local_pipeline,
+    prepare_local_pipeline,
+    run_local_pipeline,
+)
+from julep.qos import QoSTier
+from julep.registry import Registry
+
+
+def _reasoner_project(root: Path) -> None:
+    package = root / "summary.ctx"
+    package.mkdir()
+    (package / "settings.yaml").write_text(
+        """
+model: test:summary
+system: Summarize the supplied value.
+reply_schema:
+  type: object
+  properties:
+    answer:
+      type: string
+  required: [answer]
+""".strip(),
+        encoding="utf-8",
+    )
+    (root / "pyproject.toml").write_text(
+        """
+[tool.julep]
+
+[tool.julep.pipeline.summary]
+ctx = "summary.ctx"
+""".strip(),
+        encoding="utf-8",
+    )
+
+
+def _tool_agent_project(root: Path) -> None:
+    package = root / "agent.ctx"
+    package.mkdir()
+    (package / "settings.yaml").write_text(
+        """
+model: test:agent
+max_rounds: 2
+""".strip(),
+        encoding="utf-8",
+    )
+    (package / "prompt.j2").write_text(
+        """
+<<< role:system >>>
+Use lookup once, then finish.
+<<< role:user >>>
+{{ value }}
+""".strip(),
+        encoding="utf-8",
+    )
+    (package / "schema.pyi").write_text(
+        """
+class Input:
+    query: str
+
+class Output:
+    answer: str
+""".strip(),
+        encoding="utf-8",
+    )
+    (package / "tools.pyi").write_text(
+        """
+def lookup(query: str) -> dict:
+    \"\"\"Look up one query.\"\"\"
+    ...
+""".strip(),
+        encoding="utf-8",
+    )
+    (root / "pyproject.toml").write_text(
+        """
+[tool.julep]
+
+[tool.julep.mcp.servers.srv]
+url = "http://mcp.test"
+
+[tool.julep.pipeline.agent]
+ctx = "agent.ctx"
+
+[tool.julep.pipeline.agent.tools]
+lookup = "srv:lookup"
+""".strip(),
+        encoding="utf-8",
+    )
+
+
+def _lookup_snapshot() -> McpSnapshot:
+    return McpSnapshot(
+        servers={
+            "srv": McpServerSnapshot(
+                server="srv",
+                version="1",
+                tools={
+                    "lookup": McpToolSpec(
+                        input_schema={
+                            "type": "object",
+                            "properties": {"query": {"type": "string"}},
+                            "required": ["query"],
+                        },
+                        annotations=McpAnnotations(
+                            read_only_hint=True,
+                            idempotent_hint=True,
+                        ),
+                    )
+                },
+            )
+        }
+    )
+
+
+def test_async_configured_pipeline_uses_canonical_caller_and_principal(
+    tmp_path: Path,
+) -> None:
+    _reasoner_project(tmp_path)
+    seen: dict[str, Any] = {}
+
+    async def llm(
+        reasoner: Any,
+        value: Any,
+        principal: Any,
+        transcript: Any,
+        dispatch: Any,
+    ) -> Any:
+        seen.update(
+            reasoner=reasoner,
+            value=value,
+            principal=principal,
+            transcript=transcript,
+            dispatch=dispatch,
+        )
+        return {"answer": value["text"].upper()}
+
+    result = run(
+        arun_local_pipeline(
+            "summary",
+            {"text": "hello", "transcript": ["ordinary business input"]},
+            project_root=tmp_path,
+            llm=llm,
+            principal={"tenant": "acme"},
+        )
+    )
+
+    assert result == {"answer": "HELLO"}
+    assert seen["reasoner"].name == "summary.ctx"
+    assert seen["value"]["transcript"] == ["ordinary business input"]
+    assert seen["principal"] == {"tenant": "acme"}
+    assert seen["transcript"] is None
+    assert seen["dispatch"].qos is QoSTier.STANDARD
+
+
+def test_prepared_pipeline_is_reusable_and_sync_context_supplies_llm(
+    tmp_path: Path,
+) -> None:
+    _reasoner_project(tmp_path)
+    calls: list[Any] = []
+
+    async def llm(
+        _reasoner: Any,
+        value: Any,
+        _principal: Any,
+        _transcript: Any,
+        _dispatch: Any,
+    ) -> Any:
+        calls.append(value)
+        return {"answer": str(value["n"])}
+
+    prepared = prepare_local_pipeline("summary", project_root=tmp_path)
+    artifact_hash = prepared.artifact_hash
+
+    assert prepared.run({"n": 1}, context=WorkerContext(llm=llm)) == {
+        "answer": "1"
+    }
+    assert prepared.run({"n": 2}, context=WorkerContext(llm=llm)) == {
+        "answer": "2"
+    }
+    assert prepared.artifact_hash == artifact_hash
+    assert calls == [{"n": 1}, {"n": 2}]
+
+
+def test_tool_agent_uses_frozen_defs_mcp_context_and_principal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("jinja2")
+    _tool_agent_project(tmp_path)
+    monkeypatch.setattr(
+        "julep.mcp_snapshot.snapshot_servers",
+        lambda *_args, **_kwargs: _lookup_snapshot(),
+    )
+    model_calls: list[dict[str, Any]] = []
+    effect_calls: list[dict[str, Any]] = []
+
+    async def llm(
+        reasoner: Any,
+        value: Any,
+        principal: Any,
+        transcript: Any,
+        dispatch: Any,
+        **kwargs: Any,
+    ) -> Any:
+        model_calls.append(
+            {
+                "reasoner": reasoner,
+                "value": value,
+                "principal": principal,
+                "transcript": transcript,
+                "dispatch": dispatch,
+                "tools": kwargs.get("tools"),
+            }
+        )
+        if len(model_calls) == 1:
+            return {
+                "tool_calls": [
+                    {
+                        "id": "lookup-1",
+                        "tool": "lookup",
+                        "input": value["input"],
+                    }
+                ]
+            }
+        observation = value["input"][0]["output"]
+        return {"done": True, "output": {"answer": observation["found"]}}
+
+    async def mcp(
+        server: str,
+        tool: str,
+        value: Any,
+        cid: str,
+        principal: Any,
+        secrets: Any,
+        input_schema_validated: bool,
+    ) -> Any:
+        effect_calls.append(
+            {
+                "server": server,
+                "tool": tool,
+                "value": value,
+                "cid": cid,
+                "principal": principal,
+                "secrets": secrets,
+                "validated": input_schema_validated,
+            }
+        )
+        return {"found": value["query"].upper()}
+
+    result = run(
+        arun_local_pipeline(
+            "agent",
+            {"query": "julep"},
+            project_root=tmp_path,
+            llm=llm,
+            context=WorkerContext(mcp_call=mcp),
+            principal={"tenant": "acme"},
+        )
+    )
+
+    assert result["status"] == "done"
+    assert result["output"] == {"answer": "JULEP"}
+    assert model_calls[0]["tools"][0]["function"]["name"] == "lookup"
+    assert model_calls[0]["principal"] == {"tenant": "acme"}
+    assert effect_calls == [
+        {
+            "server": "srv",
+            "tool": "lookup",
+            "value": {"query": "julep"},
+            "cid": effect_calls[0]["cid"],
+            "principal": {"tenant": "acme"},
+            "secrets": None,
+            "validated": True,
+        }
+    ]
+
+
+def test_tool_agent_rejects_caller_without_tools_extension(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("jinja2")
+    _tool_agent_project(tmp_path)
+    monkeypatch.setattr(
+        "julep.mcp_snapshot.snapshot_servers",
+        lambda *_args, **_kwargs: _lookup_snapshot(),
+    )
+
+    async def strict_five(
+        _reasoner: Any,
+        _value: Any,
+        _principal: Any,
+        _transcript: Any,
+        _dispatch: Any,
+    ) -> Any:
+        return {"done": True, "output": {"answer": "unused"}}
+
+    async def mcp(*_args: Any) -> Any:
+        return {}
+
+    with pytest.raises(LocalExecutionConfigurationError, match="tools= keyword"):
+        run(
+            arun_local_pipeline(
+                "agent",
+                {"query": "julep"},
+                project_root=tmp_path,
+                llm=strict_five,
+                context=WorkerContext(mcp_call=mcp),
+            )
+        )
+
+
+def test_local_pipeline_errors_are_typed_and_actionable(tmp_path: Path) -> None:
+    _reasoner_project(tmp_path)
+
+    with pytest.raises(LocalPipelineNotFound, match="configured pipelines: summary"):
+        prepare_local_pipeline("missing", project_root=tmp_path)
+
+    with pytest.raises(LocalPipelineNotFound, match="unknown environment 'prod'"):
+        prepare_local_pipeline("summary", project_root=tmp_path, env="prod")
+
+    with pytest.raises(LocalExecutionConfigurationError, match="pass llm="):
+        run(arun_local_pipeline("summary", {}, project_root=tmp_path))
+
+    async def llm(
+        _reasoner: Any,
+        _value: Any,
+        _principal: Any,
+        _transcript: Any,
+        _dispatch: Any,
+    ) -> Any:
+        return {"answer": "unused"}
+
+    registry = Registry()
+    registry.register_reasoner(Reasoner("summary.ctx", "test:different"))
+    prepared = prepare_local_pipeline("summary", project_root=tmp_path)
+    with pytest.raises(LocalExecutionConfigurationError, match="compiled declaration"):
+        prepared.run(context=WorkerContext(llm=llm, registry=registry))
+
+
+def test_sync_helper_rejects_an_active_event_loop(tmp_path: Path) -> None:
+    _reasoner_project(tmp_path)
+
+    async def llm(
+        _reasoner: Any,
+        _value: Any,
+        _principal: Any,
+        _transcript: Any,
+        _dispatch: Any,
+    ) -> Any:
+        return {"answer": "ok"}
+
+    async def inside_loop() -> None:
+        with pytest.raises(LocalExecutionConfigurationError, match="active event loop"):
+            run_local_pipeline("summary", {}, project_root=tmp_path, llm=llm)
+
+    asyncio.run(inside_loop())
+
+
+def test_transcript_scoped_agent_fails_before_model_io(tmp_path: Path) -> None:
+    (tmp_path / "foreground_app.py").write_text(
+        """
+from julep import (
+    Application,
+    ContextPolicy,
+    ContextScope,
+    PipelineSpec,
+    Reasoner,
+    app,
+)
+
+reasoner = Reasoner("scoped", "test:scoped")
+application = Application(
+    "foreground-test",
+    [
+        PipelineSpec(
+            name="scoped",
+            flow=app(
+                "scoped",
+                max_rounds=1,
+                ctx=ContextPolicy(
+                    scope=ContextScope.WHOLE_SESSION,
+                    max_tokens=128,
+                ),
+            ),
+            reasoners=(reasoner,),
+        )
+    ],
+)
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[tool.julep]
+src = ["."]
+application = "foreground_app:application"
+""".strip(),
+        encoding="utf-8",
+    )
+    called = False
+
+    async def llm(
+        _reasoner: Any,
+        _value: Any,
+        _principal: Any,
+        _transcript: Any,
+        _dispatch: Any,
+    ) -> Any:
+        nonlocal called
+        called = True
+        return {"done": True, "output": "unused"}
+
+    prepared = prepare_local_pipeline("scoped", project_root=tmp_path)
+    with pytest.raises(LocalExecutionUnsupported, match="transcript-scoped"):
+        prepared.run({}, llm=llm)
+    assert called is False

--- a/tests/test_local_pipeline.py
+++ b/tests/test_local_pipeline.py
@@ -7,6 +7,15 @@ from typing import Any
 import pytest
 
 from conftest import run
+from julep import (
+    CapabilityManifest,
+    CompiledPipeline,
+    LocalPipeline,
+    PipelineSpec,
+    app,
+    deploy,
+    seq,
+)
 from julep.contracts import McpAnnotations
 from julep.dotctx import Reasoner
 from julep.execution.effects import WorkerContext
@@ -354,6 +363,81 @@ def test_tool_agent_uses_frozen_defs_mcp_context_and_principal(
     ]
 
 
+def test_local_pipeline_agent_enforces_deployment_max_calls_across_rounds() -> None:
+    reasoner = Reasoner("limited-controller", "test:limited")
+    snapshot = _lookup_snapshot()
+    flow = app(
+        reasoner.name,
+        tools=["lookup"],
+        tool_aliases={"lookup": "srv/lookup"},
+        max_rounds=3,
+        native_tools=True,
+    )
+    capabilities = CapabilityManifest.from_dict(
+        {"tools": [{"name": "srv/lookup", "maxCalls": 1}]}
+    )
+    spec = PipelineSpec(
+        name="limited-agent",
+        flow=flow,
+        reasoners=(reasoner,),
+        capabilities=capabilities,
+        snapshot=snapshot,
+    )
+    prepared = LocalPipeline(
+        name=spec.name,
+        environment="local",
+        compiled=CompiledPipeline(
+            spec=spec,
+            deployment=deploy(
+                flow,
+                snapshot=snapshot,
+                capabilities=capabilities,
+            ),
+            declared_schema_hash="test",
+            compiled_schema_hash="test",
+        ),
+        reasoners={reasoner.name: reasoner},
+    )
+    model_calls = 0
+    effect_calls = 0
+
+    async def llm(
+        _reasoner: Any,
+        _value: Any,
+        _principal: Any,
+        _transcript: Any,
+        _dispatch: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        nonlocal model_calls
+        model_calls += 1
+        return {
+            "tool_calls": [
+                {
+                    "id": f"lookup-{model_calls}",
+                    "tool": "lookup",
+                    "input": {"query": "julep"},
+                }
+            ]
+        }
+
+    async def mcp_call(*_args: Any, **_kwargs: Any) -> Any:
+        nonlocal effect_calls
+        effect_calls += 1
+        return {"found": "JULEP"}
+
+    result = prepared.run(
+        {"query": "julep"},
+        llm=llm,
+        context=WorkerContext(mcp_call=mcp_call),
+    )
+
+    assert result["status"] == "denied"
+    assert result["reason"] == "tool 'lookup' exceeded maxCalls=1"
+    assert model_calls == 2
+    assert effect_calls == 1
+
+
 def test_tool_agent_rejects_caller_without_tools_extension(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -433,6 +517,64 @@ def test_configured_local_pipeline_validates_frozen_mcp_before_dispatch(
     with pytest.raises(ToolInputValidation, match="srv/typed"):
         prepared.run({"query": 7}, context=context)
     assert len(calls) == 1
+
+
+def test_configured_local_pipeline_rejects_mixed_controller_tool_surfaces(
+) -> None:
+    model_called = False
+    reasoner = Reasoner("shared-controller", "test:shared")
+    snapshot = _lookup_snapshot()
+    flow = seq(
+        app(
+            reasoner.name,
+            tools=["lookup"],
+            tool_aliases={"lookup": "srv/lookup"},
+            max_rounds=1,
+            native_tools=True,
+        ),
+        app(reasoner.name, max_rounds=1),
+    )
+    spec = PipelineSpec(
+        name="mixed-controller-surface",
+        flow=flow,
+        reasoners=(reasoner,),
+        snapshot=snapshot,
+    )
+    prepared = LocalPipeline(
+        name=spec.name,
+        environment="local",
+        compiled=CompiledPipeline(
+            spec=spec,
+            deployment=deploy(flow, snapshot=snapshot),
+            declared_schema_hash="test",
+            compiled_schema_hash="test",
+        ),
+        reasoners={reasoner.name: reasoner},
+    )
+
+    async def llm(
+        _reasoner: Any,
+        _value: Any,
+        _principal: Any,
+        _transcript: Any,
+        _dispatch: Any,
+        *,
+        tools: Any = None,
+    ) -> Any:
+        del tools
+        nonlocal model_called
+        model_called = True
+        return {"done": True, "output": "unused"}
+
+    async def mcp_call(*_args: Any, **_kwargs: Any) -> Any:
+        return {"unused": True}
+
+    with pytest.raises(
+        LocalExecutionConfigurationError,
+        match="different frozen tool surfaces",
+    ):
+        prepared.run({}, llm=llm, context=WorkerContext(mcp_call=mcp_call))
+    assert model_called is False
 
 
 def test_local_pipeline_errors_are_typed_and_actionable(tmp_path: Path) -> None:

--- a/tests/test_local_pipeline.py
+++ b/tests/test_local_pipeline.py
@@ -10,6 +10,7 @@ from conftest import run
 from julep.contracts import McpAnnotations
 from julep.dotctx import Reasoner
 from julep.execution.effects import WorkerContext
+from julep.errors import ToolInputValidation
 from julep.freeze import McpServerSnapshot, McpSnapshot, McpToolSpec
 from julep.local import (
     LocalExecutionConfigurationError,
@@ -125,6 +126,68 @@ def _lookup_snapshot() -> McpSnapshot:
                 },
             )
         }
+    )
+
+
+def _direct_effect_project(root: Path) -> None:
+    module_name = f"direct_effect_app_{abs(hash(str(root)))}"
+    (root / f"{module_name}.py").write_text(
+        """
+import asyncio
+
+from julep import (
+    Application,
+    PipelineSpec,
+    call,
+    mcp,
+    snapshot_from_listings,
+    tool,
+)
+
+@tool(effect="read", idempotent=True)
+async def async_upper(value):
+    await asyncio.sleep(0)
+    return value.upper()
+
+typed_snapshot = snapshot_from_listings(
+    {
+        "srv": {
+            "typed": {
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                }
+            }
+        }
+    }
+)
+
+application = Application(
+    "direct-effects",
+    [
+        PipelineSpec(
+            name="async-native",
+            flow=async_upper,
+            tools=(async_upper,),
+        ),
+        PipelineSpec(
+            name="typed-mcp",
+            flow=call(mcp("srv", "typed")),
+            snapshot=typed_snapshot,
+        ),
+    ],
+)
+""".strip(),
+        encoding="utf-8",
+    )
+    (root / "pyproject.toml").write_text(
+        """
+[tool.julep]
+src = ["."]
+application = "{module_name}:application"
+""".strip().format(module_name=module_name),
+        encoding="utf-8",
     )
 
 
@@ -324,6 +387,52 @@ def test_tool_agent_rejects_caller_without_tools_extension(
                 context=WorkerContext(mcp_call=mcp),
             )
         )
+
+
+def test_configured_local_pipeline_awaits_async_native_tool(tmp_path: Path) -> None:
+    _direct_effect_project(tmp_path)
+    prepared = prepare_local_pipeline("async-native", project_root=tmp_path)
+
+    assert prepared.run("julep") == "JULEP"
+
+
+def test_configured_local_pipeline_validates_frozen_mcp_before_dispatch(
+    tmp_path: Path,
+) -> None:
+    _direct_effect_project(tmp_path)
+    calls: list[dict[str, Any]] = []
+
+    async def mcp(
+        server: str,
+        tool: str,
+        value: Any,
+        cid: str,
+        principal: Any,
+        secrets: Any,
+        input_schema_validated: bool,
+    ) -> Any:
+        calls.append(
+            {
+                "server": server,
+                "tool": tool,
+                "value": value,
+                "cid": cid,
+                "principal": principal,
+                "secrets": secrets,
+                "validated": input_schema_validated,
+            }
+        )
+        return {"result": value["query"]}
+
+    prepared = prepare_local_pipeline("typed-mcp", project_root=tmp_path)
+    context = WorkerContext(mcp_call=mcp)
+
+    assert prepared.run({"query": "ok"}, context=context) == {"result": "ok"}
+    assert calls[0]["validated"] is True
+
+    with pytest.raises(ToolInputValidation, match="srv/typed"):
+        prepared.run({"query": 7}, context=context)
+    assert len(calls) == 1
 
 
 def test_local_pipeline_errors_are_typed_and_actionable(tmp_path: Path) -> None:

--- a/tests/test_local_pipeline.py
+++ b/tests/test_local_pipeline.py
@@ -15,6 +15,7 @@ from julep import (
     app,
     deploy,
     seq,
+    think,
 )
 from julep.contracts import McpAnnotations
 from julep.dotctx import Reasoner
@@ -519,8 +520,7 @@ def test_configured_local_pipeline_validates_frozen_mcp_before_dispatch(
     assert len(calls) == 1
 
 
-def test_configured_local_pipeline_rejects_mixed_controller_tool_surfaces(
-) -> None:
+def test_configured_local_pipeline_rejects_mixed_controller_tool_surfaces() -> None:
     model_called = False
     reasoner = Reasoner("shared-controller", "test:shared")
     snapshot = _lookup_snapshot()
@@ -574,6 +574,163 @@ def test_configured_local_pipeline_rejects_mixed_controller_tool_surfaces(
         match="different frozen tool surfaces",
     ):
         prepared.run({}, llm=llm, context=WorkerContext(mcp_call=mcp_call))
+    assert model_called is False
+
+
+def test_local_pipeline_rejects_toolful_agent_and_think_reasoner_reuse() -> None:
+    reasoner = Reasoner("shared-think-controller", "test:shared")
+    snapshot = _lookup_snapshot()
+    flow = seq(
+        think(reasoner.name),
+        app(
+            reasoner.name,
+            tools=["lookup"],
+            tool_aliases={"lookup": "srv/lookup"},
+            max_rounds=1,
+            native_tools=True,
+        ),
+    )
+    spec = PipelineSpec(
+        name="mixed-think-agent-surface",
+        flow=flow,
+        reasoners=(reasoner,),
+        snapshot=snapshot,
+    )
+    prepared = LocalPipeline(
+        name=spec.name,
+        environment="local",
+        compiled=CompiledPipeline(
+            spec=spec,
+            deployment=deploy(flow, snapshot=snapshot),
+            declared_schema_hash="test",
+            compiled_schema_hash="test",
+        ),
+        reasoners={reasoner.name: reasoner},
+    )
+    model_called = False
+
+    async def llm(
+        _reasoner: Any,
+        _value: Any,
+        _principal: Any,
+        _transcript: Any,
+        _dispatch: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        nonlocal model_called
+        model_called = True
+        return {"done": True, "output": "unused"}
+
+    async def mcp_call(*_args: Any, **_kwargs: Any) -> Any:
+        return {"unused": True}
+
+    with pytest.raises(
+        LocalExecutionConfigurationError,
+        match="both ordinary foreground reasoning and a native-tool agent",
+    ):
+        prepared.run({}, llm=llm, context=WorkerContext(mcp_call=mcp_call))
+    assert model_called is False
+
+
+def test_local_pipeline_non_native_agent_does_not_send_provider_tools() -> None:
+    reasoner = Reasoner("legacy-controller", "test:legacy")
+    snapshot = _lookup_snapshot()
+    flow = app(
+        reasoner.name,
+        tools=["lookup"],
+        tool_aliases={"lookup": "srv/lookup"},
+        max_rounds=2,
+    )
+    spec = PipelineSpec(
+        name="legacy-agent",
+        flow=flow,
+        reasoners=(reasoner,),
+        snapshot=snapshot,
+    )
+    prepared = LocalPipeline(
+        name=spec.name,
+        environment="local",
+        compiled=CompiledPipeline(
+            spec=spec,
+            deployment=deploy(flow, snapshot=snapshot),
+            declared_schema_hash="test",
+            compiled_schema_hash="test",
+        ),
+        reasoners={reasoner.name: reasoner},
+    )
+    model_calls = 0
+    effect_calls = 0
+
+    async def strict_five_argument_llm(
+        _reasoner: Any,
+        _value: Any,
+        _principal: Any,
+        _transcript: Any,
+        _dispatch: Any,
+    ) -> Any:
+        nonlocal model_calls
+        model_calls += 1
+        if model_calls == 1:
+            return {"tool": "lookup", "input": {"query": "julep"}}
+        return {"done": True, "output": "done"}
+
+    async def mcp_call(*_args: Any, **_kwargs: Any) -> Any:
+        nonlocal effect_calls
+        effect_calls += 1
+        return {"found": "JULEP"}
+
+    result = prepared.run(
+        {"query": "julep"},
+        llm=strict_five_argument_llm,
+        context=WorkerContext(mcp_call=mcp_call),
+    )
+
+    assert result["status"] == "done"
+    assert result["output"] == "done"
+    assert model_calls == 2
+    assert effect_calls == 1
+
+
+def test_local_pipeline_rejects_agent_subflows_before_model_io() -> None:
+    reasoner = Reasoner("subflow-controller", "test:subflow")
+    snapshot = _lookup_snapshot()
+    flow = app(
+        reasoner.name,
+        subflows=["child"],
+        max_rounds=1,
+    )
+    spec = PipelineSpec(
+        name="agent-subflow",
+        flow=flow,
+        reasoners=(reasoner,),
+        snapshot=snapshot,
+    )
+    prepared = LocalPipeline(
+        name=spec.name,
+        environment="local",
+        compiled=CompiledPipeline(
+            spec=spec,
+            deployment=deploy(flow, snapshot=snapshot),
+            declared_schema_hash="test",
+            compiled_schema_hash="test",
+        ),
+        reasoners={reasoner.name: reasoner},
+    )
+    model_called = False
+
+    async def llm(
+        _reasoner: Any,
+        _value: Any,
+        _principal: Any,
+        _transcript: Any,
+        _dispatch: Any,
+    ) -> Any:
+        nonlocal model_called
+        model_called = True
+        return {"sub": "child", "input": {}}
+
+    with pytest.raises(LocalExecutionUnsupported, match="agent subflows"):
+        prepared.run({}, llm=llm)
     assert model_called is False
 
 

--- a/tests/test_p2_spike_episode.py
+++ b/tests/test_p2_spike_episode.py
@@ -28,6 +28,34 @@ def _canonical_ir(node: Node) -> str:
     return canonical_json(normalize_ids(Node.from_json(node.to_json())).to_json())
 
 
+def _spike_mcp_listings() -> dict[str, dict[str, object]]:
+    """Describe the compatibility payloads accepted by ``spike_mcp_call``."""
+    listings = episode.mcp_listings()
+    tools = listings[episode.MCP_SERVER]
+    tools["read_episode"]["inputSchema"] = {"type": "string"}
+    tools["write_summary_surfaces"]["inputSchema"] = {
+        "type": "object",
+        "properties": {
+            "episodeId": {"type": "string"},
+            "found": {"type": "boolean"},
+            "text": {"type": "string"},
+            "contentHash": {"type": "string"},
+            "summary": {"type": "string"},
+            "oneLiner": {"type": "string"},
+        },
+        "required": [
+            "episodeId",
+            "found",
+            "text",
+            "contentHash",
+            "summary",
+            "oneLiner",
+        ],
+        "additionalProperties": False,
+    }
+    return listings
+
+
 def _manual_spike_episode_ir() -> Node:
     happy_path = dsl.seq(
         dsl.arr("spike.assign_source"),
@@ -92,7 +120,7 @@ def test_spike_episode_slice_dry_run_rolls_up_artifact_statuses() -> None:
     episode.reset_store()
     deployment = deploy(
         episode_slice.BATCH.to_ir(),
-        mcp_listings=episode.mcp_listings(),
+        mcp_listings=_spike_mcp_listings(),
     )
 
     result = deployment.dry_run(

--- a/tests/test_reasoner_batch.py
+++ b/tests/test_reasoner_batch.py
@@ -456,7 +456,12 @@ async def _same_key_fresh_collectors_start_distinct_poll_workflows(
         )
 
         BlockingFakeBatch.release = True
-        out_a, out_b = await asyncio.gather(receiver_a.result(), receiver_b.result())
+        # Temporal 1.20's time-skipping test server cannot service two
+        # concurrent ``result()`` waiters because both try to unlock time
+        # skipping. Waiting sequentially still lets the server advance every
+        # workflow and preserves the two independent receiver assertions.
+        out_a = await receiver_a.result()
+        out_b = await receiver_b.result()
 
     assert out_a == "alpha"
     assert out_b == "beta"

--- a/tests/test_worker_store.py
+++ b/tests/test_worker_store.py
@@ -813,9 +813,9 @@ def test_bundle_runner_is_inert_without_store(tmp_path: Path) -> None:
 
 @pytest.mark.skipif(not HAVE_TEMPORAL, reason="temporalio not installed")
 def test_bundle_runner_forwards_current_workflow_instance_abstract_methods() -> None:
-    assert WorkflowInstance.__abstractmethods__ == frozenset(
-        {"activate", "get_serialization_context", "get_external_store_context", "get_info"}
-    )
+    abstract_methods = WorkflowInstance.__abstractmethods__
+    assert abstract_methods
+    assert abstract_methods <= _BundleResolvingInstance.__dict__.keys()
     assert _BundleResolvingInstance.__abstractmethods__ == frozenset()
 
 


### PR DESCRIPTION
## Summary

- Add service-free local API testing and configured foreground execution through create_local_app, julep run, prepare_local_pipeline run/arun, and serve api --local.
- Add a durable local development supervisor plus dry-run and prototyping surfaces without requiring an alternate SQLite data path.
- Add synchronous and asynchronous client run_and_wait APIs with idempotent submission, bounded polling, typed terminal failures, and timeout errors.
- Reject idempotency-key reuse across pipeline or effective-release boundaries while preserving same-run and matching retry behavior.
- Add the LiteLLM caller and model ladder, public dispatch and reasoner-replacement primitives, and stricter configuration lint and cost reporting.
- Harden tool-surface validation, wire-level agent budgets, local credential isolation, scoped dotctx schema-drift checks, and optional-Temporal boundaries.
- Refresh adoption, local execution, control-plane, and Python API documentation for the 3.0.0rc4 surface.

This PR is stacked on #1617.

## Validation

- Complete pytest matrix with Temporal current, Temporal absent, and minimum supported Temporal 1.20
- Ruff across the repository
- Strict mypy across 146 source files
- Distribution metadata and version test report 3.0.0rc4
- Docs-site type check and production build
- Independent Codex reviews with no remaining blockers
- git diff --check