### PR TITLE
ci: add tag-triggered PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,150 @@
+name: Publish
+
+# Publishes the `julep` distribution to PyPI.
+#
+# Normal path: push an annotated tag matching the version in pyproject.toml
+# (e.g. `v3.0.0rc5`) and this workflow builds, verifies, and uploads it.
+# Manual path: run via workflow_dispatch, which builds and verifies but only
+# uploads when `publish` is explicitly set to true.
+#
+# A PyPI version can never be replaced or re-uploaded, so the build job proves
+# the artifacts are installable before the publish job is allowed to run.
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Upload to PyPI (leave false to build and verify only)"
+        type: boolean
+        default: false
+
+# Never let two releases race to the same version.
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # uv is installed from PyPI rather than via a third-party setup action:
+      # this workflow handles a publish credential, so its action surface is
+      # kept to first-party actions/* only.
+      - name: Install uv
+        run: python -m pip install --upgrade uv
+
+      # On a tag push the tag is the release's source of truth, so a tag that
+      # disagrees with pyproject.toml is a mistake worth failing loudly on
+      # before anything reaches PyPI.
+      - name: Tag must match the packaged version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          pyproject_version="$(python -c '
+          import pathlib, tomllib
+          print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])
+          ')"
+          echo "tag=$tag_version pyproject=$pyproject_version"
+          if [ "$tag_version" != "$pyproject_version" ]; then
+            echo "::error::tag $GITHUB_REF_NAME implies version $tag_version but pyproject.toml declares $pyproject_version"
+            exit 1
+          fi
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Validate distribution metadata
+        run: uvx twine check dist/*
+
+      # The wheel ships package data (py.typed, the vendored wasm executor). A
+      # packaging regression that drops them is invisible until someone
+      # installs the release, so assert on the wheel contents here.
+      - name: Wheel must contain its package data
+        run: |
+          python - <<'EOF'
+          import glob, sys, zipfile
+
+          (wheel,) = glob.glob("dist/*.whl")
+          names = zipfile.ZipFile(wheel).namelist()
+          missing = [
+              expected
+              for expected in ("julep/py.typed", "julep/execution/_wasm/executor.wasm")
+              if expected not in names
+          ]
+          if missing:
+              sys.exit(f"{wheel} is missing package data: {missing}")
+          print(f"{wheel}: {len(names)} files, package data present")
+          EOF
+
+      # Install the built wheel into a clean environment with no extras, so a
+      # core module that grew an unconditional optional import cannot ship.
+      - name: Built wheel must install and import
+        run: |
+          uv venv /tmp/verify --python 3.12
+          uv pip install --python /tmp/verify/bin/python dist/*.whl
+          /tmp/verify/bin/python -c "import julep; print('import ok')"
+          /tmp/verify/bin/julep --version
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    name: Publish to PyPI
+    # Only the tag push, or a dispatch that explicitly opted in, uploads.
+    if: startsWith(github.ref, 'refs/tags/v') || inputs.publish
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: python -m pip install --upgrade uv
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Upload to PyPI
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}
+        run: uv publish dist/*
+
+      # Confirms the release is actually resolvable from the index rather than
+      # trusting the upload's exit code.
+      - name: Installed release must be importable from PyPI
+        run: |
+          version="$(python -c '
+          import glob, pathlib
+          # julep-3.0.0rc4-py3-none-any.whl -> 3.0.0rc4
+          print(pathlib.Path(glob.glob("dist/*.whl")[0]).name.split("-")[1])
+          ')"
+          echo "verifying julep==$version on PyPI"
+          uv venv /tmp/from-pypi --python 3.12
+          for attempt in 1 2 3 4 5; do
+            if uv pip install --python /tmp/from-pypi/bin/python --no-cache "julep==$version"; then
+              break
+            fi
+            echo "index not ready yet (attempt $attempt); retrying in 15s"
+            sleep 15
+          done
+          /tmp/from-pypi/bin/python -c "import julep; print('import ok')"
+          /tmp/from-pypi/bin/julep --version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,9 +21,11 @@ on:
         type: boolean
         default: false
 
-# Never let two releases race to the same version.
+# Never let two releases race to the same version. A single, ref-independent
+# group means a manual dispatch and a tag push queue up serially instead of
+# racing to upload the same immutable PyPI version from different commits.
 concurrency:
-  group: publish-${{ github.ref }}
+  group: publish-pypi
   cancel-in-progress: false
 
 permissions:
@@ -106,8 +108,12 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    # Only the tag push, or a dispatch that explicitly opted in, uploads.
-    if: startsWith(github.ref, 'refs/tags/v') || inputs.publish
+    # Only an actual tag push, or a dispatch that explicitly opted in, uploads.
+    # `github.event_name == 'push'` is required alongside the ref check: a
+    # workflow_dispatch run can itself target a `v*` tag ref, and without the
+    # event check that would satisfy the ref clause and publish regardless of
+    # the `publish` input.
+    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || inputs.publish
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -123,10 +129,13 @@ jobs:
           name: dist
           path: dist/
 
+      # --check-url lets a rerun (e.g. after the post-upload verification step
+      # below flakes transiently) succeed: uv skips any file already present
+      # on the index instead of failing on PyPI's immutable-file rule.
       - name: Upload to PyPI
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}
-        run: uv publish dist/*
+        run: uv publish dist/* --check-url https://pypi.org/simple/
 
       # Confirms the release is actually resolvable from the index rather than
       # trusting the upload's exit code.


### PR DESCRIPTION
## Why

`3.0.0rc4` was released by running `uv build && uv publish` from a laptop, with the PyPI token living in an unrelated repository's `.env`. There was no release workflow in this repo at all (`.github/workflows/` held only `ci.yml` and `docs-pages.yml`), so releases were neither reproducible nor auditable, and they depended on whoever happened to have the token locally.

## What

Adds `.github/workflows/publish.yml`. Pushing a `v*` tag builds, verifies, and uploads to PyPI using the new `UV_PUBLISH_TOKEN` repository secret. `workflow_dispatch` runs the identical build and verification but uploads only when its `publish` input is explicitly set to true, so the pipeline can be exercised without consuming a version number.

A PyPI version can never be replaced or re-uploaded, so the `build` job must prove the artifacts are good before `publish` is allowed to run:

- the tag must agree with the version in `pyproject.toml` (a tag/version mismatch fails before anything reaches the index);
- `twine check` must accept the sdist and wheel metadata;
- the wheel must still carry its package data — `py.typed` and the vendored `execution/_wasm/executor.wasm`, whose loss is invisible until a user installs the release;
- the wheel must install, import, and expose the `julep` console script in a clean 3.12 interpreter **with no extras**, which also guards the same no-optional-imports property `ci.yml`'s `bare-import` job protects.

After upload, the release is reinstalled from the index (with retries for index propagation) so success reflects a resolvable release rather than the upload's exit code.

`uv` is installed from PyPI instead of via a third-party setup action, keeping the action surface of a credential-handling job to first-party `actions/*` only.

## Notes for the reviewer

- **`UV_PUBLISH_TOKEN` is already set** as a repository secret, using the token verified working by the `3.0.0rc4` upload.
- A `PYPI_API_TOKEN` secret exists from 2025-06 and is **unused by this workflow** — its scope and validity are unknown, and it predates the 3.x line. Worth pruning separately if it's dead.
- Optional hardening not included here: point the workflow at a protected `pypi` GitHub Environment for a manual approval gate, or migrate to PyPI Trusted Publishing (OIDC) and drop the long-lived token entirely.
- Verified with `actionlint` (clean); the YAML parses, and both embedded version-extraction snippets and the package-data assertion were run locally against the real `dist/` artifacts.
- This branch contains only the workflow file; unrelated local edits to `.gitignore` and `FEEDBACK.md` were deliberately left out.

Base is `main`: `dev` is stale (last commit 2026-03, 4648 commits behind), and `main` is the repo default where recent PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/julep-ai/julep/pull/1622">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->