### PR TITLE
feat: dotctx skills and embedded execution surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
   project file or Kubernetes-derived application naming (FEEDBACK 37).
 - Configured `llm_caller` values now participate in embedded caller precedence,
   and `LlmResult`, `LlmCallMeta`, `AttemptMeta`, and `EmbeddedRun` are root-public.
+- `LlmUsage` gives model-call metadata a typed prompt/completion/total and cache
+  token shape. The LiteLLM caller captures that usage, preserves reported
+  prices, and can fail-soft derive missing prices from LiteLLM's pricing map.
+- `EmbeddedRun` now includes aggregate LLM usage and total price, with explicit
+  reported/derived/mixed/unknown status and completeness fields (FEEDBACK 38).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@
 - Configured `llm_caller` values now participate in embedded caller precedence,
   and `LlmResult`, `LlmCallMeta`, `AttemptMeta`, and `EmbeddedRun` are root-public.
 - `LlmUsage` gives model-call metadata a typed prompt/completion/total and cache
-  token shape. The LiteLLM caller captures that usage, preserves reported
-  prices, and can fail-soft derive missing prices from LiteLLM's pricing map.
+  token shape. The LiteLLM caller captures that usage, preserves explicitly
+  provider-attested prices, and classifies ambiguous attached or pricing-map
+  prices as derived metadata.
 - `EmbeddedRun` now includes aggregate LLM usage and total price, with explicit
   reported/derived/mixed/unknown status and completeness fields (FEEDBACK 38).
 - `julep run <package>.ctx` now records its local projection in the run cache,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@
 
 - Embedded retries now honor declared exponential backoff by default; direct
   dry-run callers can pass `sleeper=None` for record-only behavior (FEEDBACK 38).
+- A failing Helm smoke test now reports the smoke-test Job's logs. The
+  reconciler fetches them out of band on failure only, by label selector
+  (`kubectl logs --selector job-name=<release>-smoke`), because the Job's Pod
+  carries a generated suffix and the chart retains failed Jobs. Log retrieval
+  can never decide pass/fail: a missing `kubectl`, a denied RBAC rule, or an
+  empty log leaves the original Helm failure intact with a
+  `smoke-test logs unavailable` note (FEEDBACK 28).
 
 ## 3.0.0rc5 (unreleased)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@
   project file or Kubernetes-derived application naming (FEEDBACK 37).
 - Configured `llm_caller` values now participate in embedded caller precedence,
   and `LlmResult`, `LlmCallMeta`, `AttemptMeta`, and `EmbeddedRun` are root-public.
+- `julep apply --activate` activates every lane of the release it just
+  published, over the connection `--api-url`/`--api-key` already established,
+  instead of printing one `julep activate` command per lane. Explicit
+  activation stays the default. Without a control-plane connection the flag
+  exits 2 before publishing anything. Every lane is attempted even after one
+  fails, so a partial rollout prints which lanes moved and which did not and
+  exits 1. Note the sharp edge: a control plane configured with
+  `JULEP_SERVER_HELM_CHART` re-reconciles the lane on activation and answers
+  `409` unless it reproduces the release's frozen `deployment_config`
+  byte-identically — both `--activate` and `julep activate` now name that cause
+  instead of reporting a bare conflict.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
   project file or Kubernetes-derived application naming (FEEDBACK 37).
 - Configured `llm_caller` values now participate in embedded caller precedence,
   and `LlmResult`, `LlmCallMeta`, `AttemptMeta`, and `EmbeddedRun` are root-public.
+- `julep run <package>.ctx` now records its local projection in the run cache,
+  including failed runs, so the same run id is available to `julep trace`.
+- Foreground runs now honor `WorkerContext.trajectory_sink`, trajectory blob
+  storage/redaction, and `on_attempt`; `TrajectoryRecorder` and
+  `InMemoryTrajectoryStore` can capture caller-named embedded runs (FEEDBACK 38).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@
   empty log leaves the original Helm failure intact with a
   `smoke-test logs unavailable` note (FEEDBACK 28).
 
-## 3.0.0rc5 (unreleased)
+## 3.0.0rc5 (2026-07-28)
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 3.0.0rc6 (unreleased)
+
+### Added
+
+- Embedded runs can expose a frozen `EmbeddedRun` envelope through
+  `arun_detailed` / `run_detailed`, stream projection events to a synchronous
+  sink, and retain caller-owned projections across failures (FEEDBACK 38).
+- `julep.embedded.load_pipeline` compiles standalone `.ctx` packages without a
+  project file or Kubernetes-derived application naming (FEEDBACK 37).
+- Configured `llm_caller` values now participate in embedded caller precedence,
+  and `LlmResult`, `LlmCallMeta`, `AttemptMeta`, and `EmbeddedRun` are root-public.
+
+### Fixed
+
+- Embedded retries now honor declared exponential backoff by default; direct
+  dry-run callers can pass `sleeper=None` for record-only behavior (FEEDBACK 38).
+
 ## 3.0.0rc5 (unreleased)
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,24 @@
   byte-identically — both `--activate` and `julep activate` now name that cause
   instead of reporting a bare conflict.
 
+### Changed
+
+- **Behavior change: a hand-run worker now fails closed on Temporal payload
+  encryption.** `TEMPORAL_PAYLOAD_ENCRYPTION_REQUIRED` defaulted to `true` on
+  the control plane and `false` on the worker, so a worker joined the plane the
+  server encrypts with a plaintext converter unless the operator remembered to
+  set the variable. The worker default is now `true`, matching the server:
+  `julep worker` (and `julep artifact worker`) refuse to start without
+  `TEMPORAL_PAYLOAD_KEYS`/`TEMPORAL_PAYLOAD_KEY_ID`, and `serve()` refuses to
+  poll even for settings assembled in code rather than from the environment.
+  The documented opt-out is unchanged: set
+  `TEMPORAL_PAYLOAD_ENCRYPTION_REQUIRED=false` to run against a deliberately
+  plaintext Temporal. Deployed workers are unaffected — the Helm path already
+  hardcoded encryption on — as are `julep serve api --local`, `julep dev up`,
+  and `create_local_app`, which set the opt-out (or a keyring) explicitly. Ad
+  hoc Temporal *client* connections (`julep run` against a remote env) keep the
+  permissive default.
+
 ### Fixed
 
 - Embedded retries now honor declared exponential backoff by default; direct

--- a/docs-site/content/docs/deploy/control-plane.md
+++ b/docs-site/content/docs/deploy/control-plane.md
@@ -80,11 +80,13 @@ reconciler behind `julep apply` and `JULEP_SERVER_HELM_CHART` hardcodes
 `payloadEncryption.enabled=true` and `payloadEncryption.required=true` and
 refuses to reconcile without a payload-encryption Secret name. There is no
 setting that turns it off for a managed lane. `TEMPORAL_PAYLOAD_ENCRYPTION_REQUIRED`
-is a genuine knob only for a server or worker you run by hand, and the two
-defaults are asymmetric: this server defaults it to `true`, while a bare
-`julep worker` defaults it to `false`. Set it explicitly on hand-run workers
-rather than relying on the default. Provisioning the Secret is an operator step
-with no automation behind it — see
+is a genuine knob only for a server or worker you run by hand, and the server
+and the worker now default it the same way: `true`. A hand-run `julep worker`
+without `TEMPORAL_PAYLOAD_KEYS`/`TEMPORAL_PAYLOAD_KEY_ID` refuses to start
+rather than joining the durable plane with a plaintext converter. Running a
+worker against a deliberately plaintext Temporal is still supported, but it is
+now an explicit `TEMPORAL_PAYLOAD_ENCRYPTION_REQUIRED=false`. Provisioning the
+Secret is an operator step with no automation behind it — see
 [the payload-encryption Secret](/docs/deploy/kubernetes#the-payload-encryption-secret).
 
 **API keys are mandatory in effect.** `JULEP_API_KEYS` defaults to empty, and an

--- a/docs-site/content/docs/deploy/embedded.md
+++ b/docs-site/content/docs/deploy/embedded.md
@@ -5,8 +5,9 @@ description: "Call one Julep pipeline in your own process, inside your own workf
 
 Embedded execution runs one configured Julep pipeline as a normal function call
 in your process. There is no Temporal, no PostgreSQL, no Julep server, no
-release publication, and no Kubernetes. The public entry point is
-`prepare_local_pipeline(...)` plus `LocalPipeline.arun(...)`.
+release publication, and no Kubernetes. For a standalone `.ctx` package, the
+primary entry point is `julep.embedded.load_pipeline(...)`; configured projects
+use `prepare_local_pipeline(...)`.
 
 This is the path to use when your application already has a workflow engine —
 DBOS, Temporal, Celery, Airflow, or a plain request handler — and you want Julep
@@ -65,8 +66,10 @@ prepare_local_pipeline(
     env: str = "local",
 ) -> LocalPipeline
 
-await pipeline.arun(input=None, *, llm=None, context=None, principal=None) -> Any
-pipeline.run(input=None, *, llm=None, context=None, principal=None) -> Any
+await pipeline.arun(input=None, *, llm=None, context=None, principal=None, sink=None) -> Any
+await pipeline.arun_detailed(..., sink=None, projection=None) -> EmbeddedRun
+pipeline.run(input=None, *, llm=None, context=None, principal=None, sink=None) -> Any
+pipeline.run_detailed(..., sink=None, projection=None) -> EmbeddedRun
 ```
 
 Prepare once and reuse the object: compilation is the expensive part, and every
@@ -79,8 +82,9 @@ keywords; they recompile on every call, so they are for scripts and tests rather
 than a hot path.
 
 Effects are always explicit. A pipeline that invokes a reasoner needs a model
-seam — pass `llm=` or `WorkerContext(llm=...)`, where an explicit `llm=` wins
-over the context's — otherwise `arun` raises
+seam. Precedence is explicit `llm=`, `WorkerContext(llm=...)`, then the
+project's configured `[tool.julep] llm_caller`; the configured callable is
+resolved once when the pipeline is prepared. If all are absent, `arun` raises
 `LocalExecutionConfigurationError`. `julep.llm.litellm_caller()` is the built-in
 implementation of the canonical seam
 `LlmCaller(reasoner, value, principal, transcript, dispatch, *, tools=None)`;
@@ -95,9 +99,24 @@ published release, an activated deployment, or Kubernetes.
 
 ## Embed without a Julep project file
 
-`prepare_local_pipeline` reads `pyproject.toml` / `julep.toml` by default. If you
-own a `.ctx` package but no Julep project file, build the same configuration
-objects in memory and pass them as `config=`:
+Use `load_pipeline` when you own a `.ctx` package but no Julep project file:
+
+```python
+from julep.embedded import load_pipeline
+from julep.llm import litellm_caller
+
+summary = load_pipeline("episode_summary.ctx", env={"SUMMARY_MODEL": "openai/gpt-5.4-nano@medium"})
+value = await summary.arun({"episode_id": "42"}, llm=litellm_caller())
+```
+
+The path is resolved before compilation and the application name is always
+`embedded`, so local paths are not subject to Kubernetes label rules. `tools=`
+maps prompt-visible MCP aliases to configured `server:tool` targets; it does not
+accept native Python callables. `load_pipeline` has no configured `llm_caller`,
+so pass `llm=` or `WorkerContext(llm=...)`.
+
+For multiple pipelines, code-defined applications, or the full project config
+surface, build configuration objects in memory and pass them as `config=`:
 
 ```python
 from pathlib import Path
@@ -144,12 +163,6 @@ tool-less prompt needs none of them. When a `JulepConfig` declares only ctx
 pipelines and no `application`, Julep synthesizes the application from those
 pipelines, so a code-defined `Application` is not required.
 
-This is the supported no-project-file path today, and it is admittedly
-control-plane vocabulary for what is really a prompt call. A first-class
-`julep.embedded.load_pipeline(path, env=...)` — load a `.ctx` directory, compile
-one tool-less pipeline, return a `LocalPipeline` — is planned. `julep.embedded`
-does not exist yet; use the recipe above until it does.
-
 ## What embedded execution accepts
 
 The embedded path is a real subset of the IR, checked before any effect runs
@@ -179,36 +192,43 @@ Two further behaviors to know:
 - The MCP surface is snapshotted and frozen when the pipeline is prepared.
   Embedded execution does not run the control plane's per-run MCP preflight or
   re-snapshot drift check; call `prepare_local_pipeline(...)` again to refresh.
+- Retry annotations use real asynchronous sleeps and honor their exponential
+  backoff. Tests and specialized direct `Deployment.adry_run` callers can inject
+  a fake sleeper, or pass `sleeper=None` for record-only behavior.
 
 An ordinary business input field named `transcript` is fine — only the agent
 runtime's transcript protocol is unsupported.
 
 ## Observability: what you get today
 
-**`LocalPipeline.arun` returns the interpreter's unwrapped value and nothing
-else.** The interpreter's result carries a projection event id, attribute
-metadata, and reported cost, and the run builds an in-memory projection — none of
-that is returned to the caller or forwarded to a sink. Attempt counts, token
-usage, cost, and the artifact identity of the specific call are not observable
-from the return value. `WorkerContext.on_attempt` is a worker-activity seam and is
-not invoked on this path.
+`arun` and `run` remain value-only. `arun_detailed` and `run_detailed` return an
+`EmbeddedRun` containing the value, the exact `InMemoryProjection`, and the
+pipeline's `artifact_hash`. The projection exposes ordered PLANNED/DID/FAILED
+events, per-step attributes, values, status, and declared/reported cost.
 
-Do not plan embedded adoption around Julep-side tracing. What you can do today:
+The envelope and `sink=` solve different problems. The envelope is returned only
+on success. A sink receives events synchronously as execution proceeds, including
+FAILED before the original exception propagates, so it supports live and failure
+capture. Pass a caller-owned `projection=` to `arun_detailed` when you need to
+inspect the same projection after an exception. Sink `append` methods are
+synchronous and sink exceptions deliberately fail the run; transport adapters
+should catch their own failures.
+
+Additional telemetry guidance:
 
 - **Own the model-call telemetry.** Inject your own `LlmCaller` instead of
   `litellm_caller()`. It receives the rendered `Reasoner`, the input value, the
   `principal`, and the `ReasonerDispatch` (including the resolved QoS tier), and it
-  returns the provider response — so latency, tokens, cost, retries, and prompt
-  identity are all recordable in your existing instrumentation, at the seam you
-  control.
+  returns the provider response. Return root-public `LlmResult` with
+  `LlmCallMeta` to place usage metadata on the step's DID event. A bare reply has
+  no framework usage metadata.
 - **Record the deployment identity yourself.** `LocalPipeline.artifact_hash`,
   `.name`, and `.environment` are stable for the prepared object; log them
   alongside your own step id.
 
-An optional result envelope and a projection sink for embedded runs are planned,
-and would not change the value-only default of `arun`. Until then, a complete
-Julep-side execution trace requires the durable backends: Temporal's projection
-interceptor, or DBOS's `set_projection_sink` (see [Deploy on DBOS](/docs/deploy/dbos)).
+Provider cost remains intentionally unknown when the caller reports none. Token
+usage and admission weights are not USD prices: `cost_by_shape()` does not invent
+money, and `llm.cost.status` remains `unknown` where applicable.
 
 ## Durability: who owns the workflow
 

--- a/docs-site/content/docs/deploy/embedded.md
+++ b/docs-site/content/docs/deploy/embedded.md
@@ -203,8 +203,11 @@ runtime's transcript protocol is unsupported.
 
 `arun` and `run` remain value-only. `arun_detailed` and `run_detailed` return an
 `EmbeddedRun` containing the value, the exact `InMemoryProjection`, and the
-pipeline's `artifact_hash`. The projection exposes ordered PLANNED/DID/FAILED
-events, per-step attributes, values, status, and declared/reported cost.
+pipeline's `artifact_hash`, plus aggregate LLM `usage`, `usage_complete`,
+`total_cost`, `cost_status`, and `cost_complete`. The projection exposes ordered
+PLANNED/DID/FAILED events, per-step attributes, values, status, and
+declared/reported cost. Usage-derived prices remain metadata and do not become
+projection charges.
 
 The envelope and `sink=` solve different problems. The envelope is returned only
 on success. A sink receives events synchronously as execution proceeds, including

--- a/docs-site/content/docs/deploy/kubernetes.md
+++ b/docs-site/content/docs/deploy/kubernetes.md
@@ -31,7 +31,7 @@ reads its configuration from the environment:
 | `WORKER_HEALTH_PORT` | off | HTTP port serving `GET /healthz` and `GET /readyz` |
 | `TEMPORAL_PAYLOAD_KEYS` | unset | Payload-codec keyring; comma-separated `key-id=64hex` entries. Set with `TEMPORAL_PAYLOAD_KEY_ID`. See [the payload-encryption Secret](#the-payload-encryption-secret). |
 | `TEMPORAL_PAYLOAD_KEY_ID` | unset | Key id used for new writes. Set with `TEMPORAL_PAYLOAD_KEYS`. |
-| `TEMPORAL_PAYLOAD_ENCRYPTION_REQUIRED` | `false` | Refuse to start unless a keyring is configured. `julep apply` always sets it `true`; a hand-run `julep worker` defaults to `false`. |
+| `TEMPORAL_PAYLOAD_ENCRYPTION_REQUIRED` | `true` | Refuse to start unless a keyring is configured. `julep apply` always sets it `true`, and a hand-run `julep worker` now defaults the same way. Set it to `false` to run a worker against a deliberately plaintext Temporal. |
 | `JULEP_BLOB_STORE_URL` | unset | Absolute local `file://` URL for durable transcript/claim-check blobs. Mutually exclusive with a factory-provided `blob_store`. |
 
 `WORKER_CONTEXT_FACTORY` is required and has no default: a `WorkerContext`

--- a/docs-site/content/docs/deploy/operations.md
+++ b/docs-site/content/docs/deploy/operations.md
@@ -366,6 +366,10 @@ export TEMPORAL_NAMESPACE=default
 export TEMPORAL_TASK_QUEUE=julep
 export JULEP_BLOB_STORE_URL=file:///var/lib/julep/blobs
 export WORKER_HEALTH_PORT=8080
+# The worker fails closed on payload encryption. Either export
+# TEMPORAL_PAYLOAD_KEYS/TEMPORAL_PAYLOAD_KEY_ID, or opt out explicitly for a
+# deliberately plaintext local Temporal:
+export TEMPORAL_PAYLOAD_ENCRYPTION_REQUIRED=false
 julep worker
 ```
 

--- a/docs-site/content/docs/guides/sessions.md
+++ b/docs-site/content/docs/guides/sessions.md
@@ -301,6 +301,9 @@ export TEMPORAL_ADDRESS=localhost:7233
 export TEMPORAL_NAMESPACE=default
 export TEMPORAL_TASK_QUEUE=support-sessions
 export WORKER_HEALTH_PORT=8080
+# Payload encryption is required by default; set the keyring, or opt out
+# explicitly for a deliberately plaintext local Temporal.
+export TEMPORAL_PAYLOAD_ENCRYPTION_REQUIRED=false
 julep worker
 ```
 

--- a/docs-site/content/docs/guides/using-the-cli.md
+++ b/docs-site/content/docs/guides/using-the-cli.md
@@ -99,7 +99,8 @@ keys are rejected with a close-match suggestion.
 | `julep doctor` | Preflight: discovery, dangling `secret://` refs, git, Langfuse, Temporal. |
 | `julep deploy [SEL] --env <name>` | Freeze → publish bundle to the env artifact store → record in the deploy ledger. |
 | `julep plan --env <name> [--mcp-snapshot]` | Compile code plus configured dotctx pipelines and report drift; optionally fetch configured MCP schemas. |
-| `julep apply --env <name> [--mcp-snapshot] [--publish-only] [--api-url --api-key]` | Publish a signed schema-v2 release, optionally register it with a control plane, and optionally reconcile lane workers. |
+| `julep apply --env <name> [--mcp-snapshot] [--publish-only] [--api-url --api-key] [--activate]` | Publish a signed schema-v2 release, optionally register it with a control plane, and optionally reconcile lane workers. `--activate` also switches traffic for every lane inline. |
+| `julep activate --env <name> --lane <lane> --release <hash> [--api-url --api-key]` | Switch one lane's traffic to a published release; roll back with an earlier hash. |
 | `julep status [SEL] --env <name>` | Aggregate application state or inspect the legacy ledger; `--remote --api-url --api-key --limit` reads control-plane runs. |
 | `julep worker [--smoke-test-seconds N]` | Run the environment-configured Temporal worker continuously (`0`) or verify/poll/drain for a positive `N`. |
 | `julep keygen [--format env|json] [--output PATH]` | Generate independent local admin/worker API, payload, vault, and signing credentials; output files are mode `0600`. |

--- a/docs-site/content/docs/internals/dotctx-format.md
+++ b/docs-site/content/docs/internals/dotctx-format.md
@@ -35,9 +35,12 @@ golden corpus do not move.
 
 ```
 <name>.ctx/
-├── settings.yaml        # name, model, temperature, max_rounds, agent, sub, context, tools
+├── settings.yaml        # name, model, temperature, max_rounds, agent, sub, context, tools, skills
 ├── schema.pyi           # input/output models -> reply_schema (JSON Schema)
 ├── tools.pyi            # tool stubs -> granted tool keys + expected schemas
+├── skills/              # activated by settings.yaml `skills:` (see below)
+│   └── <skill-name>/
+│       └── SKILL.md     # YAML frontmatter (name, description) + markdown body
 ├── prompt.j2            # single-template form (optional <<< role:... >>> markers), OR
 └── messages/            # multi-message form
     ├── 00_system.yml    # role: system, Jinja2 body
@@ -155,6 +158,123 @@ loader does two things:
 The stubs do **not** create tools. The tools are served by real MCP servers
 (for mem-mcp: its internal task-family servers); `tools.pyi` is the
 prompt-side contract assertion.
+
+### `skills/` → progressive disclosure
+
+A package may ship agent skills as `skills/<name>/SKILL.md` — YAML frontmatter
+(`name`, `description`) followed by a markdown body. Activation is **explicit**:
+
+```yaml
+skills: [natural-writing]
+```
+
+- The key **absent** activates nothing (a present-but-unused `skills/`
+  directory warns). `skills: []` also activates nothing, silently.
+- A configured name with no matching sidecar is a load error, as is a
+  directory whose name disagrees with its frontmatter `name`.
+- Only `SKILL.md` is read. Any other file in a skill directory is a load
+  error — bundled skill resources (`references/`, `scripts/`) are reserved.
+
+Both the minimal settings-only layout (`julep/dotctx.py`) and the rich layout
+(`julep/dotctx_rich.py`) accept `skills:`. Skills need no `[dotctx]` extra —
+`julep/skills.py` imports neither jinja2 nor `Reasoner`. A single-file `.ctx`
+(mem-mcp's compact frontmatter form) cannot activate skills: the key being
+present in any form, including `skills: []`, is a load error because sidecars
+need the directory layout. In the minimal layout a non-empty `skills:` with no
+`base_dir` is an error.
+
+When `skills:` is non-empty **every** directory under `skills/` is parsed and
+validated, not just the activated ones, so a malformed sibling skill fails the
+load. When the key is absent or empty, nothing under `skills/` is read at all.
+
+The complete load-time and call-time error inventory is:
+
+| Condition | Result |
+|---|---|
+| `skills:` is not a list (e.g. a bare string) | `SkillError` |
+| a list item is not a non-empty string (e.g. a mapping) | `SkillError`; per-skill option mappings are deliberately reserved for later |
+| duplicate names in `skills:` | `SkillError` |
+| key absent, `skills/` present | `InertSkillsDirectoryWarning`, nothing active |
+| `skills: []` | nothing active, no warning |
+| non-empty `skills:` but no `skills/` directory | `SkillError` |
+| a non-directory entry inside `skills/` | `SkillError` |
+| a skill directory with no `SKILL.md` | `SkillError` |
+| a skill directory with any file besides `SKILL.md` | `SkillError` |
+| directory name != frontmatter `name` | `SkillError` |
+| a configured name with no sidecar | `SkillError`, listing what is available |
+| `SKILL.md` with no frontmatter, invalid YAML, a non-mapping frontmatter, a missing/blank `name`, or an empty body | `SkillError` |
+| a `Reasoner` given a string that is not `skill/<name>@v<12 hex>` | `SkillError` telling the caller to pass `skill_keys([...])` |
+| the reasoner grants a tool literally named `__load_skill__` while skills are active | `ValueError` at call time (the name is reserved) |
+
+`description` is optional; a missing one renders as `(no description)` in the
+prompt block, and its whitespace is collapsed. A leading BOM is stripped and
+CRLF is normalized to LF before hashing, so a Windows checkout and a Unix
+checkout produce the same key. `Skill.source` is diagnostics only — excluded
+from equality and from the content hash, which is what makes identical skills
+in different packages one skill.
+
+Disclosure is progressive. Only the name and description of each activated
+skill reach the system prompt; the body arrives when the model calls the
+reserved `__load_skill__` tool, which the LLM caller resolves from the frozen
+release and answers in place. Those round trips happen *inside* one reasoner
+call: the flow shape is unchanged, `max_rounds` still counts rounds of task
+progress, and skill calls never reach the agent loop. `LlmCallMeta.skill_loads`
+records which skills were actually read.
+
+The prompt block is a `# Available skills` list of `- **name** — description`
+lines, prepended ahead of the authored system prompt because it is a stable
+prefix that prompt caching can cover. The `__load_skill__` tool's `name` enum
+lists only skills not yet disclosed, so the model cannot spend a round
+re-reading something already in its context. Bodies are answered as `tool`
+messages appended to the same call's message list, and the caller re-asks. The
+loop closes when every activated skill has been read, when the model stops
+asking, or when a budget of **two** malformed requests (an unknown name, or a
+name already provided) is spent. `__load_skill__` calls are stripped from the
+parsed reply before it is returned, so they never surface as controller tool
+calls. Bodies are resolved from the registry populated by the frozen release,
+never from the filesystem, so replay is deterministic.
+
+Single-shot batch submission has no tool round trip, so a batched reasoner
+inlines every activated skill instead.
+
+Skills are content-addressed as `skill/<name>@v<hash12>` over
+(name, description, body), and `Reasoner.skills` holds those keys — so editing
+a skill body moves the reasoner identity exactly the way editing a template
+does, and byte-identical copies in different packages cost one artifact entry.
+
+`skills` enters the reasoner's deploy identity only when non-empty, so
+pre-existing artifacts hash identically. The declarations blob (schema v3)
+carries each skill's name, description, and body once per key; a worker
+rebuilding a skill re-verifies the content against the key it was stored under.
+Because the key covers the body, an edited skill body changes the reasoner's
+identity hash — the same drift detection that already covers template edits.
+
+**Differences from mem-mcp's `skills:`.** mem-mcp activates *all* skills when
+the key is absent and inlines every body into the system prompt. Julep requires
+explicit activation and discloses progressively, so a package migrating from
+mem-mcp must list the names it wants.
+
+Programmatically:
+
+```python
+from julep import Reasoner, Skill, skill_keys
+
+house_style = Skill(
+    name="house-style",
+    description="How we write.",
+    body="Short sentences. Concrete nouns.",
+)
+reasoner = Reasoner(
+    name="drafter",
+    model="openai:gpt-5.5",
+    system="You draft release notes.",
+    skills=skill_keys([house_style]),
+)
+```
+
+`Reasoner` is a pure value type and never touches the registry, so
+`skill_keys()` is the explicit bridge: it registers each `Skill` and returns
+the content keys the reasoner stores.
 
 ### Settings normalization
 

--- a/docs-site/content/docs/internals/dotctx-format.md
+++ b/docs-site/content/docs/internals/dotctx-format.md
@@ -203,7 +203,9 @@ The complete load-time and call-time error inventory is:
 | directory name != frontmatter `name` | `SkillError` |
 | a configured name with no sidecar | `SkillError`, listing what is available |
 | `SKILL.md` with no frontmatter, invalid YAML, a non-mapping frontmatter, a missing/blank `name`, or an empty body | `SkillError` |
-| a `Reasoner` given a string that is not `skill/<name>@v<12 hex>` | `SkillError` telling the caller to pass `skill_keys([...])` |
+| a `SKILL.md` frontmatter name outside `^[A-Za-z0-9][A-Za-z0-9._-]*$` | `SkillError`, naming the file and offending name |
+| a `Reasoner` given a string that is not `skill/<name>@v<12 hex>` | `ValueError` telling the caller to pass `skill_keys([...])` |
+| a `Reasoner` given multiple skill keys declaring the same name | `ValueError`, naming the duplicate skill and reasoner |
 | the reasoner grants a tool literally named `__load_skill__` while skills are active | `ValueError` at call time (the name is reserved) |
 
 `description` is optional; a missing one renders as `(no description)` in the
@@ -225,9 +227,11 @@ The prompt block is a `# Available skills` list of `- **name** — description`
 lines, prepended ahead of the authored system prompt because it is a stable
 prefix that prompt caching can cover. The `__load_skill__` tool's `name` enum
 lists only skills not yet disclosed, so the model cannot spend a round
-re-reading something already in its context. Bodies are answered as `tool`
-messages appended to the same call's message list, and the caller re-asks. The
-loop closes when every activated skill has been read, when the model stops
+re-reading something already in its context. While the tool remains offered,
+bodies are answered as `tool` messages and the caller re-asks. After the tool
+is withdrawn, already-loaded bodies are carried into the final request as a
+plain user message, without tool-call or tool-result blocks. The loop closes
+when every activated skill has been read, when the model stops
 asking, or when a budget of **two** malformed requests (an unknown name, or a
 name already provided) is spent. `__load_skill__` calls are stripped from the
 parsed reply before it is returned, so they never surface as controller tool

--- a/docs-site/content/docs/reference/julep-cli.md
+++ b/docs-site/content/docs/reference/julep-cli.md
@@ -400,12 +400,13 @@ and does not change plan's success exit code.
 
 ## `julep apply`
 
-Synopsis: `julep apply --env ENV [--publish-only] [--mcp-snapshot] [--api-url URL] [--api-key KEY]`
+Synopsis: `julep apply --env ENV [--publish-only] [--mcp-snapshot] [--api-url URL] [--api-key KEY] [--activate]`
 
 Compile and publish a signed, immutable application release. By default it then
 reconciles one digest-pinned Helm release and release-specific Temporal task
 queue per logical lane, runs the chart's worker smoke test, and records local
-applied state. It never switches application traffic.
+applied state. It never switches application traffic unless `--activate` is
+given.
 
 | Flag | Default | Meaning |
 |---|---|---|
@@ -414,6 +415,7 @@ applied state. It never switches application traffic.
 | `--mcp-snapshot` | false | Fetch configured MCP `tools/list` schemas before publishing. Requires `julep[mcp]`. |
 | `--api-url URL` | unset | Register the release manifest with this control-plane API after publishing. |
 | `--api-key KEY` | unset | Admin bearer key for release registration. |
+| `--activate` | false | Activate every lane of the published release inline. Requires `--api-url`/`--api-key`. See [inline activation](#inline-activation-with---activate). |
 
 An explicit `snapshot=` in application code remains authoritative. The CLI
 flag applies the configured server snapshot to pipelines without native tools.
@@ -430,6 +432,65 @@ Exit/errors: unknown env exits `2`; compile, signing, artifact store,
 configuration, reconciliation, or registration failures exit `1`; success
 exits `0` and prints the release, artifact, every release-scoped lane queue,
 optional `registered <release-hash>`, and `traffic unchanged`.
+
+### Inline activation with `--activate`
+
+Explicit activation remains the default: without `--activate`, `apply`
+publishes, prints `traffic   unchanged`, and prints the exact
+`julep activate ...` command for every lane.
+
+`--activate` instead activates every lane of the release inline, over the same
+control-plane connection `--api-url`/`--api-key` already established. Without
+that connection there is nothing to activate against, so `--activate` exits `2`
+before publishing anything.
+
+Activation is attempted for every lane even after one fails, so a partial
+rollout is reported rather than hidden:
+
+```text
+activated brief-refresh            sha256:...
+error: lane 'digest' activation failed: ...
+traffic   partial: activated brief-refresh, summary; unchanged digest
+```
+
+A partial rollout exits `1`; a fully activated release prints
+`traffic   activated <lanes>` and exits `0`.
+
+**Caveat: control planes that reconcile Helm themselves answer `409`.** When the
+server is configured with `JULEP_SERVER_HELM_CHART`, `POST /v1/deployments`
+re-runs the lane reconcile. That reconcile re-derives the lane deployment
+config and refuses unless it reproduces the release's frozen
+`deployment_config` byte-identically — a mismatch (a chart, namespace, queue
+map, or worker-environment difference between the publishing CLI and the
+server) surfaces as HTTP `409`. Julep names that cause instead of reporting a
+bare conflict, but the activation still fails.
+
+Use `--activate` against a control plane that leaves worker rollout external
+(no `JULEP_SERVER_HELM_CHART`), where `apply` has already reconciled the lanes
+and activation is a pure traffic switch. Against a reconciling control plane,
+align the server's reconciler configuration with the release first, then
+activate explicitly with `julep activate`.
+
+## `julep activate`
+
+Synopsis: `julep activate --env ENV --lane LANE --release HASH [--api-url URL] [--api-key KEY]`
+
+Point one lane at a published release. This is the traffic switch `julep apply`
+deliberately does not perform. Rolling back is the same operation with an
+earlier release hash.
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--env ENV` | required | Configured application environment. |
+| `--lane LANE` | required | Deployment lane to switch. |
+| `--release HASH` | required | Published release hash to activate. |
+| `--api-url URL` | `JULEP_API_URL` | Control-plane base URL. |
+| `--api-key KEY` | `JULEP_API_KEY` | Admin bearer key. |
+
+Exit/errors: unknown env exits `2`; a missing API URL or a missing httpx exits
+`2`; a non-admin key (`403`), a server-side reconciler conflict (`409`, see
+[the caveat above](#inline-activation-with---activate)), and any other API
+error exit `1`. Success prints `activated <lane> <release>` and exits `0`.
 
 ## `julep status`
 

--- a/docs-site/content/docs/reference/julep-cli.md
+++ b/docs-site/content/docs/reference/julep-cli.md
@@ -405,7 +405,11 @@ Synopsis: `julep apply --env ENV [--publish-only] [--mcp-snapshot] [--api-url UR
 Compile and publish a signed, immutable application release. By default it then
 reconciles one digest-pinned Helm release and release-specific Temporal task
 queue per logical lane, runs the chart's worker smoke test, and records local
-applied state. It never switches application traffic unless `--activate` is
+applied state. A failing smoke test aborts the apply and reports the smoke-test
+Job's logs alongside the Helm failure, fetched out of band with
+`kubectl logs --selector job-name=<release>-smoke`; if that fetch is not
+possible (no `kubectl`, no RBAC), the Helm failure is still what surfaces, with
+a `smoke-test logs unavailable` note. It never switches application traffic unless `--activate` is
 given.
 
 | Flag | Default | Meaning |

--- a/docs-site/content/docs/reference/python-api.md
+++ b/docs-site/content/docs/reference/python-api.md
@@ -639,7 +639,8 @@ CLI entry points:
 | `run` | `julep run <name-or-path.ctx> [--input JSON] [--run-id id] [--env name]` |
 | `deploy` | `julep deploy [selector] [--exclude expr] [--env name]` |
 | `plan` | `julep plan [--env name] [--json] [--mcp-snapshot]` |
-| `apply` | `julep apply --env name [--publish-only] [--mcp-snapshot] [--api-url URL] [--api-key KEY]` |
+| `apply` | `julep apply --env name [--publish-only] [--mcp-snapshot] [--api-url URL] [--api-key KEY] [--activate]` |
+| `activate` | `julep activate --env name --lane lane --release hash [--api-url URL] [--api-key KEY]` |
 | `status` | `julep status [selector] [--exclude expr] [--env name] [--remote] [--api-url URL] [--api-key KEY] [--limit N]` |
 | `keygen` | `julep keygen [--format env|json] [--output PATH] [--force]` |
 | `dev up` | `julep dev up [--env name] [--api-url URL] [--api-key KEY] [--start-temporal/--no-start-temporal] [--publish/--no-publish] [--worker/--no-worker] [--startup-timeout SECONDS] [--dry-run]` |

--- a/docs/superpowers/plans/2026-07-27-dotctx-skills.md
+++ b/docs/superpowers/plans/2026-07-27-dotctx-skills.md
@@ -1,0 +1,2480 @@
+# dotctx Skills (Progressive Disclosure) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Teach Julep the `skills:` dotctx setting — a package activates named `SKILL.md` sidecars, whose descriptions ride in the system prompt and whose bodies the model pulls mid-call through a reserved `__load_skill__` tool resolved from the frozen release.
+
+**Architecture:** A skill is a content-addressed registry citizen (`skill/<name>@v<hash12>`) sitting beside pures, renderers, and reasoners. `Reasoner.skills` holds those keys, so an edited skill body changes the reasoner identity by the same mechanism an edited template already does. Disclosure happens *inside* `complete_reasoner` as a bounded inner provider loop — the same shape `output_retries` already uses — so it never touches the IR: a `think` leaf stays a `think` leaf and `max_rounds` keeps meaning rounds of task progress.
+
+**Tech Stack:** Python 3.12+, PyYAML, pytest. No new dependencies. jinja2 is deliberately *not* required — `julep/skills.py` must import cleanly without the `[dotctx]` extra.
+
+## Global Constraints
+
+- Target release: **rc6**. rc5 has shipped; nothing here may change the meaning of an already-frozen artifact.
+- Skills resolve **only** from `<pkg>.ctx/skills/<name>/SKILL.md`. No upward search, no shared root — dotctx packages stay standalone. Duplication across packages is accepted and deduplicated by content hash, not by path.
+- Activation is **explicit**: the `skills:` key absent means no skills. This deliberately diverges from mem-mcp's implicit-all rule.
+- Only `SKILL.md` is supported inside a skill directory. Any other file is a load-time error. Levels 1+2 of Anthropic's three-level skill format; level 3 (bundled `references/`, `scripts/`) is reserved.
+- Every failure is loud at load time with the offending file/name in the message (G-8: loud, never silent).
+- Skill bodies never live on `Reasoner` and never reach the provider except as a tool result.
+- Content hashes cover `name`, `description`, `body` — never the source path.
+- Declarations blob schema version bumps `2` → `3`.
+- Run tests with `uv run python -m pytest` (a bare `pytest` also collects; `pythonpath = ["."]` is set in `pyproject.toml:147`).
+
+## Design Decision Requiring Confirmation
+
+`julep/execution/llm.py:653` sets `native_response_format = native and not has_tools` — offering *any* tool disables provider-native `response_format` and falls back to prompt-injected schema guidance. All three real skill-using packages (`briefs/draft.ctx`, `briefs/review.ctx`, `briefs/plan_sections.ctx`) carry a `schema.pyi`, so they currently get native structured output.
+
+**Chosen default (implemented by Task 7):** a two-phase call. The skill tool is offered only while undisclosed skills remain; once the model has loaded what it wants (or the budget closes), the tool is withdrawn and the final call runs tool-free, restoring native `response_format` for reasoners that grant no real tools.
+
+**The residual cost:** when the model loads *no* skill, the single call it makes still carried the tool, so that call loses native structured output. `output_retries` (set to `1` on all three packages) is the existing safety net. Relaxing the blanket `not has_tools` rule for providers that support tools alongside structured outputs is a real fix but is **out of scope here** — it changes behavior for every tool-bearing reasoner, not just skill users.
+
+---
+
+## File Structure
+
+**Created:**
+- `julep/skills.py` — the whole skill vocabulary: `Skill`, key derivation, `SKILL.md` parsing, package loading, prompt-block and tool-definition formatting, batch inlining. No jinja2, no `Reasoner` import (keeps it importable from `julep/dotctx.py` without a cycle).
+- `tests/test_skills.py` — value type, parser, package loader, registry.
+- `tests/test_skills_dotctx.py` — settings wiring across all three package layouts.
+- `tests/test_skills_declarations.py` — artifact identity and blob round trip.
+- `tests/test_llm_skills.py` — the runtime disclosure loop.
+- `tests/fixtures/memmcp/brief_draft.ctx/` — a vendored skill-bearing package.
+
+**Modified:**
+- `julep/registry.py` — `Registry.skills`, `register_skill`, `get_skill`.
+- `julep/dotctx.py` — `Reasoner.skills` field, `replace()`, `_REPLACE_HANDLED_FIELDS`, minimal-layout wiring in `reasoner_from_settings`.
+- `julep/dotctx_rich.py` — `_ALLOWED_SETTINGS`, `_build_reasoner`, `RichDotctx.skills`, single-file rejection.
+- `julep/deploy.py` — `_reasoner_identity`.
+- `julep/app.py` — `_reasoner_runtime_declaration`.
+- `julep/declarations.py` — blob `skills` section, rebuild, schema version.
+- `julep/execution/llm_result.py` — `LlmCallMeta.skill_loads`.
+- `julep/execution/llm.py` — the disclosure loop.
+- `julep/execution/openai_batch.py`, `julep/execution/anthropic_batch.py` — single-shot inlining.
+- `julep/__init__.py` — public exports.
+- `tests/test_memmcp_compat.py` — drop the tolerance.
+- `docs-site/content/docs/internals/dotctx-format.md` — document the format.
+
+---
+
+### Task 1: The `Skill` value type and `SKILL.md` parser
+
+**Files:**
+- Create: `julep/skills.py`
+- Test: `tests/test_skills.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `Skill(name: str, description: str, body: str, source: str = "")` (frozen dataclass, `source` excluded from equality); `skill_key(skill: Skill) -> str`; `parse_skill_markdown(text: str, *, origin: str) -> Skill`; `SkillError(JulepError)`; `SKILL_TOOL: str = "__load_skill__"`; `SKILL_KEY_RE: re.Pattern`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_skills.py`:
+
+```python
+"""Skill value type, SKILL.md parsing, package loading, and registration."""
+
+from __future__ import annotations
+
+import pytest
+
+from julep.skills import (
+    SKILL_TOOL,
+    Skill,
+    SkillError,
+    parse_skill_markdown,
+    skill_key,
+)
+
+SKILL_MD = """\
+---
+name: natural-writing
+description: >
+  Write like a human, not a language model.
+---
+
+# Natural Writing
+
+Cut the significance inflation.
+"""
+
+
+def test_parse_skill_markdown_splits_frontmatter_from_body() -> None:
+    skill = parse_skill_markdown(SKILL_MD, origin="skills/natural-writing/SKILL.md")
+    assert skill.name == "natural-writing"
+    assert skill.description == "Write like a human, not a language model."
+    assert skill.body.startswith("# Natural Writing")
+    assert "significance inflation" in skill.body
+    assert skill.source == "skills/natural-writing/SKILL.md"
+
+
+def test_key_is_content_addressed_and_ignores_source() -> None:
+    a = parse_skill_markdown(SKILL_MD, origin="pkg_a/skills/natural-writing/SKILL.md")
+    b = parse_skill_markdown(SKILL_MD, origin="pkg_b/skills/natural-writing/SKILL.md")
+    assert skill_key(a) == skill_key(b)
+    assert a == b                       # source is excluded from equality
+    assert skill_key(a).startswith("skill/natural-writing@v")
+    assert len(skill_key(a).rsplit("@v", 1)[1]) == 12
+
+
+def test_key_changes_when_body_changes() -> None:
+    a = parse_skill_markdown(SKILL_MD, origin="x")
+    b = parse_skill_markdown(SKILL_MD.replace("inflation", "deflation"), origin="x")
+    assert skill_key(a) != skill_key(b)
+
+
+def test_key_changes_when_description_changes() -> None:
+    a = parse_skill_markdown(SKILL_MD, origin="x")
+    b = parse_skill_markdown(SKILL_MD.replace("a language model", "an LLM"), origin="x")
+    assert skill_key(a) != skill_key(b)
+
+
+def test_missing_frontmatter_is_a_loud_error() -> None:
+    with pytest.raises(SkillError, match="frontmatter"):
+        parse_skill_markdown("# Just a heading\n", origin="skills/x/SKILL.md")
+
+
+def test_missing_name_is_a_loud_error() -> None:
+    text = "---\ndescription: no name here\n---\n\nbody\n"
+    with pytest.raises(SkillError, match="non-empty name"):
+        parse_skill_markdown(text, origin="skills/x/SKILL.md")
+
+
+def test_non_mapping_frontmatter_is_a_loud_error() -> None:
+    with pytest.raises(SkillError, match="YAML mapping"):
+        parse_skill_markdown("---\n- a\n- b\n---\n\nbody\n", origin="skills/x/SKILL.md")
+
+
+def test_empty_body_is_a_loud_error() -> None:
+    text = "---\nname: x\ndescription: d\n---\n\n   \n"
+    with pytest.raises(SkillError, match="empty body"):
+        parse_skill_markdown(text, origin="skills/x/SKILL.md")
+
+
+def test_skill_tool_name_is_provider_safe() -> None:
+    from julep.execution.llm import provider_safe_tool_name
+
+    assert provider_safe_tool_name(SKILL_TOOL) == SKILL_TOOL
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run python -m pytest tests/test_skills.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'julep.skills'`
+
+- [ ] **Step 3: Write `julep/skills.py`**
+
+```python
+"""Agent skills for dotctx packages.
+
+A *skill* is a named block of reusable instructions living beside a dotctx
+package as ``skills/<name>/SKILL.md`` — YAML frontmatter (``name``,
+``description``) followed by a markdown body. A package activates skills by
+name through the ``skills:`` setting; activation is explicit, so a ``skills/``
+directory on its own changes nothing.
+
+Disclosure is progressive. Only each activated skill's *name and description*
+reach the system prompt; the body arrives mid-call when the model asks for it
+through the reserved ``__load_skill__`` tool, which
+:mod:`julep.execution.llm` resolves from the frozen release — never from the
+filesystem, so replay is deterministic.
+
+Skills are content-addressed as ``skill/<name>@v<hash12>`` over
+(name, description, body). Byte-identical copies in different packages
+converge on one registry entry and one copy in the deploy artifact, while an
+edited body yields a different key — and because ``Reasoner.skills`` holds
+those keys, an edited skill moves the reasoner identity exactly the way an
+edited template already does.
+
+This module deliberately imports neither jinja2 nor :class:`~julep.dotctx.Reasoner`:
+skills work in the minimal settings-only layout, without the ``[dotctx]`` extra.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import warnings
+from dataclasses import dataclass, field
+from typing import Any, Optional, Sequence
+
+from .errors import JulepError
+
+# Reserved native tool: the LLM caller resolves a call to this from the frozen
+# skill set and re-asks, rather than surfacing it to the agent loop.
+SKILL_TOOL = "__load_skill__"
+
+_HASH_PREFIX_LEN = 12
+SKILL_KEY_RE = re.compile(r"^skill/(?P<name>[^@]+)@v[0-9a-f]{%d}$" % _HASH_PREFIX_LEN)
+
+# Same frontmatter shape mem-mcp's loader and the single-file .ctx format use.
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)$", re.DOTALL)
+
+
+class SkillError(JulepError):
+    """A skill sidecar or ``skills:`` declaration is malformed."""
+
+
+class InertSkillsDirectoryWarning(UserWarning):
+    """A package ships ``skills/`` but activates nothing."""
+
+
+@dataclass(frozen=True)
+class Skill:
+    """One ``SKILL.md`` sidecar.
+
+    ``source`` is diagnostics only: it is excluded from equality and from the
+    content hash so identical skills in different packages are one skill.
+    """
+
+    name: str
+    description: str
+    body: str
+    source: str = field(default="", compare=False)
+
+
+def skill_key(skill: Skill) -> str:
+    """The content-addressed registry key for ``skill``."""
+    material = "\0".join((skill.name, skill.description, skill.body))
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()
+    return f"skill/{skill.name}@v{digest[:_HASH_PREFIX_LEN]}"
+
+
+def skill_name_of(key: str) -> str:
+    """The declared name inside a registry key, for error messages."""
+    match = SKILL_KEY_RE.match(key)
+    if match is None:
+        raise SkillError(
+            f"malformed skill key {key!r}; expected 'skill/<name>@v<12 hex chars>'"
+        )
+    return match.group("name")
+
+
+def parse_skill_markdown(text: str, *, origin: str) -> Skill:
+    """Parse a ``SKILL.md``: YAML frontmatter then a markdown body."""
+    import yaml
+
+    match = _FRONTMATTER_RE.match(text)
+    if match is None:
+        raise SkillError(
+            f"skill {origin!r} has no YAML frontmatter; a SKILL.md must open with "
+            "'---', a mapping with name/description, then '---'"
+        )
+    try:
+        frontmatter = yaml.safe_load(match.group(1)) or {}
+    except Exception as exc:
+        raise SkillError(f"skill {origin!r} frontmatter is not valid YAML: {exc}") from exc
+    if not isinstance(frontmatter, dict):
+        raise SkillError(f"skill {origin!r} frontmatter must be a YAML mapping")
+
+    raw_name = frontmatter.get("name")
+    if not isinstance(raw_name, str) or not raw_name.strip():
+        raise SkillError(f"skill {origin!r} frontmatter needs a non-empty name")
+
+    raw_description = frontmatter.get("description", "")
+    description = (
+        raw_description if isinstance(raw_description, str) else str(raw_description)
+    )
+    body = match.group(2).strip()
+    if not body:
+        raise SkillError(
+            f"skill {origin!r} has an empty body; a skill with no instructions "
+            "cannot be disclosed"
+        )
+    return Skill(
+        name=raw_name.strip(),
+        description=" ".join(description.split()),
+        body=body,
+        source=origin,
+    )
+```
+
+Add `from .skills import SkillError` is *not* needed in `errors.py`; `JulepError` already lives there (confirm with `grep -n "class JulepError" julep/errors.py`).
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run python -m pytest tests/test_skills.py -v`
+Expected: PASS (9 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add julep/skills.py tests/test_skills.py
+git commit -m "feat(skills): Skill value type and SKILL.md parser"
+```
+
+---
+
+### Task 2: Package loading with the explicit allowlist
+
+**Files:**
+- Modify: `julep/skills.py`
+- Test: `tests/test_skills.py`
+
+**Interfaces:**
+- Consumes: `Skill`, `SkillError`, `parse_skill_markdown` from Task 1.
+- Produces: `load_package_skills(pkg_dir: str, allowlist: Optional[Sequence[str]]) -> tuple[Skill, ...]`; `parse_skills_setting(value: Any, *, origin: str) -> Optional[tuple[str, ...]]`; `InertSkillsDirectoryWarning`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_skills.py`:
+
+```python
+import os
+
+from julep.skills import (
+    InertSkillsDirectoryWarning,
+    load_package_skills,
+    parse_skills_setting,
+)
+
+
+def _write_skill(pkg: str, dirname: str, *, name: str, body: str = "Do the thing.") -> None:
+    path = os.path.join(pkg, "skills", dirname)
+    os.makedirs(path, exist_ok=True)
+    with open(os.path.join(path, "SKILL.md"), "w", encoding="utf-8") as fh:
+        fh.write(f"---\nname: {name}\ndescription: describes {name}\n---\n\n{body}\n")
+
+
+def test_allowlist_selects_and_orders_by_declaration(tmp_path) -> None:
+    pkg = str(tmp_path)
+    _write_skill(pkg, "alpha", name="alpha")
+    _write_skill(pkg, "beta", name="beta")
+    skills = load_package_skills(pkg, ["beta", "alpha"])
+    assert [s.name for s in skills] == ["beta", "alpha"]
+
+
+def test_absent_key_activates_nothing_and_warns_when_dir_exists(tmp_path) -> None:
+    pkg = str(tmp_path)
+    _write_skill(pkg, "alpha", name="alpha")
+    with pytest.warns(InertSkillsDirectoryWarning, match="skills/"):
+        assert load_package_skills(pkg, None) == ()
+
+
+def test_empty_list_activates_nothing_without_warning(tmp_path, recwarn) -> None:
+    pkg = str(tmp_path)
+    _write_skill(pkg, "alpha", name="alpha")
+    assert load_package_skills(pkg, []) == ()
+    assert not [w for w in recwarn if w.category is InertSkillsDirectoryWarning]
+
+
+def test_no_skills_dir_and_no_allowlist_is_silent(tmp_path, recwarn) -> None:
+    assert load_package_skills(str(tmp_path), None) == ()
+    assert not [w for w in recwarn if w.category is InertSkillsDirectoryWarning]
+
+
+def test_configured_name_without_a_sidecar_fails_closed(tmp_path) -> None:
+    pkg = str(tmp_path)
+    _write_skill(pkg, "alpha", name="alpha")
+    with pytest.raises(SkillError, match="ghost.*available.*alpha"):
+        load_package_skills(pkg, ["ghost"])
+
+
+def test_allowlist_without_a_skills_dir_fails_closed(tmp_path) -> None:
+    with pytest.raises(SkillError, match="no skills/ directory"):
+        load_package_skills(str(tmp_path), ["alpha"])
+
+
+def test_extra_file_in_a_skill_directory_is_rejected(tmp_path) -> None:
+    pkg = str(tmp_path)
+    _write_skill(pkg, "alpha", name="alpha")
+    with open(os.path.join(pkg, "skills", "alpha", "references.md"), "w") as fh:
+        fh.write("more")
+    with pytest.raises(SkillError, match="references.md"):
+        load_package_skills(pkg, ["alpha"])
+
+
+def test_loose_file_directly_under_skills_is_rejected(tmp_path) -> None:
+    pkg = str(tmp_path)
+    _write_skill(pkg, "alpha", name="alpha")
+    with open(os.path.join(pkg, "skills", "README.md"), "w") as fh:
+        fh.write("hi")
+    with pytest.raises(SkillError, match="README.md"):
+        load_package_skills(pkg, ["alpha"])
+
+
+def test_directory_name_must_match_frontmatter_name(tmp_path) -> None:
+    pkg = str(tmp_path)
+    _write_skill(pkg, "alpha", name="not-alpha")
+    with pytest.raises(SkillError, match="directory 'alpha'.*'not-alpha'"):
+        load_package_skills(pkg, ["not-alpha"])
+
+
+def test_duplicate_names_are_unresolvable(tmp_path) -> None:
+    pkg = str(tmp_path)
+    _write_skill(pkg, "alpha", name="alpha")
+    os.makedirs(os.path.join(pkg, "skills", "alpha-copy"))
+    with open(os.path.join(pkg, "skills", "alpha-copy", "SKILL.md"), "w") as fh:
+        fh.write("---\nname: alpha\ndescription: dupe\n---\n\nbody\n")
+    with pytest.raises(SkillError, match="directory 'alpha-copy'"):
+        load_package_skills(pkg, ["alpha"])
+
+
+def test_duplicate_allowlist_entries_are_rejected() -> None:
+    with pytest.raises(SkillError, match="duplicate"):
+        parse_skills_setting(["a", "a"], origin="settings.yaml")
+
+
+def test_parse_skills_setting_forms() -> None:
+    assert parse_skills_setting(None, origin="s") is None
+    assert parse_skills_setting([], origin="s") == ()
+    assert parse_skills_setting(["a", "b"], origin="s") == ("a", "b")
+
+
+def test_mapping_items_reserved_for_future_options() -> None:
+    with pytest.raises(SkillError, match="list of skill names"):
+        parse_skills_setting([{"name": "a", "mode": "inline"}], origin="s")
+
+
+def test_non_list_setting_is_rejected() -> None:
+    with pytest.raises(SkillError, match="list of skill names"):
+        parse_skills_setting("natural-writing", origin="s")
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run python -m pytest tests/test_skills.py -v`
+Expected: FAIL — `ImportError: cannot import name 'load_package_skills'`
+
+- [ ] **Step 3: Implement the loader**
+
+Append to `julep/skills.py`:
+
+```python
+def parse_skills_setting(value: Any, *, origin: str) -> Optional[tuple[str, ...]]:
+    """Normalize the ``skills:`` setting.
+
+    ``None`` means the key is absent (activate nothing); ``()`` means an
+    explicit empty list. Mapping items are rejected by name so per-skill
+    options remain an additive change later.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str) or not isinstance(value, (list, tuple)):
+        raise SkillError(
+            f"settings 'skills' in {origin!r} must be a list of skill names"
+        )
+    names: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item.strip():
+            raise SkillError(
+                f"settings 'skills' in {origin!r} must be a list of skill names; "
+                f"got {item!r} (per-skill option mappings are not supported yet)"
+            )
+        names.append(item.strip())
+    duplicates = sorted({n for n in names if names.count(n) > 1})
+    if duplicates:
+        raise SkillError(
+            f"settings 'skills' in {origin!r} has duplicate entries: "
+            + ", ".join(duplicates)
+        )
+    return tuple(names)
+
+
+def load_package_skills(
+    pkg_dir: str, allowlist: Optional[Sequence[str]]
+) -> tuple[Skill, ...]:
+    """Load the skills a package activates, in declaration order.
+
+    ``allowlist`` is ``None`` when the ``skills:`` key is absent — nothing is
+    activated, and a present-but-inert ``skills/`` directory warns. Every
+    configured name must resolve; a skill directory must hold exactly one
+    ``SKILL.md`` (level-3 bundled resources are not supported yet).
+    """
+    skills_dir = os.path.join(pkg_dir, "skills")
+    has_dir = os.path.isdir(skills_dir)
+
+    if allowlist is None:
+        if has_dir:
+            warnings.warn(
+                f"dotctx package {pkg_dir!r} has a skills/ directory but no "
+                "'skills:' setting, so no skill is active; list the names you "
+                "want to activate",
+                InertSkillsDirectoryWarning,
+                stacklevel=3,
+            )
+        return ()
+    if not allowlist:
+        return ()
+    if not has_dir:
+        raise SkillError(
+            f"dotctx package {pkg_dir!r} activates skills "
+            f"({', '.join(allowlist)}) but has no skills/ directory"
+        )
+
+    by_name: dict[str, Skill] = {}
+    origin_of: dict[str, str] = {}
+    for entry in sorted(os.listdir(skills_dir)):
+        entry_path = os.path.join(skills_dir, entry)
+        if not os.path.isdir(entry_path):
+            raise SkillError(
+                f"{os.path.join('skills', entry)!r} in {pkg_dir!r} is not a skill "
+                "directory; skills/ may contain only <name>/SKILL.md directories"
+            )
+        contents = sorted(os.listdir(entry_path))
+        if contents != ["SKILL.md"]:
+            extra = [name for name in contents if name != "SKILL.md"]
+            if not extra:
+                raise SkillError(
+                    f"skill directory {entry!r} in {pkg_dir!r} has no SKILL.md"
+                )
+            raise SkillError(
+                f"skill directory {entry!r} in {pkg_dir!r} contains unsupported "
+                f"files: {', '.join(extra)}; only SKILL.md is read (bundled skill "
+                "resources are not supported yet)"
+            )
+        origin = os.path.join(skills_dir, entry, "SKILL.md")
+        with open(origin, "r", encoding="utf-8") as fh:
+            skill = parse_skill_markdown(fh.read(), origin=origin)
+        if skill.name != entry:
+            raise SkillError(
+                f"skill directory {entry!r} in {pkg_dir!r} declares name "
+                f"{skill.name!r}; the directory name and the frontmatter name "
+                "must match"
+            )
+        if skill.name in by_name:
+            raise SkillError(
+                f"skill {skill.name!r} is declared twice in {pkg_dir!r}: "
+                f"directory {origin_of[skill.name]!r} and directory {entry!r}"
+            )
+        by_name[skill.name] = skill
+        origin_of[skill.name] = entry
+
+    missing = [name for name in allowlist if name not in by_name]
+    if missing:
+        raise SkillError(
+            f"dotctx package {pkg_dir!r} activates unknown skills: "
+            f"{', '.join(missing)} (available: {', '.join(sorted(by_name)) or 'none'})"
+        )
+    return tuple(by_name[name] for name in allowlist)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run python -m pytest tests/test_skills.py -v`
+Expected: PASS (23 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add julep/skills.py tests/test_skills.py
+git commit -m "feat(skills): package loader with explicit allowlist and level-2 limit"
+```
+
+---
+
+### Task 3: Registry citizenship
+
+**Files:**
+- Modify: `julep/registry.py:310-321` (the `Registry.__init__` body), and add methods after `get_renderer` (`julep/registry.py:565`)
+- Test: `tests/test_skills.py`
+
+**Interfaces:**
+- Consumes: `Skill`, `skill_key` from Task 1.
+- Produces: `Registry.skills: dict[str, Skill]`; `Registry.register_skill(skill: Skill) -> str` returning the key; `Registry.get_skill(key: str) -> Skill`; module-level `julep.skills.register_skill(skill, *, registry=DEFAULT_REGISTRY) -> str`, `julep.skills.get_skill(key, *, registry=DEFAULT_REGISTRY) -> Skill`, and `julep.skills.skill_keys(items: Sequence[Skill | str], *, registry=DEFAULT_REGISTRY) -> tuple[str, ...]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_skills.py`:
+
+```python
+from julep.registry import Registry
+from julep.skills import get_skill, register_skill, skill_keys
+
+
+def _skill(name: str, body: str = "body") -> Skill:
+    return Skill(name=name, description=f"describes {name}", body=body)
+
+
+def test_register_returns_the_content_key_and_round_trips() -> None:
+    reg = Registry()
+    key = reg.register_skill(_skill("alpha"))
+    assert key == skill_key(_skill("alpha"))
+    assert reg.get_skill(key).body == "body"
+
+
+def test_identical_skills_from_different_sources_converge() -> None:
+    reg = Registry()
+    a = Skill(name="alpha", description="describes alpha", body="body", source="pkg_a")
+    b = Skill(name="alpha", description="describes alpha", body="body", source="pkg_b")
+    assert reg.register_skill(a) == reg.register_skill(b)
+    assert len(reg.skills) == 1
+
+
+def test_edited_copies_coexist_under_distinct_keys() -> None:
+    reg = Registry()
+    first = reg.register_skill(_skill("alpha", body="one"))
+    second = reg.register_skill(_skill("alpha", body="two"))
+    assert first != second
+    assert len(reg.skills) == 2
+
+
+def test_unknown_key_teaches() -> None:
+    reg = Registry()
+    with pytest.raises(KeyError, match="unknown skill"):
+        reg.get_skill("skill/ghost@v000000000000")
+
+
+def test_skill_keys_registers_objects_and_passes_strings_through() -> None:
+    reg = Registry()
+    existing = reg.register_skill(_skill("beta"))
+    keys = skill_keys([_skill("alpha"), existing], registry=reg)
+    assert keys == (skill_key(_skill("alpha")), existing)
+    assert set(reg.skills) == set(keys)
+
+
+def test_module_level_helpers_use_the_default_registry() -> None:
+    key = register_skill(_skill("gamma-unique-to-this-test"))
+    assert get_skill(key).name == "gamma-unique-to-this-test"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run python -m pytest tests/test_skills.py -k "registry or register or skill_keys or unknown_key or converge or coexist" -v`
+Expected: FAIL — `AttributeError: 'Registry' object has no attribute 'register_skill'`
+
+- [ ] **Step 3: Implement registry support**
+
+In `julep/registry.py`, add to the imports at the top:
+
+```python
+from .skills import Skill, skill_key
+```
+
+In `Registry.__init__` (after `self.renderer_declarations` on line 314), add:
+
+```python
+        # Content-addressed agent skills (skill/<name>@v<hash12>). Keys carry
+        # their own content hash, so sharing them process-wide is safe.
+        self.skills: dict[str, Skill] = {}
+```
+
+After `get_renderer` (line 569), add:
+
+```python
+    def register_skill(self, skill: Skill) -> str:
+        """Register a skill under its content key and return that key.
+
+        ``Skill`` equality ignores ``source``, so byte-identical sidecars in
+        different packages register once. A genuine mismatch under one key is
+        impossible (the key hashes every compared field) and is treated as a
+        corrupt-input error rather than silently overwritten.
+        """
+        key = skill_key(skill)
+        existing = self.skills.get(key)
+        if existing is not None and existing != skill:
+            raise ValueError(
+                f"skill key {key!r} already registered with different content"
+            )
+        self.skills[key] = skill
+        return key
+
+    def get_skill(self, key: str) -> Skill:
+        try:
+            return self.skills[key]
+        except KeyError as e:
+            raise KeyError(
+                f"unknown skill {key!r}; load its dotctx package or call "
+                "register_skill()"
+            ) from e
+```
+
+Then append the module-level helpers to `julep/skills.py`:
+
+```python
+def register_skill(skill: Skill, *, registry: Any = None) -> str:
+    """Register ``skill`` and return its content-addressed key."""
+    from .registry import DEFAULT_REGISTRY
+
+    target = DEFAULT_REGISTRY if registry is None else registry
+    return target.register_skill(skill)
+
+
+def get_skill(key: str, *, registry: Any = None) -> Skill:
+    """Look up a registered skill by key."""
+    from .registry import DEFAULT_REGISTRY
+
+    target = DEFAULT_REGISTRY if registry is None else registry
+    return target.get_skill(key)
+
+
+def skill_keys(items: Sequence[Any], *, registry: Any = None) -> tuple[str, ...]:
+    """Bridge from authored ``Skill`` objects to ``Reasoner.skills`` keys.
+
+    ``Reasoner`` is a pure value type and never touches the registry, so a
+    code-first caller registers here and passes the returned keys in.
+    """
+    keys: list[str] = []
+    for item in items:
+        if isinstance(item, Skill):
+            keys.append(register_skill(item, registry=registry))
+        elif isinstance(item, str):
+            keys.append(item)
+        else:
+            raise SkillError(
+                f"expected a Skill or a skill key string, got {item!r}"
+            )
+    return tuple(keys)
+```
+
+Note the deferred `from .registry import DEFAULT_REGISTRY` inside each function: `julep/registry.py` imports `julep/skills.py` at module scope, so the reverse import must stay lazy.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run python -m pytest tests/test_skills.py -v`
+Expected: PASS (29 tests)
+
+- [ ] **Step 5: Verify no import cycle broke anything**
+
+Run: `uv run python -m pytest tests/test_renderer_registry.py tests/test_core.py -q`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add julep/registry.py julep/skills.py tests/test_skills.py
+git commit -m "feat(skills): content-addressed skill registry"
+```
+
+---
+
+### Task 4: `Reasoner.skills` and artifact identity
+
+**Files:**
+- Modify: `julep/dotctx.py:56-63` (`_REPLACE_HANDLED_FIELDS`), `julep/dotctx.py:183-200` (field block), `julep/dotctx.py:202-253` (`__init__`), `julep/dotctx.py:255-310` (`replace`)
+- Modify: `julep/deploy.py:200-229` (`_reasoner_identity`)
+- Test: `tests/test_skills_declarations.py`
+
+**Interfaces:**
+- Consumes: `SKILL_KEY_RE`, `SkillError` from Task 1.
+- Produces: `Reasoner.skills: tuple[str, ...]` (keyword-only in `__init__` and `replace`); `_reasoner_identity` emits `"skills"` only when non-empty.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_skills_declarations.py`:
+
+```python
+"""Reasoner.skills: identity, replace(), and the declarations blob round trip."""
+
+from __future__ import annotations
+
+import pytest
+
+from julep.dotctx import Reasoner
+from julep.skills import Skill, skill_key
+
+ALPHA = Skill(name="alpha", description="describes alpha", body="Do alpha.")
+BETA = Skill(name="beta", description="describes beta", body="Do beta.")
+ALPHA_KEY = skill_key(ALPHA)
+BETA_KEY = skill_key(BETA)
+
+
+def test_reasoner_defaults_to_no_skills() -> None:
+    assert Reasoner(name="r", model="openai:gpt-5.5").skills == ()
+
+
+def test_reasoner_stores_skill_keys_in_order() -> None:
+    r = Reasoner(name="r", model="openai:gpt-5.5", skills=[BETA_KEY, ALPHA_KEY])
+    assert r.skills == (BETA_KEY, ALPHA_KEY)
+
+
+def test_malformed_skill_key_is_rejected_at_construction() -> None:
+    with pytest.raises(ValueError, match="malformed skill key"):
+        Reasoner(name="r", model="openai:gpt-5.5", skills=["natural-writing"])
+
+
+def test_replace_preserves_and_overrides_skills() -> None:
+    r = Reasoner(name="r", model="openai:gpt-5.5", skills=[ALPHA_KEY])
+    assert r.replace(temperature=0.5).skills == (ALPHA_KEY,)
+    assert r.replace(skills=()).skills == ()
+    assert r.replace(skills=[BETA_KEY]).skills == (BETA_KEY,)
+
+
+def test_identity_omits_skills_when_absent_and_includes_them_when_set() -> None:
+    from julep.deploy import _reasoner_identity
+    from julep.registry import DEFAULT_REGISTRY
+
+    plain = Reasoner(name="ident-plain", model="openai:gpt-5.5")
+    DEFAULT_REGISTRY.register_reasoner(plain)
+    assert "skills" not in _reasoner_identity("ident-plain")
+
+    skilled = Reasoner(name="ident-skilled", model="openai:gpt-5.5", skills=[ALPHA_KEY])
+    DEFAULT_REGISTRY.register_reasoner(skilled)
+    assert _reasoner_identity("ident-skilled")["skills"] == [ALPHA_KEY]
+
+
+def test_editing_a_skill_body_moves_the_reasoner_identity() -> None:
+    from julep.deploy import _reasoner_identity
+    from julep.registry import DEFAULT_REGISTRY
+
+    edited = Skill(name="alpha", description="describes alpha", body="Do alpha DIFFERENTLY.")
+    before = Reasoner(name="ident-drift", model="openai:gpt-5.5", skills=[ALPHA_KEY])
+    DEFAULT_REGISTRY.register_reasoner(before)
+    first = _reasoner_identity("ident-drift")
+
+    DEFAULT_REGISTRY.reasoners.pop("ident-drift")
+    after = Reasoner(name="ident-drift", model="openai:gpt-5.5", skills=[skill_key(edited)])
+    DEFAULT_REGISTRY.register_reasoner(after)
+    assert _reasoner_identity("ident-drift") != first
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run python -m pytest tests/test_skills_declarations.py -v`
+Expected: FAIL — `TypeError: Reasoner.__init__() got an unexpected keyword argument 'skills'`
+
+- [ ] **Step 3: Add the field**
+
+In `julep/dotctx.py`, extend `_REPLACE_HANDLED_FIELDS` (line 56) with `"skills"`:
+
+```python
+_REPLACE_HANDLED_FIELDS = frozenset(
+    {
+        "name", "model", "system", "reply_schema", "tools", "temperature",
+        "max_rounds", "is_agent", "sub_contract", "context_scope",
+        "system_render", "user_render", "max_tokens", "reasoning_effort",
+        "output_retries", "require_tool_call", "response_format", "prompt_cache",
+        "skills",
+    }
+)
+```
+
+Add the declared field after `prompt_cache` (line 200):
+
+```python
+    skills: tuple[str, ...] = ()          # content-addressed skill/<name>@v<hash> keys
+```
+
+Add the keyword-only parameter to `__init__` after `prompt_cache` (line 222):
+
+```python
+        skills: Sequence[str] = (),
+```
+
+And set it after the `prompt_cache` validation block (line 253), validating each key:
+
+```python
+        from .skills import SKILL_KEY_RE
+
+        skill_keys_tuple = tuple(skills)
+        for key in skill_keys_tuple:
+            if SKILL_KEY_RE.match(key) is None:
+                raise ValueError(
+                    f"malformed skill key {key!r} on reasoner {name!r}; "
+                    "expected 'skill/<name>@v<12 hex chars>' — pass "
+                    "julep.skills.skill_keys([...]) rather than bare names"
+                )
+        object.__setattr__(self, "skills", skill_keys_tuple)
+```
+
+Add to `replace()`'s signature after `prompt_cache` (line 275):
+
+```python
+        skills: Sequence[str] = _KEEP,
+```
+
+and to the constructed `Reasoner` inside `replace()` (after line 303):
+
+```python
+            skills=_replacement(skills, self.skills),
+```
+
+In `julep/deploy.py`, add to `_reasoner_identity` after the `prompt_cache` clause (line 228):
+
+```python
+    if reasoner.skills:
+        ident["skills"] = list(reasoner.skills)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run python -m pytest tests/test_skills_declarations.py -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Verify frozen artifacts did not move**
+
+Run: `uv run python -m pytest tests/golden tests/test_agent_and_deploy.py -q`
+Expected: PASS — `_reasoner_identity` adds `skills` only when non-empty, so pre-existing artifacts hash identically.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add julep/dotctx.py julep/deploy.py tests/test_skills_declarations.py
+git commit -m "feat(skills): Reasoner.skills field and artifact identity"
+```
+
+---
+
+### Task 5: Wire the `skills:` setting into all three package layouts
+
+**Files:**
+- Modify: `julep/dotctx_rich.py:73-97` (`_ALLOWED_SETTINGS`), `julep/dotctx_rich.py:111-128` (`RichDotctx`), `julep/dotctx_rich.py:1067-1099` (`_build_reasoner`), `julep/dotctx_rich.py:1107-1163` (single file), `julep/dotctx_rich.py:1224-1242` (rich directory)
+- Modify: `julep/dotctx.py:449-505` (`reasoner_from_settings`)
+- Test: `tests/test_skills_dotctx.py`
+
+**Interfaces:**
+- Consumes: `load_package_skills`, `parse_skills_setting`, `skill_keys` from Tasks 2-3.
+- Produces: `RichDotctx.skills: tuple[Skill, ...]`; `skills:` accepted in `settings.yaml` for the minimal and rich directory layouts and rejected for single-file `.ctx`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_skills_dotctx.py`:
+
+```python
+"""The skills: setting across the minimal, rich, and single-file layouts."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytest.importorskip("jinja2")
+
+from julep.dotctx import load_dotctx
+from julep.dotctx_rich import load_rich_dotctx
+from julep.registry import Registry
+from julep.skills import InertSkillsDirectoryWarning, SkillError, skill_key
+
+
+def _skill_dir(pkg, name: str, body: str = "Do the thing.") -> None:
+    path = pkg / "skills" / name
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: describes {name}\n---\n\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def _rich_pkg(tmp_path, settings: str):
+    pkg = tmp_path / "draft.ctx"
+    pkg.mkdir()
+    (pkg / "settings.yaml").write_text(settings, encoding="utf-8")
+    (pkg / "prompt.j2").write_text(
+        "<<< role:system >>>\nYou draft.\n<<< role:user >>>\nGo.\n", encoding="utf-8"
+    )
+    return pkg
+
+
+def test_rich_package_activates_a_skill(tmp_path) -> None:
+    pkg = _rich_pkg(tmp_path, "model: openai:gpt-5.5\nskills: [alpha]\n")
+    _skill_dir(pkg, "alpha")
+    _skill_dir(pkg, "beta")
+    registry = Registry()
+    rich = load_rich_dotctx(str(pkg), registry=registry, env={})
+    assert [s.name for s in rich.skills] == ["alpha"]
+    assert rich.reasoner.skills == (skill_key(rich.skills[0]),)
+    assert rich.reasoner.skills[0] in registry.skills
+
+
+def test_rich_package_with_empty_list_activates_nothing(tmp_path) -> None:
+    pkg = _rich_pkg(tmp_path, "model: openai:gpt-5.5\nskills: []\n")
+    _skill_dir(pkg, "alpha")
+    rich = load_rich_dotctx(str(pkg), registry=Registry(), env={})
+    assert rich.skills == () and rich.reasoner.skills == ()
+
+
+def test_rich_package_warns_on_an_inert_skills_dir(tmp_path) -> None:
+    pkg = _rich_pkg(tmp_path, "model: openai:gpt-5.5\n")
+    _skill_dir(pkg, "alpha")
+    with pytest.warns(InertSkillsDirectoryWarning):
+        rich = load_rich_dotctx(str(pkg), registry=Registry(), env={})
+    assert rich.reasoner.skills == ()
+
+
+def test_rich_package_missing_skill_fails_closed(tmp_path) -> None:
+    pkg = _rich_pkg(tmp_path, "model: openai:gpt-5.5\nskills: [ghost]\n")
+    _skill_dir(pkg, "alpha")
+    with pytest.raises(SkillError, match="ghost"):
+        load_rich_dotctx(str(pkg), registry=Registry(), env={})
+
+
+def test_skills_is_an_accepted_settings_key(tmp_path) -> None:
+    pkg = _rich_pkg(tmp_path, "model: openai:gpt-5.5\nskills: [alpha]\n")
+    _skill_dir(pkg, "alpha")
+    load_rich_dotctx(str(pkg), registry=Registry(), env={})  # no unknown-key error
+
+
+def test_minimal_layout_supports_skills(tmp_path) -> None:
+    pkg = tmp_path / "planner"
+    pkg.mkdir()
+    (pkg / "settings.yaml").write_text(
+        "model: openai:gpt-5.5\nsystem: You plan.\nskills: [alpha]\n", encoding="utf-8"
+    )
+    _skill_dir(pkg, "alpha")
+    reasoner = load_dotctx(str(pkg), env={}, _registry=Registry())
+    assert len(reasoner.skills) == 1
+    assert reasoner.skills[0].startswith("skill/alpha@v")
+
+
+def test_single_file_ctx_rejects_skills(tmp_path) -> None:
+    path = tmp_path / "solo.ctx"
+    path.write_text(
+        "---\nmodel: openai:gpt-5.5\nskills: [alpha]\n---\nBody.\n", encoding="utf-8"
+    )
+    with pytest.raises(SkillError, match="single-file"):
+        load_rich_dotctx(str(path), registry=Registry(), env={})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run python -m pytest tests/test_skills_dotctx.py -v`
+Expected: FAIL — `ValueError: unknown settings keys ... skills`
+
+- [ ] **Step 3: Wire the loaders**
+
+In `julep/dotctx_rich.py`, add `"skills",` to `_ALLOWED_SETTINGS` (after `"tools",` on line 95).
+
+Add the import near the other `julep` imports (after line 61):
+
+```python
+from .skills import Skill, load_package_skills, parse_skills_setting
+```
+
+Add the field to `RichDotctx` (after line 128):
+
+```python
+    skills: tuple[Skill, ...] = ()
+```
+
+Give `_build_reasoner` a `skills` parameter — change its signature (line 1067) to add, after `user_render`:
+
+```python
+    skill_keys_: tuple[str, ...] = (),
+```
+
+and pass it into the constructed `Reasoner` (after line 1098):
+
+```python
+        skills=skill_keys_,
+```
+
+In `load_single_file_dotctx`, immediately after `_validate_settings_keys(settings, path)` (line 1133), add:
+
+```python
+    if parse_skills_setting(settings.get("skills"), origin=path) is not None:
+        raise SkillError(
+            f"single-file dotctx {path!r} cannot activate skills; skills load from "
+            "<package>.ctx/skills/<name>/SKILL.md, which needs the directory layout"
+        )
+```
+
+and import `SkillError` alongside the others.
+
+In `load_rich_dotctx`, after the `tools` tuple is built (line 1222), add:
+
+```python
+    skills = load_package_skills(
+        path, parse_skills_setting(settings.get("skills"), origin=path)
+    )
+    skill_key_tuple = tuple(registry.register_skill(skill) for skill in skills)
+```
+
+pass `skill_keys_=skill_key_tuple` into `_build_reasoner`, and add `skills=skills` to the returned `RichDotctx`.
+
+In `julep/dotctx.py`, inside `reasoner_from_settings`, resolve skills before constructing the Reasoner (just before the `return _registry.register_reasoner(...)` at line 505 — locate the `Reasoner(` construction that begins around line 484):
+
+```python
+    from .skills import load_package_skills, parse_skills_setting
+
+    skill_key_tuple: tuple[str, ...] = ()
+    declared = parse_skills_setting(settings.get("skills"), origin=base_dir or nm)
+    if base_dir is not None:
+        skill_key_tuple = tuple(
+            _registry.register_skill(skill)
+            for skill in load_package_skills(base_dir, declared)
+        )
+    elif declared:
+        raise ValueError(
+            f"reasoner {nm!r} declares skills but was built without a base_dir; "
+            "skills load from <package>/skills/<name>/SKILL.md"
+        )
+```
+
+and add `skills=skill_key_tuple,` to that `Reasoner(...)` call.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run python -m pytest tests/test_skills_dotctx.py -v`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Verify existing dotctx tests still pass**
+
+Run: `uv run python -m pytest tests/test_dotctx_rich.py tests/test_dotctx_single_file.py tests/test_dotctx_reply.py -q`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add julep/dotctx_rich.py julep/dotctx.py tests/test_skills_dotctx.py
+git commit -m "feat(skills): accept skills: in the minimal and rich dotctx layouts"
+```
+
+---
+
+### Task 6: Ship skills in the declarations blob
+
+**Files:**
+- Modify: `julep/app.py:535-571` (`_reasoner_runtime_declaration`)
+- Modify: `julep/declarations.py:23` (schema version), `julep/declarations.py:94-190` (`declarations_blob`), `julep/declarations.py:290-355` (`_reasoner_from_json`), `julep/declarations.py:418-530` (`load_declarations`)
+- Test: `tests/test_skills_declarations.py`
+
+**Interfaces:**
+- Consumes: `Reasoner.skills` (Task 4), `Registry.register_skill`/`get_skill` (Task 3).
+- Produces: blob key `"skills": {key: {"name", "description", "body"}}`; `_BLOB_SCHEMA_VERSION == 3`; `load_declarations` registers rebuilt skills into every target registry *and* `DEFAULT_REGISTRY`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_skills_declarations.py`:
+
+```python
+import hashlib
+import json
+
+
+def test_blob_carries_skill_bodies_and_round_trips() -> None:
+    from julep.declarations import declarations_blob, load_declarations
+    from julep.registry import Registry
+
+    source = Registry()
+    key = source.register_skill(ALPHA)
+    reasoner = Reasoner(name="blob-r", model="openai:gpt-5.5", skills=[key])
+    blob = declarations_blob([reasoner], registry=source)
+
+    payload = json.loads(blob)
+    assert payload["schemaVersion"] == 3
+    assert payload["skills"][key] == {
+        "name": "alpha",
+        "description": "describes alpha",
+        "body": "Do alpha.",
+    }
+    assert payload["reasoners"]["blob-r"]["skills"] == [key]
+
+    target = Registry()
+    load_declarations(
+        blob,
+        expected_hash="sha256:" + hashlib.sha256(blob).hexdigest(),
+        registry=target,
+    )
+    assert target.get_reasoner("blob-r").skills == (key,)
+    assert target.get_skill(key).body == "Do alpha."
+
+
+def test_blob_rejects_a_skill_key_that_does_not_match_its_content() -> None:
+    from julep.declarations import DeclarationError, load_declarations
+    from julep.registry import Registry
+
+    payload = {
+        "schemaVersion": 3,
+        "reasoners": {},
+        "renderers": {},
+        "agents": {},
+        "skills": {
+            "skill/alpha@v000000000000": {
+                "name": "alpha",
+                "description": "describes alpha",
+                "body": "Do alpha.",
+            }
+        },
+    }
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    with pytest.raises(DeclarationError, match="content hash"):
+        load_declarations(
+            blob,
+            expected_hash="sha256:" + hashlib.sha256(blob).hexdigest(),
+            registry=Registry(),
+        )
+
+
+def test_blob_rejects_a_reasoner_referencing_an_undeclared_skill() -> None:
+    from julep.declarations import DeclarationError, load_declarations
+    from julep.registry import Registry
+
+    payload = {
+        "schemaVersion": 3,
+        "reasoners": {
+            "orphan": {
+                "name": "orphan",
+                "model": "openai:gpt-5.5",
+                "system": "",
+                "replySchema": None,
+                "tools": [],
+                "temperature": None,
+                "maxRounds": None,
+                "isAgent": False,
+                "subContract": None,
+                "contextScope": "local",
+                "systemRender": None,
+                "userRender": None,
+                "maxTokens": None,
+                "reasoningEffort": None,
+                "outputRetries": 0,
+                "requireToolCall": False,
+                "responseFormat": None,
+                "promptCache": None,
+                "skills": [ALPHA_KEY],
+                "rendererSourceHashes": {},
+            }
+        },
+        "renderers": {},
+        "agents": {},
+        "skills": {},
+    }
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    with pytest.raises(DeclarationError, match="undeclared skill"):
+        load_declarations(
+            blob,
+            expected_hash="sha256:" + hashlib.sha256(blob).hexdigest(),
+            registry=Registry(),
+        )
+
+
+def test_blob_fails_when_the_source_registry_lacks_a_referenced_skill() -> None:
+    from julep.app import ApplicationDefinitionError
+    from julep.declarations import declarations_blob
+    from julep.registry import Registry
+
+    reasoner = Reasoner(name="missing-skill", model="openai:gpt-5.5", skills=[BETA_KEY])
+    with pytest.raises(ApplicationDefinitionError, match="no registered content"):
+        declarations_blob([reasoner], registry=Registry())
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run python -m pytest tests/test_skills_declarations.py -k blob -v`
+Expected: FAIL — `KeyError: 'skills'` / `assert 2 == 3`
+
+- [ ] **Step 3: Implement blob support**
+
+In `julep/app.py`, add to the dict returned by `_reasoner_runtime_declaration` (after `"promptCache"`, line 569):
+
+```python
+        "skills": list(reasoner.skills),
+```
+
+In `julep/declarations.py`:
+
+Bump line 23 to `_BLOB_SCHEMA_VERSION = 3`.
+
+In `declarations_blob`, after the `renderers` loop and before the `agents` block (line 143), add:
+
+```python
+    skills: dict[str, dict[str, Any]] = {}
+    for reasoner in reasoner_values.values():
+        for key in reasoner.skills:
+            if key in skills:
+                continue
+            skill = registry.skills.get(key)
+            if skill is None:
+                raise ApplicationDefinitionError(
+                    f"reasoner {reasoner.name!r} references skill {key!r} with no "
+                    "registered content; load its dotctx package before releasing"
+                )
+            skills[key] = {
+                "name": skill.name,
+                "description": skill.description,
+                "body": skill.body,
+            }
+```
+
+and add to the `payload` dict (after `"agents"`, line 187):
+
+```python
+        "skills": {name: skills[name] for name in sorted(skills)},
+```
+
+In `_reasoner_from_json`, read the list before constructing the Reasoner:
+
+```python
+    skills_raw = value.get("skills", [])
+    if not isinstance(skills_raw, list) or not all(
+        isinstance(item, str) for item in skills_raw
+    ):
+        _fail(f"reasoner {name!r} skills must be a list of strings")
+```
+
+and pass `skills=skills_raw,` into the returned `Reasoner(...)`.
+
+In `load_declarations`, after the renderers are rebuilt (line 452) add the skill rebuild:
+
+```python
+    from .skills import Skill, skill_key
+
+    skill_values = _object(payload.get("skills", {}), label="declarations skills")
+    rebuilt_skills: dict[str, Skill] = {}
+    for key, raw in skill_values.items():
+        entry = _object(raw, label=f"skill {key!r}")
+        skill = Skill(
+            name=_string(entry.get("name"), label=f"skill {key!r} name"),
+            description=_string(
+                entry.get("description"), label=f"skill {key!r} description"
+            ),
+            body=_string(entry.get("body"), label=f"skill {key!r} body"),
+        )
+        if skill_key(skill) != key:
+            _fail(f"skill {key!r} does not match the content hash of its declaration")
+        rebuilt_skills[key] = skill
+```
+
+After the reasoner renderer cross-check loop (line 477), add the skill cross-check:
+
+```python
+        for skill_ref in reasoner.skills:
+            if skill_ref not in rebuilt_skills:
+                _fail(f"reasoner {name!r} references undeclared skill {skill_ref!r}")
+```
+
+In the conflict-detection loop over `targets` (line 484), add:
+
+```python
+        for key, skill in rebuilt_skills.items():
+            existing_skill = target.skills.get(key)
+            if existing_skill is not None and existing_skill != skill:
+                raise ApplicationDefinitionError(
+                    f"skill {key!r} conflicts with the verified application declaration"
+                )
+```
+
+In the registration loop (line 509), add:
+
+```python
+        target.skills.update(rebuilt_skills)
+```
+
+And in the release-scoped global share block at the end (alongside renderers), add:
+
+```python
+    if release_scoped and registry is not DEFAULT_REGISTRY:
+        # Skill keys are content-addressed like renderer names, and the LLM
+        # caller resolves skill bodies from DEFAULT_REGISTRY, so share them.
+        DEFAULT_REGISTRY.skills.update(rebuilt_skills)
+```
+
+Place that inside the existing `if release_scoped and registry is not DEFAULT_REGISTRY:` block rather than adding a second one.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run python -m pytest tests/test_skills_declarations.py -v`
+Expected: PASS (10 tests)
+
+- [ ] **Step 5: Run the declarations and application suites**
+
+Run: `uv run python -m pytest tests/test_declarations.py tests/test_application.py -q`
+Expected: PASS. Any test asserting `schemaVersion == 2` must be updated to `3` — that is the intended breaking change for rc6.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add julep/app.py julep/declarations.py tests/test_skills_declarations.py
+git commit -m "feat(skills): carry skill bodies in the declarations blob (schema v3)"
+```
+
+---
+
+### Task 7: Prompt block and tool definition
+
+**Files:**
+- Modify: `julep/skills.py`
+- Test: `tests/test_llm_skills.py`
+
+**Interfaces:**
+- Consumes: `Skill` from Task 1.
+- Produces: `skills_prompt_block(skills: Sequence[Skill]) -> str`; `load_skill_tool_def(skills: Sequence[Skill], *, loaded: Sequence[str]) -> dict[str, Any]`; `inline_skills_block(skills: Sequence[Skill]) -> str`; `resolve_skill_keys(keys: Sequence[str], *, registry=None) -> tuple[Skill, ...]`; `batch_system_text(system: str, keys: Sequence[str], *, registry=None) -> str`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_llm_skills.py`:
+
+```python
+"""Progressive skill disclosure: the prompt block, the tool, and the inner loop."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import pytest
+
+from julep.dotctx import Reasoner
+from julep.registry import Registry
+from julep.skills import (
+    SKILL_TOOL,
+    Skill,
+    batch_system_text,
+    inline_skills_block,
+    load_skill_tool_def,
+    resolve_skill_keys,
+    skills_prompt_block,
+)
+
+ALPHA = Skill(name="alpha", description="Use for alpha work.", body="ALPHA BODY")
+BETA = Skill(name="beta", description="Use for beta work.", body="BETA BODY")
+
+
+def test_prompt_block_lists_names_and_descriptions_but_never_bodies() -> None:
+    block = skills_prompt_block([ALPHA, BETA])
+    assert "alpha" in block and "Use for alpha work." in block
+    assert "beta" in block and "Use for beta work." in block
+    assert "ALPHA BODY" not in block and "BETA BODY" not in block
+    assert SKILL_TOOL in block
+
+
+def test_tool_def_enumerates_only_undisclosed_skills() -> None:
+    definition = load_skill_tool_def([ALPHA, BETA], loaded=["alpha"])
+    assert definition["function"]["name"] == SKILL_TOOL
+    enum = definition["function"]["parameters"]["properties"]["name"]["enum"]
+    assert enum == ["beta"]
+    assert definition["function"]["parameters"]["required"] == ["name"]
+
+
+def test_inline_block_carries_full_bodies() -> None:
+    block = inline_skills_block([ALPHA])
+    assert "ALPHA BODY" in block and "Use for alpha work." in block
+
+
+def test_resolve_skill_keys_reads_the_registry() -> None:
+    reg = Registry()
+    key = reg.register_skill(ALPHA)
+    assert resolve_skill_keys([key], registry=reg) == (ALPHA,)
+
+
+def test_batch_system_text_inlines_and_preserves_the_system() -> None:
+    reg = Registry()
+    key = reg.register_skill(ALPHA)
+    text = batch_system_text("You draft.", [key], registry=reg)
+    assert text.endswith("You draft.")
+    assert "ALPHA BODY" in text
+
+
+def test_batch_system_text_passes_through_without_skills() -> None:
+    assert batch_system_text("You draft.", [], registry=Registry()) == "You draft."
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run python -m pytest tests/test_llm_skills.py -v`
+Expected: FAIL — `ImportError: cannot import name 'skills_prompt_block'`
+
+- [ ] **Step 3: Implement the formatters**
+
+Append to `julep/skills.py`:
+
+```python
+def resolve_skill_keys(keys: Sequence[str], *, registry: Any = None) -> tuple[Skill, ...]:
+    """Look up skill content for a reasoner's keys, in declaration order."""
+    from .registry import DEFAULT_REGISTRY
+
+    target = DEFAULT_REGISTRY if registry is None else registry
+    return tuple(target.get_skill(key) for key in keys)
+
+
+def skills_prompt_block(skills: Sequence[Skill]) -> str:
+    """The always-present metadata block: names and descriptions only.
+
+    This is disclosure level 1. It is a stable prefix, so it sits ahead of the
+    authored system prompt where prompt caching can cover it.
+    """
+    lines = [
+        "# Available skills",
+        "",
+        "Each skill below is a set of instructions you may load when it is "
+        f"relevant to the task. Call the `{SKILL_TOOL}` tool with the skill's "
+        "name to read its full instructions before you act on it. Load a skill "
+        "only when it applies; do not mention this mechanism in your reply.",
+        "",
+    ]
+    for skill in skills:
+        lines.append(f"- **{skill.name}** — {skill.description or '(no description)'}")
+    return "\n".join(lines)
+
+
+def inline_skills_block(skills: Sequence[Skill]) -> str:
+    """Every activated skill in full, for single-shot paths that cannot ask.
+
+    Batch submission has no tool round trip, so disclosure collapses to
+    inlining rather than silently dropping the instructions.
+    """
+    blocks = [
+        f"## {skill.name}\nDescription: {skill.description or '(none)'}\n\n{skill.body}".strip()
+        for skill in skills
+    ]
+    return "# Available skills\n\nUse these skills when they are relevant.\n\n" + "\n\n".join(
+        blocks
+    )
+
+
+def load_skill_tool_def(
+    skills: Sequence[Skill], *, loaded: Sequence[str] = ()
+) -> dict[str, Any]:
+    """The provider tool definition for ``__load_skill__``.
+
+    The enum lists only skills that have not been disclosed yet, so a model
+    cannot spend a round re-reading something already in its context.
+    """
+    remaining = [skill.name for skill in skills if skill.name not in set(loaded)]
+    return {
+        "type": "function",
+        "function": {
+            "name": SKILL_TOOL,
+            "description": (
+                "Load the full instructions for one available skill. Call this "
+                "before acting when a skill applies to the task."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The skill to load.",
+                        "enum": remaining,
+                    }
+                },
+                "required": ["name"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+def batch_system_text(
+    system: str, keys: Sequence[str], *, registry: Any = None
+) -> str:
+    """System text for a single-shot batch request: skills inlined, or unchanged."""
+    if not keys:
+        return system
+    block = inline_skills_block(resolve_skill_keys(keys, registry=registry))
+    return f"{block}\n\n{system}" if system else block
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run python -m pytest tests/test_llm_skills.py -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add julep/skills.py tests/test_llm_skills.py
+git commit -m "feat(skills): prompt metadata block, load_skill tool def, batch inlining"
+```
+
+---
+
+### Task 8: The disclosure loop in `complete_reasoner`
+
+**Files:**
+- Modify: `julep/execution/llm_result.py:24-42` (`LlmCallMeta`) and its `to_attrs`
+- Modify: `julep/execution/llm.py:618-800` (inside `complete_reasoner`)
+- Test: `tests/test_llm_skills.py`
+
+**Interfaces:**
+- Consumes: `SKILL_TOOL`, `resolve_skill_keys`, `skills_prompt_block`, `load_skill_tool_def` (Task 7); `Reasoner.skills` (Task 4).
+- Produces: `LlmCallMeta.skill_loads: tuple[str, ...]` and the `llm.skill_loads` attr; `complete_reasoner` transparently resolving `__load_skill__` calls.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_llm_skills.py`:
+
+```python
+from conftest import run
+from julep.execution.llm import complete_reasoner
+
+
+@dataclass
+class FakeFunction:
+    name: str
+    arguments: str
+
+
+@dataclass
+class FakeToolCall:
+    id: str
+    function: FakeFunction
+
+
+@dataclass
+class FakeMessage:
+    content: Optional[str] = None
+    parsed: Any = None
+    tool_calls: Optional[list[FakeToolCall]] = None
+
+
+@dataclass
+class FakeChoice:
+    message: FakeMessage
+
+
+@dataclass
+class FakeCompletion:
+    choices: list[FakeChoice]
+    usage: Any = None
+    model: str = "m"
+
+
+def _text(content: str) -> FakeCompletion:
+    return FakeCompletion(choices=[FakeChoice(FakeMessage(content=content))])
+
+
+def _skill_call(name: str, call_id: str = "c1") -> FakeCompletion:
+    return FakeCompletion(
+        choices=[
+            FakeChoice(
+                FakeMessage(
+                    tool_calls=[
+                        FakeToolCall(call_id, FakeFunction(SKILL_TOOL, json.dumps({"name": name})))
+                    ]
+                )
+            )
+        ]
+    )
+
+
+def _registry_with(*skills: Skill) -> tuple[Registry, tuple[str, ...]]:
+    reg = Registry()
+    return reg, tuple(reg.register_skill(skill) for skill in skills)
+
+
+def _reasoner(keys: tuple[str, ...], **kwargs: Any) -> Reasoner:
+    return Reasoner(
+        name="skilled",
+        model="gemini:gemini-2.5-flash",   # prompt-fallback provider: one dispatch path
+        system="You draft.",
+        skills=list(keys),
+        **kwargs,
+    )
+
+
+def test_descriptions_are_in_the_system_prompt_and_bodies_are_not(monkeypatch) -> None:
+    reg, keys = _registry_with(ALPHA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+    seen: list[list[dict[str, Any]]] = []
+
+    async def acompletion(**kwargs: Any) -> Any:
+        seen.append(kwargs["messages"])
+        return _text("done")
+
+    run(complete_reasoner(_reasoner(keys), "hi", acompletion=acompletion))
+    system = seen[0][0]["content"]
+    assert "Use for alpha work." in system
+    assert "ALPHA BODY" not in system
+    assert system.rstrip().endswith("You draft.")
+
+
+def test_skill_tool_is_offered_when_skills_are_active(monkeypatch) -> None:
+    reg, keys = _registry_with(ALPHA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+    seen: list[Any] = []
+
+    async def acompletion(**kwargs: Any) -> Any:
+        seen.append(kwargs.get("tools"))
+        return _text("done")
+
+    run(complete_reasoner(_reasoner(keys), "hi", acompletion=acompletion))
+    assert [t["function"]["name"] for t in seen[0]] == [SKILL_TOOL]
+
+
+def test_no_tool_and_no_block_without_skills() -> None:
+    seen: list[Any] = []
+
+    async def acompletion(**kwargs: Any) -> Any:
+        seen.append(kwargs)
+        return _text("done")
+
+    run(complete_reasoner(_reasoner(()), "hi", acompletion=acompletion))
+    assert "tools" not in seen[0]
+    assert "Available skills" not in seen[0]["messages"][0]["content"]
+
+
+def test_loading_a_skill_feeds_the_body_back_and_re_asks(monkeypatch) -> None:
+    reg, keys = _registry_with(ALPHA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+    replies = iter([_skill_call("alpha"), _text("drafted")])
+    seen: list[list[dict[str, Any]]] = []
+
+    async def acompletion(**kwargs: Any) -> Any:
+        seen.append(kwargs["messages"])
+        return next(replies)
+
+    result = run(complete_reasoner(_reasoner(keys), "hi", acompletion=acompletion))
+    assert result.reply == "drafted"
+    assert result.meta.skill_loads == ("alpha",)
+    assert result.meta.to_attrs()["llm.skill_loads"] == ["alpha"]
+    tool_turns = [m for m in seen[1] if m.get("role") == "tool"]
+    assert tool_turns and tool_turns[0]["content"] == "ALPHA BODY"
+
+
+def test_tool_is_withdrawn_after_the_last_skill_loads(monkeypatch) -> None:
+    reg, keys = _registry_with(ALPHA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+    replies = iter([_skill_call("alpha"), _text("drafted")])
+    seen: list[Any] = []
+
+    async def acompletion(**kwargs: Any) -> Any:
+        seen.append(kwargs.get("tools"))
+        return next(replies)
+
+    run(complete_reasoner(_reasoner(keys), "hi", acompletion=acompletion))
+    assert seen[0] is not None and seen[1] is None
+
+
+def test_second_skill_stays_loadable(monkeypatch) -> None:
+    reg, keys = _registry_with(ALPHA, BETA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+    replies = iter([_skill_call("alpha"), _skill_call("beta", "c2"), _text("drafted")])
+
+    async def acompletion(**kwargs: Any) -> Any:
+        return next(replies)
+
+    result = run(complete_reasoner(_reasoner(keys), "hi", acompletion=acompletion))
+    assert result.meta.skill_loads == ("alpha", "beta")
+
+
+def test_unknown_skill_name_is_answered_not_raised(monkeypatch) -> None:
+    reg, keys = _registry_with(ALPHA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+    replies = iter([_skill_call("ghost"), _text("drafted")])
+    seen: list[list[dict[str, Any]]] = []
+
+    async def acompletion(**kwargs: Any) -> Any:
+        seen.append(kwargs["messages"])
+        return next(replies)
+
+    result = run(complete_reasoner(_reasoner(keys), "hi", acompletion=acompletion))
+    assert result.reply == "drafted"
+    assert result.meta.skill_loads == ()
+    tool_turn = [m for m in seen[1] if m.get("role") == "tool"][0]
+    assert "ghost" in tool_turn["content"] and "alpha" in tool_turn["content"]
+
+
+def test_repeated_requests_cannot_spin_forever(monkeypatch) -> None:
+    reg, keys = _registry_with(ALPHA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+    calls = 0
+
+    async def acompletion(**kwargs: Any) -> Any:
+        nonlocal calls
+        calls += 1
+        return _skill_call("ghost", f"c{calls}")
+
+    result = run(complete_reasoner(_reasoner(keys), "hi", acompletion=acompletion))
+    assert calls <= 4                      # bounded, not unbounded
+    assert result.meta.skill_loads == ()
+
+
+def test_skill_calls_never_leak_to_the_agent_loop(monkeypatch) -> None:
+    reg, keys = _registry_with(ALPHA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+
+    async def acompletion(**kwargs: Any) -> Any:
+        return _skill_call("alpha")        # never stops asking, budget closes it
+
+    result = run(complete_reasoner(_reasoner(keys), "hi", acompletion=acompletion))
+    calls = result.reply.get("tool_calls", []) if isinstance(result.reply, dict) else []
+    assert all(call["tool"] != SKILL_TOOL for call in calls)
+    assert result.meta.native_tool_calls == 0
+
+
+def test_real_tool_name_colliding_with_the_reserved_name_is_rejected(monkeypatch) -> None:
+    reg, keys = _registry_with(ALPHA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+    tools = [{"type": "function", "function": {"name": SKILL_TOOL, "parameters": {}}}]
+
+    async def acompletion(**kwargs: Any) -> Any:
+        return _text("done")
+
+    with pytest.raises(ValueError, match="reserved"):
+        run(complete_reasoner(_reasoner(keys), "hi", acompletion=acompletion, tools=tools))
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run python -m pytest tests/test_llm_skills.py -v`
+Expected: FAIL — `AttributeError: 'LlmCallMeta' object has no attribute 'skill_loads'`
+
+- [ ] **Step 3: Add the meta field**
+
+In `julep/execution/llm_result.py`, add after `native_tool_calls` (line 36):
+
+```python
+    skill_loads: tuple[str, ...] = ()
+```
+
+and in `to_attrs`, after the existing entries, add:
+
+```python
+        if self.skill_loads:
+            out["llm.skill_loads"] = list(self.skill_loads)
+```
+
+- [ ] **Step 4: Implement the loop**
+
+In `julep/execution/llm.py`, add the imports near the other `julep` imports. `DEFAULT_REGISTRY` must be bound at module scope — `resolve_skill_keys` would otherwise resolve it lazily inside `julep.skills`, and the tests below (like `julep/prompt.py`'s renderer lookups) patch it on this module:
+
+```python
+from ..registry import DEFAULT_REGISTRY
+from ..skills import (
+    SKILL_TOOL,
+    load_skill_tool_def,
+    resolve_skill_keys,
+    skills_prompt_block,
+)
+```
+
+Immediately after `safe_tools, tool_name_reverse = (...)` (line 625), insert the skill state:
+
+```python
+    active_skills = (
+        resolve_skill_keys(reasoner.skills, registry=DEFAULT_REGISTRY)
+        if reasoner.skills
+        else ()
+    )
+    if active_skills and any(
+        tool_def.get("function", {}).get("name") == SKILL_TOOL for tool_def in safe_tools
+    ):
+        raise ValueError(
+            f"reasoner {reasoner.name!r} grants a tool named {SKILL_TOOL!r}, which is "
+            "reserved for skill disclosure; rename the tool"
+        )
+    system_text = reasoner.system
+    if active_skills:
+        block = skills_prompt_block(active_skills)
+        system_text = f"{block}\n\n{reasoner.system}" if reasoner.system else block
+    loaded_skills: list[str] = []
+    skill_turns: list[dict[str, Any]] = []
+    skill_tool_open = bool(active_skills)
+    skill_error_budget = 2
+
+    def _offering_tools() -> bool:
+        return bool(safe_tools) or skill_tool_open
+```
+
+Replace all three `reasoner.system` arguments inside `call()` (lines 660, 671, 678) with `system_text`.
+
+Inside `call()`, replace the `native_response_format` line (653) and the `has_tools` tool-attachment block (line 679) with:
+
+```python
+        offered_tools = list(safe_tools)
+        if skill_tool_open:
+            offered_tools.append(load_skill_tool_def(active_skills, loaded=loaded_skills))
+        native_response_format = native and not offered_tools
+```
+
+```python
+        if offered_tools:
+            kwargs["tools"] = offered_tools
+            if parallel_tool_calls is not None:
+                kwargs["parallel_tool_calls"] = parallel_tool_calls
+```
+
+Also inside `call()`, append the accumulated skill turns right before the `retry_note` append (line 683):
+
+```python
+        messages.extend(skill_turns)
+```
+
+In `dispatch_once`, change the native-attempt guard (line 727) from `if not has_tools and ...` to:
+
+```python
+        if not _offering_tools() and (schema is not None or json_object) and native_ok \
+                and provider not in _PROMPT_FALLBACK_PROVIDERS:
+```
+
+Replace the block from `completion = await dispatch_once()` (line 744) through the end of the `output_retries` loop (line 778) with:
+
+```python
+    pt = ct = tt = None
+    cache_read = cache_creation = None
+
+    def _accumulate(result: Any) -> None:
+        nonlocal pt, ct, tt, cache_read, cache_creation
+        apt, act, att = _usage_of(result)
+        pt, ct, tt = _add_tokens(pt, apt), _add_tokens(ct, act), _add_tokens(tt, att)
+        rcr, rcc = _cache_usage_of(result)
+        cache_read = _add_tokens(cache_read, rcr)
+        cache_creation = _add_tokens(cache_creation, rcc)
+
+    def _parse(result: Any, *, expect_json: bool) -> tuple[Any, int]:
+        parsed, calls = (
+            parse_responses_reply(result, expect_json=expect_json)
+            if is_responses_result(result)
+            else _parse_completion_reply(result, expect_json=expect_json)
+        )
+        return _restore_tool_calls(parsed), calls
+
+    def _skill_requests(parsed: Any) -> list[tuple[Any, Any]]:
+        if not isinstance(parsed, dict):
+            return []
+        calls = parsed.get("tool_calls")
+        if not isinstance(calls, list):
+            return []
+        return [
+            (call.get("id"), (call.get("input") or {}).get("name"))
+            for call in calls
+            if isinstance(call, dict) and call.get("tool") == SKILL_TOOL
+        ]
+
+    def _drop_skill_calls(parsed: Any) -> tuple[Any, int]:
+        """Skill calls are resolved here and must never reach the agent loop."""
+        if not isinstance(parsed, dict) or not isinstance(parsed.get("tool_calls"), list):
+            return parsed, 0
+        kept = [call for call in parsed["tool_calls"] if call.get("tool") != SKILL_TOOL]
+        if len(kept) == len(parsed["tool_calls"]):
+            return parsed, len(kept)
+        remainder = {key: item for key, item in parsed.items() if key != "tool_calls"}
+        if kept:
+            remainder["tool_calls"] = kept
+        return (remainder or None), len(kept)
+
+    completion = await dispatch_once()
+    _accumulate(completion)
+    reply, native_tool_calls = _parse(completion, expect_json=schema is not None)
+
+    # Progressive skill disclosure: resolve __load_skill__ from the frozen skill
+    # set and re-ask, inside this one call. The IR never sees these rounds, so a
+    # think leaf stays a think leaf and max_rounds keeps counting task progress.
+    while skill_tool_open:
+        requests = _skill_requests(reply)
+        if not requests:
+            skill_tool_open = False
+            break
+        by_name = {skill.name: skill for skill in active_skills}
+        skill_turns.append(
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": call_id,
+                        "type": "function",
+                        "function": {
+                            "name": SKILL_TOOL,
+                            "arguments": json.dumps({"name": name}),
+                        },
+                    }
+                    for call_id, name in requests
+                ],
+            }
+        )
+        for call_id, name in requests:
+            if name in loaded_skills:
+                skill_error_budget -= 1
+                content = f"skill {name!r} was already provided above"
+            elif name not in by_name:
+                skill_error_budget -= 1
+                content = (
+                    f"unknown skill {name!r}; available skills are: "
+                    + ", ".join(sorted(by_name))
+                )
+            else:
+                loaded_skills.append(str(name))
+                content = by_name[name].body
+            skill_turns.append(
+                {"role": "tool", "tool_call_id": call_id, "content": content}
+            )
+        if len(loaded_skills) >= len(active_skills) or skill_error_budget <= 0:
+            skill_tool_open = False
+        completion = await dispatch_once()
+        _accumulate(completion)
+        reply, native_tool_calls = _parse(completion, expect_json=schema is not None)
+
+    reply, native_tool_calls = _drop_skill_calls(reply)
+
+    validation_error = _final_output_schema_error(reply, native_tool_calls)
+    while schema is not None and validation_error is not None and retries_used < reasoner.output_retries:
+        retries_used += 1
+        logger.warning(
+            "reply for %s failed JSON-Schema validation (%s); re-ask %d/%d",
+            reasoner.name, validation_error, retries_used, reasoner.output_retries,
+        )
+        completion = await dispatch_once(
+            retry_note=(
+                "Your previous reply was not a single valid JSON object matching "
+                f"the required schema ({validation_error}). Reply again with ONLY "
+                "the corrected JSON object."
+            )
+        )
+        _accumulate(completion)
+        reply, native_tool_calls = _parse(completion, expect_json=True)
+        reply, native_tool_calls = _drop_skill_calls(reply)
+        validation_error = _final_output_schema_error(reply, native_tool_calls)
+```
+
+Finally, add `skill_loads=tuple(loaded_skills),` to the `LlmCallMeta(...)` construction (around line 798).
+
+Note `_drop_skill_calls` returns the count of *real* tool calls, which is what `native_tool_calls` must report; when a turn held only skill calls it returns `None` as the reply so schema validation treats it as a missing answer rather than an intermediate tool turn.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `uv run python -m pytest tests/test_llm_skills.py -v`
+Expected: PASS (16 tests)
+
+- [ ] **Step 6: Verify the existing LLM suites are untouched**
+
+Run: `uv run python -m pytest tests/test_llm.py tests/test_llm_output_retries.py tests/test_llm_native_tools.py tests/test_llm_prompt_cache.py tests/test_llm_effort.py tests/test_llm_fallback_recorded.py tests/test_openai_responses.py -q`
+Expected: PASS — a reasoner with no skills takes exactly the old path.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add julep/execution/llm.py julep/execution/llm_result.py tests/test_llm_skills.py
+git commit -m "feat(skills): progressive disclosure loop inside complete_reasoner"
+```
+
+---
+
+### Task 9: Batch paths inline instead of dropping
+
+**Files:**
+- Modify: `julep/execution/openai_batch.py:55-66`
+- Modify: `julep/execution/anthropic_batch.py:66-80`
+- Test: `tests/test_llm_skills.py`
+
+**Interfaces:**
+- Consumes: `batch_system_text` (Task 7).
+- Produces: both batch adapters emitting inlined skill bodies for skill-bearing reasoners.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_llm_skills.py`:
+
+```python
+def test_openai_batch_inlines_skill_bodies(monkeypatch) -> None:
+    from julep.execution.openai_batch import OpenAIBatchProvider
+
+    reg, keys = _registry_with(ALPHA)
+    monkeypatch.setattr("julep.execution.openai_batch.DEFAULT_REGISTRY", reg)
+    reasoner = Reasoner(
+        name="batched", model="openai:gpt-5.5", system="You draft.", skills=list(keys)
+    )
+    request = OpenAIBatchProvider().build_request("cid", reasoner, {"x": 1})
+    system = request["body"]["messages"][0]["content"]
+    assert "ALPHA BODY" in system and system.rstrip().endswith("You draft.")
+
+
+def test_openai_batch_is_unchanged_without_skills(monkeypatch) -> None:
+    from julep.execution.openai_batch import OpenAIBatchProvider
+
+    reasoner = Reasoner(name="plain-batch", model="openai:gpt-5.5", system="You draft.")
+    request = OpenAIBatchProvider().build_request("cid", reasoner, {"x": 1})
+    assert request["body"]["messages"][0]["content"] == "You draft."
+```
+
+The provider classes are `OpenAIBatchProvider` (`julep/execution/openai_batch.py:26`) and `AnthropicBatchProvider` (`julep/execution/anthropic_batch.py:37`); `build_request(custom_id, reasoner, value, *, transcript=None, dispatch=None)` is the shared signature.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run python -m pytest tests/test_llm_skills.py -k batch -v`
+Expected: FAIL — the system message is `"You draft."` with no skill body.
+
+- [ ] **Step 3: Implement**
+
+In `julep/execution/openai_batch.py`, add the imports:
+
+```python
+from ..registry import DEFAULT_REGISTRY
+from ..skills import batch_system_text
+```
+
+and replace `reasoner.system` in the `_messages(...)` call (line 61) with:
+
+```python
+                batch_system_text(reasoner.system, reasoner.skills, registry=DEFAULT_REGISTRY),
+```
+
+Make the identical change in `julep/execution/anthropic_batch.py` at its `_messages(...)` call (line 72).
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run python -m pytest tests/test_llm_skills.py -k batch -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Run the batch suites**
+
+Run: `uv run python -m pytest tests/test_anthropic_batch.py tests/test_batch_provider.py -q`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add julep/execution/openai_batch.py julep/execution/anthropic_batch.py tests/test_llm_skills.py
+git commit -m "feat(skills): inline skills on the single-shot batch paths"
+```
+
+---
+
+### Task 10: Public API surface
+
+**Files:**
+- Modify: `julep/__init__.py:201` (the `from .dotctx import (...)` block area) and the `__all__` list near line 343
+- Test: `tests/test_skills.py`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: `julep.Skill`, `julep.register_skill`, `julep.get_skill`, `julep.skill_keys`, `julep.load_package_skills`, `julep.SkillError`, `julep.SKILL_TOOL`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_skills.py`:
+
+```python
+def test_public_exports() -> None:
+    import julep
+
+    assert julep.Skill is Skill
+    assert julep.SKILL_TOOL == SKILL_TOOL
+    for name in (
+        "Skill",
+        "SkillError",
+        "SKILL_TOOL",
+        "register_skill",
+        "get_skill",
+        "skill_keys",
+        "load_package_skills",
+    ):
+        assert name in julep.__all__, name
+
+
+def test_code_first_authoring_round_trip() -> None:
+    from julep.dotctx import Reasoner
+    from julep.registry import Registry
+
+    reg = Registry()
+    written = Skill(
+        name="house-style", description="How we write.", body="Short sentences."
+    )
+    reasoner = Reasoner(
+        name="code-first",
+        model="openai:gpt-5.5",
+        system="You write.",
+        skills=skill_keys([written], registry=reg),
+    )
+    assert reg.get_skill(reasoner.skills[0]).body == "Short sentences."
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run python -m pytest tests/test_skills.py -k "public_exports or code_first" -v`
+Expected: FAIL — `AttributeError: module 'julep' has no attribute 'Skill'`
+
+- [ ] **Step 3: Add the exports**
+
+In `julep/__init__.py`, next to the other submodule imports, add:
+
+```python
+from .skills import (
+    SKILL_TOOL as SKILL_TOOL,
+    Skill as Skill,
+    SkillError as SkillError,
+    get_skill as get_skill,
+    load_package_skills as load_package_skills,
+    register_skill as register_skill,
+    skill_keys as skill_keys,
+)
+```
+
+and extend `__all__` with:
+
+```python
+    "Skill", "SkillError", "SKILL_TOOL",
+    "register_skill", "get_skill", "skill_keys", "load_package_skills",
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run python -m pytest tests/test_skills.py -v`
+Expected: PASS (31 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add julep/__init__.py tests/test_skills.py
+git commit -m "feat(skills): public API exports"
+```
+
+---
+
+### Task 11: mem-mcp compat fixture and sweep cleanup
+
+**Files:**
+- Create: `tests/fixtures/memmcp/brief_draft.ctx/settings.yaml`, `prompt.j2`, `schema.pyi`, `skills/natural-writing/SKILL.md`
+- Modify: `tests/test_memmcp_compat.py:1-14` (docstring), `tests/test_memmcp_compat.py:176-209` (the sweep)
+- Test: `tests/test_memmcp_compat.py`
+
+**Interfaces:**
+- Consumes: the full stack, Tasks 1-10.
+- Produces: the sweep tolerance removed; a vendored skill-bearing fixture.
+
+- [ ] **Step 1: Create the fixture**
+
+`tests/fixtures/memmcp/brief_draft.ctx/settings.yaml`:
+
+```yaml
+# AI-ANCHOR: prompt: living brief draft agent settings
+model: !? $env.get("LIVING_BRIEF_DRAFT_MODEL", "openai:chat-latest")
+temperature: 1.0
+reasoning_effort: medium
+max_rounds: 2
+output_retries: 1
+skills: [natural-writing]
+```
+
+`tests/fixtures/memmcp/brief_draft.ctx/prompt.j2`:
+
+```jinja
+<<< role:system >>>
+You draft a living brief.
+<<< role:user >>>
+Draft the brief for {{ title }}.
+```
+
+`tests/fixtures/memmcp/brief_draft.ctx/schema.pyi`:
+
+```python
+class Output:
+    draft: str
+```
+
+`tests/fixtures/memmcp/brief_draft.ctx/skills/natural-writing/SKILL.md` (body trimmed, structure exact — mirrors the real sidecar):
+
+```markdown
+---
+name: natural-writing
+description: >
+  Write like a human, not a language model. Use this skill whenever Claude is
+  producing prose meant to be read by people.
+---
+
+# Natural Writing
+
+LLM text is detectable because it regresses to the mean.
+
+## 1. Cut the Significance Inflation
+
+Do not stuff sentences with claims about how pivotal something is.
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `tests/test_memmcp_compat.py`:
+
+```python
+# --------------------------------------------------------------------------- #
+# brief_draft.ctx: the skills: setting with progressive disclosure.
+# --------------------------------------------------------------------------- #
+def test_brief_draft_activates_one_skill_without_inlining_it() -> None:
+    from julep.prompt import get_renderer
+    from julep.registry import Registry
+
+    rich = load_rich_dotctx(
+        str(FIXTURES / "brief_draft.ctx"), registry=Registry(), env={}
+    )
+    assert [s.name for s in rich.skills] == ["natural-writing"]
+    assert rich.reasoner.skills[0].startswith("skill/natural-writing@v")
+    # Disclosure is progressive: the body is not in the rendered system prompt.
+    system = get_renderer(rich.reasoner.system_render)({})
+    assert "Significance Inflation" not in system
+    assert system.startswith("You draft a living brief.")
+```
+
+- [ ] **Step 3: Run the test to verify it passes**
+
+Run: `uv run python -m pytest tests/test_memmcp_compat.py::test_brief_draft_activates_one_skill_without_inlining_it -v`
+Expected: PASS (the stack is complete by now; this is a characterization test proving the fixture loads).
+
+- [ ] **Step 4: Remove the sweep tolerance**
+
+In `tests/test_memmcp_compat.py`, delete the `except` clause's tolerance (lines 196-201), leaving:
+
+```python
+        try:
+            rich = load_rich_dotctx(str(path), registry=Registry(), env={})
+        except Exception as exc:
+            failures.append(f"{path.relative_to(_MEM_MCP_PROMPTS)}: {exc}")
+            continue
+```
+
+Wrap the sweep body so the inert-directory warning does not fail a `-W error` run — add at the top of `test_sibling_repo_supported_prompts_all_load`:
+
+```python
+    # plan_sections.ctx ships skills/ with no skills: key. Under Julep's
+    # explicit-activation rule that is inert and warns; the sweep only cares
+    # that every package still loads.
+    warnings.filterwarnings("ignore", category=InertSkillsDirectoryWarning)
+```
+
+with `import warnings` and `from julep.skills import InertSkillsDirectoryWarning` at the top of the file.
+
+Update the module docstring's fixture inventory (lines 1-14) to mention `brief_draft.ctx` alongside the others.
+
+- [ ] **Step 5: Run the compat suite**
+
+Run: `uv run python -m pytest tests/test_memmcp_compat.py -v`
+Expected: PASS, including `test_sibling_repo_supported_prompts_all_load` with zero tolerated failures (the sibling repo is checked out at `/home/diwank/github.com/julep-ai/mem-mcp`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/fixtures/memmcp/brief_draft.ctx tests/test_memmcp_compat.py
+git commit -m "test(skills): vendor a skill-bearing fixture and drop the sweep tolerance"
+```
+
+---
+
+### Task 12: Documentation
+
+**Files:**
+- Modify: `docs-site/content/docs/internals/dotctx-format.md:35-50` (the layout block) and add a `### Skills` section after the `tools.pyi` section (around line 156)
+- Test: `uv run python -m pytest tests/test_cookbook_examples.py -q` (docs snippets are executed by the docs runner)
+
+**Interfaces:**
+- Consumes: the finished feature.
+- Produces: user-facing documentation of the format, the divergence from mem-mcp, and the programmatic API.
+
+- [ ] **Step 1: Update the layout diagram**
+
+In the rich-layout code block, add the `skills/` entry:
+
+```
+<name>.ctx/
+├── settings.yaml        # name, model, temperature, max_rounds, agent, sub, context, tools, skills
+├── schema.pyi           # input/output models -> reply_schema (JSON Schema)
+├── tools.pyi            # tool stubs -> granted tool keys + expected schemas
+├── skills/              # activated by settings.yaml `skills:` (see below)
+│   └── <skill-name>/
+│       └── SKILL.md     # YAML frontmatter (name, description) + markdown body
+├── prompt.j2            # single-template form (optional <<< role:... >>> markers), OR
+└── messages/            # multi-message form
+```
+
+- [ ] **Step 2: Add the Skills section**
+
+```markdown
+### `skills/` → progressive disclosure
+
+A package may ship agent skills as `skills/<name>/SKILL.md` — YAML frontmatter
+(`name`, `description`) followed by a markdown body. Activation is **explicit**:
+
+```yaml
+skills: [natural-writing]
+```
+
+- The key **absent** activates nothing (a present-but-unused `skills/`
+  directory warns). `skills: []` also activates nothing, silently.
+- A configured name with no matching sidecar is a load error, as is a
+  directory whose name disagrees with its frontmatter `name`.
+- Only `SKILL.md` is read. Any other file in a skill directory is a load
+  error — bundled skill resources (`references/`, `scripts/`) are reserved.
+
+Disclosure is progressive. Only the name and description of each activated
+skill reach the system prompt; the body arrives when the model calls the
+reserved `__load_skill__` tool, which the LLM caller resolves from the frozen
+release and answers in place. Those round trips happen *inside* one reasoner
+call: the flow shape is unchanged, `max_rounds` still counts rounds of task
+progress, and skill calls never reach the agent loop. `LlmCallMeta.skill_loads`
+records which skills were actually read.
+
+Single-shot batch submission has no tool round trip, so a batched reasoner
+inlines every activated skill instead.
+
+Skills are content-addressed as `skill/<name>@v<hash12>` over
+(name, description, body), and `Reasoner.skills` holds those keys — so editing
+a skill body moves the reasoner identity exactly the way editing a template
+does, and byte-identical copies in different packages cost one artifact entry.
+
+**Differences from mem-mcp's `skills:`.** mem-mcp activates *all* skills when
+the key is absent and inlines every body into the system prompt. Julep requires
+explicit activation and discloses progressively, so a package migrating from
+mem-mcp must list the names it wants.
+
+Programmatically:
+
+```python
+from julep import Reasoner, Skill, skill_keys
+
+house_style = Skill(
+    name="house-style",
+    description="How we write.",
+    body="Short sentences. Concrete nouns.",
+)
+reasoner = Reasoner(
+    name="drafter",
+    model="openai:gpt-5.5",
+    system="You draft release notes.",
+    skills=skill_keys([house_style]),
+)
+```
+
+`Reasoner` is a pure value type and never touches the registry, so
+`skill_keys()` is the explicit bridge: it registers each `Skill` and returns
+the content keys the reasoner stores.
+```
+
+- [ ] **Step 3: Verify the docs build and snippets run**
+
+Run: `uv run python -m pytest tests/test_cookbook_examples.py tests/_docs_runner.py -q`
+Expected: PASS (if `_docs_runner.py` is not collected directly, run only the cookbook test).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs-site/content/docs/internals/dotctx-format.md
+git commit -m "docs(skills): document the skills: setting and progressive disclosure"
+```
+
+---
+
+### Task 13: Full-suite verification
+
+**Files:** none modified — this task gates the branch.
+
+- [ ] **Step 1: Run the whole suite**
+
+Run: `uv run python -m pytest -q`
+Expected: PASS. Per `FEEDBACK.md:288-296`, this suite has known order-dependent `DEFAULT_REGISTRY` collisions; compare against a pre-branch baseline rather than assuming a clean tree.
+
+- [ ] **Step 2: Capture a baseline if failures appear**
+
+```bash
+git stash
+uv run python -m pytest -q 2>&1 | tail -30 > /tmp/baseline.txt
+git stash pop
+uv run python -m pytest -q 2>&1 | tail -30 > /tmp/branch.txt
+diff /tmp/baseline.txt /tmp/branch.txt
+```
+
+Expected: no *new* failures. Any new failure must be fixed before the branch lands — do not report completion with a diff here.
+
+- [ ] **Step 3: Verify skills work without the `[dotctx]` extra**
+
+Run: `uv run python -c "import sys; sys.modules['jinja2'] = None; import julep.skills; print(julep.skills.SKILL_TOOL)"`
+Expected: prints `__load_skill__` — `julep/skills.py` must not import jinja2 transitively.
+
+- [ ] **Step 4: Commit any fixes and finish**
+
+```bash
+git add -A
+git commit -m "test(skills): full-suite verification"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Explicit activation, `[]` vs absent, missing-name failure, extra-file rejection, name/directory agreement, duplicate names → Tasks 2, 5.
+- Package-local-only resolution, content addressing, dedupe → Tasks 1, 3.
+- `Reasoner.skills`, identity, drift → Task 4.
+- Frozen artifact carriage and worker rebuild → Task 6.
+- Progressive disclosure, `__load_skill__`, bounded loop, no IR change → Tasks 7, 8.
+- Batch degradation → Task 9.
+- Programmatic API → Tasks 3, 10.
+- mem-mcp migration and sweep → Task 11.
+- Docs → Task 12.
+
+**Known gaps, deliberately out of scope:**
+- Relaxing `native_response_format = native and not has_tools` for providers that support tools alongside structured outputs (see "Design Decision Requiring Confirmation"). Without it, a skill-bearing reasoner's first call uses prompt-injected schema guidance.
+- Level-3 bundled skill resources.
+- Per-skill options (`mode: inline`) — the settings parser rejects mapping items by name so this stays additive.
+- Eval reproducibility: `eval.yaml` has no way to pin disclosure behavior, so an eval over a skill-bearing package will vary with the model's load decisions. Worth a follow-up.
+- Trajectory visibility: disclosure round trips appear in `LlmCallMeta.skill_loads`, not as trajectory nodes. This is the accepted cost of keeping skills out of the IR.

--- a/julep/__init__.py
+++ b/julep/__init__.py
@@ -319,7 +319,13 @@ from .execution import (
     WorkerContext as WorkerContext,
     interpret as interpret,
 )
+from .execution.llm_result import (
+    AttemptMeta as AttemptMeta,
+    LlmCallMeta as LlmCallMeta,
+    LlmResult as LlmResult,
+)
 from .local import (
+    EmbeddedRun as EmbeddedRun,
     LocalExecutionConfigurationError as LocalExecutionConfigurationError,
     LocalExecutionUnsupported as LocalExecutionUnsupported,
     LocalPipeline as LocalPipeline,
@@ -402,6 +408,7 @@ _BASE_EXPORTS = [
     "ProjectionEvent", "ProjectionEmitter", "ProjectionSink", "ProjectionStore",
     "InMemoryProjection", "PostgresProjection", "TeeStore", "ValueStore", "SpanData",
     "to_otel_spans",
+    "LlmResult", "LlmCallMeta", "AttemptMeta", "EmbeddedRun",
     # provider resilience
     "AttemptRecord", "CircuitBreaker", "ErrorClass", "ResiliencePolicy",
     "classify_error", "summarize_attempts",

--- a/julep/__init__.py
+++ b/julep/__init__.py
@@ -323,6 +323,7 @@ from .execution.llm_result import (
     AttemptMeta as AttemptMeta,
     LlmCallMeta as LlmCallMeta,
     LlmResult as LlmResult,
+    LlmUsage as LlmUsage,
 )
 from .local import (
     EmbeddedRun as EmbeddedRun,
@@ -408,7 +409,7 @@ _BASE_EXPORTS = [
     "ProjectionEvent", "ProjectionEmitter", "ProjectionSink", "ProjectionStore",
     "InMemoryProjection", "PostgresProjection", "TeeStore", "ValueStore", "SpanData",
     "to_otel_spans",
-    "LlmResult", "LlmCallMeta", "AttemptMeta", "EmbeddedRun",
+    "LlmResult", "LlmCallMeta", "LlmUsage", "AttemptMeta", "EmbeddedRun",
     # provider resilience
     "AttemptRecord", "CircuitBreaker", "ErrorClass", "ResiliencePolicy",
     "classify_error", "summarize_attempts",

--- a/julep/__init__.py
+++ b/julep/__init__.py
@@ -207,6 +207,17 @@ from .dotctx import (
     load_dotctx as load_dotctx,
 )
 
+# --- agent skills ---------------------------------------------------------- #
+from .skills import (
+    SKILL_TOOL as SKILL_TOOL,
+    Skill as Skill,
+    SkillError as SkillError,
+    get_skill as get_skill,
+    load_package_skills as load_package_skills,
+    register_skill as register_skill,
+    skill_keys as skill_keys,
+)
+
 # --- purity registry ------------------------------------------------------- #
 from .purity import (
     Pure as Pure,
@@ -376,6 +387,9 @@ _BASE_EXPORTS = [
     # dotctx
     "Reasoner", "get_reasoner", "load_dotctx", "dotctx_flow",
     "reasoner_to_flow", "reasoner_from_settings",
+    # agent skills
+    "Skill", "SkillError", "SKILL_TOOL",
+    "register_skill", "get_skill", "skill_keys", "load_package_skills",
     # purity
     "pure", "register_pure", "is_registered", "get_pure", "diff_pure_hashes",
     "Registry", "DEFAULT_REGISTRY",

--- a/julep/app.py
+++ b/julep/app.py
@@ -568,6 +568,7 @@ def _reasoner_runtime_declaration(
         "requireToolCall": reasoner.require_tool_call,
         "responseFormat": reasoner.response_format,
         "promptCache": reasoner.prompt_cache,
+        "skills": list(reasoner.skills),
         "rendererSourceHashes": renderer_hashes,
     }
 

--- a/julep/app.py
+++ b/julep/app.py
@@ -568,7 +568,7 @@ def _reasoner_runtime_declaration(
         "requireToolCall": reasoner.require_tool_call,
         "responseFormat": reasoner.response_format,
         "promptCache": reasoner.prompt_cache,
-        "skills": list(reasoner.skills),
+        **({"skills": list(reasoner.skills)} if reasoner.skills else {}),
         "rendererSourceHashes": renderer_hashes,
     }
 

--- a/julep/app_deploy.py
+++ b/julep/app_deploy.py
@@ -564,6 +564,7 @@ class LaneReconciler(Protocol):
 
 
 CommandRunner = Callable[[Sequence[str]], None]
+CommandOutputRunner = Callable[[Sequence[str]], str]
 
 
 class HelmLaneReconciler:
@@ -585,6 +586,7 @@ class HelmLaneReconciler:
         worker_environment: Optional[Mapping[str, str]] = None,
         worker_secret_environment: Optional[Mapping[str, Mapping[str, str]]] = None,
         runner: Optional[CommandRunner] = None,
+        log_runner: Optional[CommandOutputRunner] = None,
     ) -> None:
         if not worker_context_factory.strip():
             raise ApplicationReleaseError("worker_context_factory must be non-empty")
@@ -616,6 +618,7 @@ class HelmLaneReconciler:
             name: dict(source) for name, source in (worker_secret_environment or {}).items()
         }
         self._runner = runner or _run_command
+        self._log_runner = log_runner or _run_command_output
 
     def reconcile(
         self,
@@ -746,25 +749,66 @@ class HelmLaneReconciler:
                 ]
             )
         self._runner(args)
-        # AIDEV-NOTE: Helm 3.21 --logs looks up a Pod named exactly like the Job,
-        # but test-hook Pods have generated suffixes. Retain the smoke Job so its
-        # logs can be fetched manually instead of turning a passed test into a failure.
-        self._runner(
-            [
-                "helm",
-                "test",
-                release_name,
-                "--namespace",
-                self.namespace,
-                "--timeout",
-                "2m",
-            ]
-        )
+        # AIDEV-NOTE: no `helm test --logs`. Helm 3.21 looks up a Pod named exactly
+        # like the Job, but test-hook Pods have generated suffixes, so --logs turns
+        # a PASSED test into a reported failure. Logs are fetched out-of-band below,
+        # on failure only, so retrieval can never decide pass/fail.
+        try:
+            self._runner(
+                [
+                    "helm",
+                    "test",
+                    release_name,
+                    "--namespace",
+                    self.namespace,
+                    "--timeout",
+                    "2m",
+                ]
+            )
+        except ApplicationReleaseError as exc:
+            raise ApplicationReleaseError(
+                f"smoke test failed for {release_name}: {exc}\n"
+                + self._smoke_test_logs(release_name)
+            ) from exc
         return LaneApplyResult(
             lane=lane,
             release_name=release_name,
             task_queue=release_task_queue,
         )
+
+    def _smoke_test_logs(self, release_name: str) -> str:
+        """Best-effort smoke-test Job logs, for a FAILED ``helm test`` only.
+
+        The chart's smoke-test hook keeps ``helm.sh/hook-delete-policy:
+        before-hook-creation`` and nothing else, so a failed Job (and its Pod,
+        which has ``backoffLimit: 0`` and no TTL) survives until the next
+        ``helm test`` — the logs are still there to read. The Pod name carries a
+        generated suffix, so select on ``job-name``, the label the Job
+        controller stamps onto every Pod it creates.
+
+        AIDEV-NOTE: this must never influence pass/fail. ``helm test`` already
+        decided; a missing ``kubectl``, an evicted Pod, or a denied RBAC rule
+        returns a note, never an exception that would replace the real failure.
+        """
+        job = f"{release_name}-smoke"
+        args = [
+            "kubectl",
+            "logs",
+            "--selector",
+            f"job-name={job}",
+            "--namespace",
+            self.namespace,
+            "--all-containers=true",
+            "--tail=200",
+        ]
+        printable = " ".join(args)
+        try:
+            output = self._log_runner(args).strip()
+        except Exception as exc:  # noqa: BLE001 - retrieval failures are reported, not raised
+            return f"smoke-test logs unavailable ({printable}): {exc}"
+        if not output:
+            return f"smoke-test logs unavailable ({printable}): no output"
+        return f"smoke-test logs ({job}):\n{output}"
 
     def _validate_deployment_config(
         self,
@@ -1047,6 +1091,15 @@ def _run_command(args: Sequence[str]) -> None:
     if proc.returncode != 0:
         detail = proc.stderr.strip() or proc.stdout.strip() or "unknown Helm failure"
         raise ApplicationReleaseError(detail)
+
+
+def _run_command_output(args: Sequence[str]) -> str:
+    """Run a command and return its stdout; raise on a non-zero exit."""
+    proc = subprocess.run(list(args), capture_output=True, text=True)
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or "unknown command failure"
+        raise ApplicationReleaseError(detail)
+    return proc.stdout
 
 
 def release_from_bytes(data: bytes) -> ApplicationRelease:

--- a/julep/cli/ctxrun.py
+++ b/julep/cli/ctxrun.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, field, replace
 from typing import Any, Callable, Mapping
 
 from julep.cli import evalrun
@@ -11,12 +11,14 @@ from julep.deploy import deploy
 from julep.dotctx import load_dotctx, reasoner_to_flow
 from julep.dotctx_rich import load_rich_dotctx
 from julep.freeze import McpServerSnapshot, McpSnapshot, McpToolSpec
+from julep.projection import InMemoryProjection, ProjectionSink
 
 
 @dataclass(frozen=True)
 class CtxRunOutcome:
     artifact_hash: str
     reply: Any
+    projection: InMemoryProjection = field(default_factory=InMemoryProjection)
 
 
 def run_ctx_local(
@@ -29,6 +31,8 @@ def run_ctx_local(
     tools: Mapping[str, Callable[[Any], Any]] | None = None,
     tool_bindings: Mapping[str, str] | None = None,
     mcp_call: Any = None,
+    projection: InMemoryProjection | None = None,
+    sink: ProjectionSink | None = None,
 ) -> CtxRunOutcome:
     reasoner = load_dotctx(ctx_path, env=dict(env_vars or {}))
     if reasoner.tools:
@@ -71,39 +75,43 @@ def run_ctx_local(
             else evalrun._resolve_acompletion(None)
         )
     )
-    if rich is None:
-        reply = asyncio.run(
-            evalrun._invoke_eval_llm(
-                reasoner,
-                value,
-                acompletion=resolved,
-                llm_caller=llm_caller,
-            )
-        )
-    else:
+    tool_defs = None
+    if rich is not None:
         tool_defs = evalrun._provider_tool_defs(
             rich.expected_tool_schemas,
             rich.expected_tool_descriptions,
         )
 
-        async def controller(payload: dict[str, Any]) -> Any:
-            return await evalrun._invoke_eval_llm(
-                reasoner,
-                payload,
-                acompletion=resolved,
-                llm_caller=llm_caller,
-                tools=tool_defs,
-            )
+    async def controller(payload: Any) -> Any:
+        return await evalrun._invoke_eval_llm(
+            reasoner,
+            payload,
+            acompletion=resolved,
+            llm_caller=llm_caller,
+            tools=tool_defs,
+        )
 
-        reply = asyncio.run(
-            deployment.adry_run(
-                value,
-                reasoners={reasoner.name: controller},
-                tools=dict(tools or {}),
-                mcp_call=mcp_call,
-            )
-        ).value
-    return CtxRunOutcome(artifact_hash=deployment.artifact_hash, reply=reply)
+    # AIDEV-NOTE: even single-shot .ctx packages must traverse the interpreter;
+    # bypassing it produces no projection and makes the local trace cache blind.
+    local_deployment = (
+        deployment if rich is not None else replace(deployment, _tools=())
+    )
+    run_projection = projection if projection is not None else InMemoryProjection()
+    reply = asyncio.run(
+        local_deployment.adry_run(
+            value,
+            reasoners={reasoner.name: controller},
+            tools=dict(tools or {}),
+            mcp_call=mcp_call,
+            projection=run_projection,
+            sink=sink,
+        )
+    ).value
+    return CtxRunOutcome(
+        artifact_hash=deployment.artifact_hash,
+        reply=reply,
+        projection=run_projection,
+    )
 
 
 __all__ = ["CtxRunOutcome", "run_ctx_local"]

--- a/julep/cli/evalrun.py
+++ b/julep/cli/evalrun.py
@@ -38,6 +38,7 @@ async def _invoke_eval_llm(
     llm_caller: Optional[EvalLlmCaller],
     transcript: Optional[list[dict[str, Any]]] = None,
     tools: Optional[list[dict[str, Any]]] = None,
+    registry: Registry = DEFAULT_REGISTRY,
 ) -> Any:
     if llm_caller is None:
         result = await complete_reasoner(
@@ -47,6 +48,7 @@ async def _invoke_eval_llm(
             transcript=transcript,
             tools=tools,
             parallel_tool_calls=True if tools else None,
+            registry=registry,
         )
         return result.reply
 
@@ -340,10 +342,15 @@ def _turn_from_reply(reply: Any) -> Turn:
     return Turn(output=reply, tool_calls=[], tool_results=[], content=content, refusal=None)
 
 
-def _seed_user_turn(reasoner: Any, value: Any) -> dict[str, Any]:
+def _seed_user_turn(
+    reasoner: Any,
+    value: Any,
+    *,
+    registry: Registry = DEFAULT_REGISTRY,
+) -> dict[str, Any]:
     """The leading user turn the model saw on round 0, replayed so later rounds
     start from a valid user turn (providers reject a leading assistant turn)."""
-    text = rendered_user_for(reasoner, value)
+    text = rendered_user_for(reasoner, value, registry=registry)
     content = text if text is not None else (value if isinstance(value, str) else json.dumps(value))
     return {"role": "user", "content": content}
 
@@ -381,12 +388,14 @@ async def _run_single_shot(
     sample: Sample,
     acompletion: Optional[AnyCompletion],
     llm_caller: Optional[EvalLlmCaller] = None,
+    registry: Registry = DEFAULT_REGISTRY,
 ) -> Any:
     reply = await _invoke_eval_llm(
         reasoner,
         sample.input,
         acompletion=acompletion,
         llm_caller=llm_caller,
+        registry=registry,
     )
     text = reply if isinstance(reply, str) else json.dumps(reply)
     return {"content": text}
@@ -397,6 +406,7 @@ async def _run_tool_loop(
     sample: Sample,
     acompletion: Optional[AnyCompletion],
     llm_caller: Optional[EvalLlmCaller] = None,
+    registry: Registry = DEFAULT_REGISTRY,
 ) -> Any:
     reasoner = rich.reasoner
     tool_defs = _provider_tool_defs(
@@ -487,12 +497,15 @@ async def _run_tool_loop(
             llm_caller=llm_caller,
             tools=tool_defs,
             transcript=list(transcript) if transcript else None,
+            registry=registry,
         )
         last_turn = _turn_from_reply(reply)
         tool_calls = reply.get("tool_calls") if isinstance(reply, dict) else None
         if isinstance(tool_calls, list) and tool_calls:
             if not transcript:
-                transcript.append(_seed_user_turn(reasoner, base_value))
+                transcript.append(
+                    _seed_user_turn(reasoner, base_value, registry=registry)
+                )
             transcript.append(_assistant_call_turn(tool_calls))
             round_call_ids = [
                 (tc.get("id") if isinstance(tc, dict) else None) for tc in tool_calls
@@ -602,6 +615,7 @@ async def run_eval(
                     sample,
                     resolved,
                     llm_caller=llm_caller,
+                    registry=registry,
                 )
             else:
                 output = await _run_single_shot(
@@ -609,6 +623,7 @@ async def run_eval(
                     sample,
                     resolved,
                     llm_caller=llm_caller,
+                    registry=registry,
                 )
             try:
                 raw_score = module.score(sample.input, output, sample.expected)
@@ -641,6 +656,7 @@ def run_eval_sync(
     sample_names: Optional[Sequence[str]] = None,
     acompletion: Optional[AnyCompletion] = None,
     llm_caller: Optional[EvalLlmCaller] = None,
+    registry: Registry = DEFAULT_REGISTRY,
 ) -> EvalReport:
     return asyncio.run(
         run_eval(
@@ -651,6 +667,7 @@ def run_eval_sync(
             sample_names=sample_names,
             acompletion=acompletion,
             llm_caller=llm_caller,
+            registry=registry,
         )
     )
 

--- a/julep/cli/main.py
+++ b/julep/cli/main.py
@@ -36,7 +36,7 @@ from julep.cli.tracetree import render_tree
 from julep.cli.trigger import trigger_command
 from julep.bundle import BundleError
 from julep.artifact_store import ArtifactStoreError
-from julep.projection import ProjectionEvent
+from julep.projection import InMemoryProjection, ProjectionEvent
 
 if TYPE_CHECKING:
     from julep.client import JulepClient
@@ -675,15 +675,52 @@ def run(
                 err=True,
             )
             raise typer.Exit(2)
-        env_vars = _eval_env_vars(env)
+        cfg = _eval_project_config()
+        env_vars = _eval_env_vars(env, cfg=cfg)
+        rid = run_id or f"julep-{Path(name).stem}-local"
+        cache_root = str(cfg.root if cfg is not None else Path(".").resolve())
+        projection = InMemoryProjection()
         try:
             from julep.cli.ctxrun import run_ctx_local
 
-            ctx_outcome = run_ctx_local(name, parsed, env_vars=env_vars)
+            ctx_outcome = run_ctx_local(
+                name,
+                parsed,
+                env_vars=env_vars,
+                projection=projection,
+            )
         except (ValueError, FileNotFoundError) as exc:
+            if projection.events():
+                save_run(
+                    cache_root,
+                    run_id=rid,
+                    agent=name,
+                    status="error",
+                    events=projection.events(),
+                )
             typer.echo(f"error: {exc}", err=True)
             raise typer.Exit(2) from None
+        except Exception as exc:  # noqa: BLE001 - persist the failed local run
+            save_run(
+                cache_root,
+                run_id=rid,
+                agent=name,
+                status="error",
+                events=projection.events(),
+            )
+            typer.echo(f"error: {exc}", err=True)
+            raise typer.Exit(1) from None
+        save_run(
+            cache_root,
+            run_id=rid,
+            agent=name,
+            status="done",
+            events=ctx_outcome.projection.events(),
+        )
         typer.echo(f"artifact-digest {ctx_outcome.artifact_hash}")
+        tree = render_tree(ctx_outcome.projection.events())
+        if tree:
+            typer.echo(tree)
         typer.echo(f"output: {_json.dumps(ctx_outcome.reply, default=str)}")
         return
     cfg = load_config(Path("."))

--- a/julep/cli/main.py
+++ b/julep/cli/main.py
@@ -600,28 +600,35 @@ def _activate_release_lanes(
     release: Any,
     api_url: str | None,
     api_key: str | None,
-) -> list[tuple[str, str | None]]:
+) -> tuple[list[tuple[str, str | None]], BaseException | None]:
     """Activate every lane of a release over one control-plane connection.
 
-    Returns an ``(lane, failure_detail)`` pair per lane in release order, with
-    ``None`` as the detail for lanes that activated. Every lane is attempted so
-    a mid-list failure still reports the lanes that did move.
+    Returns outcomes plus any unexpected exception deferred until the caller
+    reports them. Expected API and transport failures do not stop later lanes.
     """
     client = _remote_client(api_url, api_key)
+    from httpx import HTTPError
     from julep.client import JulepClientError
 
     outcomes: list[tuple[str, str | None]] = []
+    unexpected: BaseException | None = None
     try:
         for lane_name in release.lanes:
             try:
                 client.activate_deployment(lane_name, release.release_hash)
             except JulepClientError as exc:
                 outcomes.append((lane_name, _activation_failure_detail(exc)))
+            except HTTPError as exc:
+                outcomes.append((lane_name, str(exc)))
+            except Exception as exc:  # noqa: BLE001 - report completed lanes first
+                outcomes.append((lane_name, str(exc)))
+                unexpected = exc
+                break
             else:
                 outcomes.append((lane_name, None))
     finally:
         client.close()
-    return outcomes
+    return outcomes, unexpected
 
 
 @app.command("ls")
@@ -995,7 +1002,9 @@ def apply_application(
     if api_url or api_key:
         _register_remote_release(release, api_url or None, api_key or None)
     if activate_lanes:
-        outcomes = _activate_release_lanes(release, api_url or None, api_key or None)
+        outcomes, unexpected = _activate_release_lanes(
+            release, api_url or None, api_key or None
+        )
         activated = [name for name, detail in outcomes if detail is None]
         failed = [(name, detail) for name, detail in outcomes if detail is not None]
         for lane_name in activated:
@@ -1009,6 +1018,8 @@ def apply_application(
                 + "; unchanged "
                 + ", ".join(name for name, _ in failed)
             )
+            if unexpected is not None:
+                raise unexpected
             raise typer.Exit(1)
         typer.echo(
             "traffic   activated " + (", ".join(activated) or "no lanes in release")

--- a/julep/cli/main.py
+++ b/julep/cli/main.py
@@ -571,6 +571,59 @@ def _register_remote_release(release: Any, api_url: str | None, api_key: str | N
     typer.echo(f"registered {release.release_hash}")
 
 
+# AIDEV-NOTE: a control plane configured with its own HelmLaneReconciler re-runs
+# the lane reconcile on every activation (julep/server/routes/deployments.py).
+# That reconcile re-derives the lane deployment config and 409s unless it
+# reproduces the release's frozen `deployment_config` byte-identically, so a
+# perfectly good release can be refused at activation time. Name the cause
+# instead of letting a bare "409 CONFLICT" look like a crash.
+_ACTIVATION_CONFLICT_HINT = (
+    "the control plane ran its own Helm reconciler for this lane and refused "
+    "the rollout (409). Inline activation re-reconciles the lane, which only "
+    "succeeds when the server reproduces the release's frozen deployment "
+    "config byte-identically. Use --activate against a control plane that "
+    "leaves worker rollout external, or reconcile server-side first and "
+    "activate with 'julep activate'"
+)
+
+
+def _activation_failure_detail(exc: Any) -> str:
+    """Render one lane-activation failure, naming the reconciler-conflict case."""
+    if exc.status_code == 403:
+        return "lane activation requires an admin API key (403)"
+    if exc.status_code == 409:
+        return f"{_ACTIVATION_CONFLICT_HINT}; server said: {exc.detail}"
+    return str(exc)
+
+
+def _activate_release_lanes(
+    release: Any,
+    api_url: str | None,
+    api_key: str | None,
+) -> list[tuple[str, str | None]]:
+    """Activate every lane of a release over one control-plane connection.
+
+    Returns an ``(lane, failure_detail)`` pair per lane in release order, with
+    ``None`` as the detail for lanes that activated. Every lane is attempted so
+    a mid-list failure still reports the lanes that did move.
+    """
+    client = _remote_client(api_url, api_key)
+    from julep.client import JulepClientError
+
+    outcomes: list[tuple[str, str | None]] = []
+    try:
+        for lane_name in release.lanes:
+            try:
+                client.activate_deployment(lane_name, release.release_hash)
+            except JulepClientError as exc:
+                outcomes.append((lane_name, _activation_failure_detail(exc)))
+            else:
+                outcomes.append((lane_name, None))
+    finally:
+        client.close()
+    return outcomes
+
+
 @app.command("ls")
 def ls(
     selector: str = typer.Argument("", help="Selection expression (default: all)."),
@@ -849,6 +902,16 @@ def apply_application(
         "--api-key",
         help="Admin bearer key used with --api-url to register the release.",
     ),
+    activate_lanes: bool = typer.Option(
+        False,
+        "--activate",
+        help=(
+            "Shift traffic to the published release for every lane instead of "
+            "printing the per-lane 'julep activate' commands. Requires "
+            "--api-url/--api-key, and a control plane that leaves worker "
+            "rollout external (a server-side Helm reconciler answers 409)."
+        ),
+    ),
 ) -> None:
     """Publish an immutable release and reconcile inactive lane workers."""
     from julep.cli.application import release_queue_lines
@@ -856,6 +919,15 @@ def apply_application(
     cfg = load_config(Path("."))
     if env not in cfg.envs:
         typer.echo(f"error: unknown env {env!r}", err=True)
+        raise typer.Exit(2)
+    # Refuse before publishing: --activate is meaningless without the same
+    # control-plane context that registers the release in the first place.
+    if activate_lanes and not (api_url or api_key):
+        typer.echo(
+            "error: --activate unavailable: re-run apply with --api-url/--api-key "
+            "to register this release with the control plane before activating",
+            err=True,
+        )
         raise typer.Exit(2)
     try:
         release, lanes = apply_configured_application(
@@ -885,6 +957,26 @@ def apply_application(
         typer.echo(f"queue     {lane_name:24} {task_queue}")
     if api_url or api_key:
         _register_remote_release(release, api_url or None, api_key or None)
+    if activate_lanes:
+        outcomes = _activate_release_lanes(release, api_url or None, api_key or None)
+        activated = [name for name, detail in outcomes if detail is None]
+        failed = [(name, detail) for name, detail in outcomes if detail is not None]
+        for lane_name in activated:
+            typer.echo(f"activated {lane_name:24} {release.release_hash}")
+        for lane_name, detail in failed:
+            typer.echo(f"error: lane {lane_name!r} activation failed: {detail}", err=True)
+        if failed:
+            typer.echo(
+                "traffic   partial: activated "
+                + (", ".join(activated) or "no lanes")
+                + "; unchanged "
+                + ", ".join(name for name, _ in failed)
+            )
+            raise typer.Exit(1)
+        typer.echo(
+            "traffic   activated " + (", ".join(activated) or "no lanes in release")
+        )
+        return
     typer.echo("traffic   unchanged")
     if api_url or api_key:
         # AIDEV-NOTE: activate needs the same connection context apply used, but
@@ -933,13 +1025,11 @@ def activate(
     try:
         client.activate_deployment(lane, release)
     except JulepClientError as exc:
+        detail = _activation_failure_detail(exc)
         if exc.status_code == 403:
-            typer.echo(
-                "error: lane activation requires an admin API key (403)",
-                err=True,
-            )
+            typer.echo(f"error: {detail}", err=True)
         else:
-            typer.echo(f"error: lane activation failed: {exc}", err=True)
+            typer.echo(f"error: lane activation failed: {detail}", err=True)
         raise typer.Exit(1) from None
     finally:
         client.close()

--- a/julep/declarations.py
+++ b/julep/declarations.py
@@ -19,8 +19,9 @@ from .registry import (
     RendererDependency,
     RendererEntry,
 )
+from .skills import Skill, skill_key
 
-_BLOB_SCHEMA_VERSION = 2
+_BLOB_SCHEMA_VERSION = 3
 _SHA256_REF = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 
@@ -138,6 +139,23 @@ def declarations_blob(
             ],
         }
 
+    skills: dict[str, dict[str, Any]] = {}
+    for reasoner in reasoner_values.values():
+        for key in reasoner.skills:
+            if key in skills:
+                continue
+            skill = registry.skills.get(key)
+            if skill is None:
+                raise ApplicationDefinitionError(
+                    f"reasoner {reasoner.name!r} references skill {key!r} with no "
+                    "registered content; load its dotctx package before releasing"
+                )
+            skills[key] = {
+                "name": skill.name,
+                "description": skill.description,
+                "body": skill.body,
+            }
+
     agents: dict[str, dict[str, Any]] = {}
     if flow is not None:
         for node in flow.walk():
@@ -185,6 +203,7 @@ def declarations_blob(
         },
         "renderers": renderers,
         "agents": {name: agents[name] for name in sorted(agents)},
+        "skills": {name: skills[name] for name in sorted(skills)},
     }
     return canonical_json(payload).encode("utf-8")
 
@@ -318,6 +337,11 @@ def _reasoner_from_json(name: str, raw: Any) -> Reasoner:
     output_retries = value.get("outputRetries")
     if not isinstance(output_retries, int) or isinstance(output_retries, bool):
         _fail(f"reasoner {name!r} outputRetries must be an integer")
+    skills_raw = value.get("skills", [])
+    if not isinstance(skills_raw, list) or not all(
+        isinstance(item, str) for item in skills_raw
+    ):
+        _fail(f"reasoner {name!r} skills must be a list of strings")
 
     return Reasoner(
         name=declared_name,
@@ -350,6 +374,7 @@ def _reasoner_from_json(name: str, raw: Any) -> Reasoner:
         prompt_cache=_optional_string(
             value.get("promptCache"), label=f"reasoner {name!r} promptCache"
         ),
+        skills=skills_raw,
     )
 
 
@@ -451,6 +476,21 @@ def load_declarations(
         rebuilt_renderers[name] = entry
         renderer_declarations[name] = declaration
 
+    skill_values = _object(payload.get("skills", {}), label="declarations skills")
+    rebuilt_skills: dict[str, Skill] = {}
+    for key, raw in skill_values.items():
+        skill_entry = _object(raw, label=f"skill {key!r}")
+        skill = Skill(
+            name=_string(skill_entry.get("name"), label=f"skill {key!r} name"),
+            description=_string(
+                skill_entry.get("description"), label=f"skill {key!r} description"
+            ),
+            body=_string(skill_entry.get("body"), label=f"skill {key!r} body"),
+        )
+        if skill_key(skill) != key:
+            _fail(f"skill {key!r} does not match the content hash of its declaration")
+        rebuilt_skills[key] = skill
+
     reasoner_values = _object(payload.get("reasoners"), label="declarations reasoners")
     rebuilt_reasoners = {
         name: _reasoner_from_json(name, raw) for name, raw in reasoner_values.items()
@@ -475,6 +515,9 @@ def load_declarations(
                     f"reasoner {name!r} renderer {renderer_name!r} hash does not "
                     "match the rebuilt declaration"
                 )
+        for skill_ref in reasoner.skills:
+            if skill_ref not in rebuilt_skills:
+                _fail(f"reasoner {name!r} references undeclared skill {skill_ref!r}")
 
     agent_values = _object(payload.get("agents"), label="declarations agents")
     rebuilt_agents = {
@@ -505,6 +548,12 @@ def load_declarations(
                 raise ApplicationDefinitionError(
                     f"agent {name!r} conflicts with the verified application declaration"
                 )
+        for key, skill in rebuilt_skills.items():
+            existing_skill = target.skills.get(key)
+            if existing_skill is not None and existing_skill != skill:
+                raise ApplicationDefinitionError(
+                    f"skill {key!r} conflicts with the verified application declaration"
+                )
 
     for target in targets:
         for reasoner in rebuilt_reasoners.values():
@@ -513,6 +562,7 @@ def load_declarations(
             target.renderers[name] = entry
             target.renderer_declarations[name] = renderer_declarations[name]
         target.agent_specs.update(rebuilt_agents)
+        target.skills.update(rebuilt_skills)
 
     # Renderer names are content-addressed, so sharing them process-wide is
     # safe even when reasoner names are release-scoped. The prompt adapter's
@@ -530,6 +580,9 @@ def load_declarations(
                 )
             DEFAULT_REGISTRY.renderers[name] = entry
             DEFAULT_REGISTRY.renderer_declarations[name] = renderer_declarations[name]
+        # Skill keys are content-addressed like renderer names, and the LLM
+        # caller resolves skill bodies from DEFAULT_REGISTRY, so share them.
+        DEFAULT_REGISTRY.skills.update(rebuilt_skills)
 
 
 __all__ = ["DeclarationError", "declarations_blob", "load_declarations"]

--- a/julep/declarations.py
+++ b/julep/declarations.py
@@ -555,6 +555,14 @@ def load_declarations(
                     f"skill {key!r} conflicts with the verified application declaration"
                 )
 
+    if release_scoped and registry is not DEFAULT_REGISTRY:
+        for key, skill in rebuilt_skills.items():
+            existing_skill = DEFAULT_REGISTRY.skills.get(key)
+            if existing_skill is not None and existing_skill != skill:
+                raise ApplicationDefinitionError(
+                    f"skill {key!r} conflicts with a loaded release declaration"
+                )
+
     for target in targets:
         for reasoner in rebuilt_reasoners.values():
             target.register_reasoner(reasoner)
@@ -562,7 +570,8 @@ def load_declarations(
             target.renderers[name] = entry
             target.renderer_declarations[name] = renderer_declarations[name]
         target.agent_specs.update(rebuilt_agents)
-        target.skills.update(rebuilt_skills)
+        for skill in rebuilt_skills.values():
+            target.register_skill(skill)
 
     # Renderer names are content-addressed, so sharing them process-wide is
     # safe even when reasoner names are release-scoped. The prompt adapter's
@@ -580,9 +589,10 @@ def load_declarations(
                 )
             DEFAULT_REGISTRY.renderers[name] = entry
             DEFAULT_REGISTRY.renderer_declarations[name] = renderer_declarations[name]
-        # Skill keys are content-addressed like renderer names, and the LLM
-        # caller resolves skill bodies from DEFAULT_REGISTRY, so share them.
-        DEFAULT_REGISTRY.skills.update(rebuilt_skills)
+        # Release workers still support callers configured with the process-wide
+        # registry, so share content-addressed skills after collision preflight.
+        for skill in rebuilt_skills.values():
+            DEFAULT_REGISTRY.register_skill(skill)
 
 
 __all__ = ["DeclarationError", "declarations_blob", "load_declarations"]

--- a/julep/deploy.py
+++ b/julep/deploy.py
@@ -39,6 +39,8 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import time
+import uuid
 from dataclasses import dataclass, field
 from datetime import timedelta
 from functools import cached_property
@@ -66,6 +68,8 @@ from .shapes import surface_shape as _compute_surface_shape
 
 if TYPE_CHECKING:
     from .projection import InMemoryProjection, ProjectionSink
+    from .trajectory import Redactor, TrajectorySink
+    from .execution.blobstore import BlobStore
 from .validate import Diagnostic, blocking, validate
 
 if TYPE_CHECKING:
@@ -747,6 +751,10 @@ class Deployment:
         max_parallel: Optional[int] = None,
         projection: Optional["InMemoryProjection"] = None,
         sink: Optional["ProjectionSink"] = None,
+        run_id: Optional[str] = None,
+        trajectory_sink: Optional["TrajectorySink"] = None,
+        trajectory_blob_store: Optional["BlobStore"] = None,
+        redactor: Optional["Redactor"] = None,
         sleeper: Optional[Callable[[float], Awaitable[None]]] = asyncio.sleep,
     ) -> "InterpreterResult":
         """Run locally, optionally retaining and/or forwarding projection events.
@@ -769,6 +777,13 @@ class Deployment:
 
         from .execution.interpreter import InMemoryEnv, interpret  # lazy: keeps deploy import-light
         from .projection import InMemoryProjection, ProjectionEmitter, TeeStore
+        from .trajectory import (
+            ProjectionTrajectorySink,
+            TrajectoryRecorder,
+            TrajectoryRun,
+            _best_effort,
+            redact_secret_shaped,
+        )
 
         local_tools = {
             native_tool.name: native_tool.bound_tool
@@ -776,7 +791,42 @@ class Deployment:
         }
         local_tools.update(tools or {})
         store = projection if projection is not None else InMemoryProjection()
-        emitter_store = TeeStore(store, sink) if sink is not None else store
+        trajectory_id: Optional[str] = None
+        recorder: Optional[TrajectoryRecorder] = None
+        projection_sinks = [] if sink is None else [sink]
+        if trajectory_sink is not None:
+            # AIDEV-NOTE: UUID generation is foreground-only. Durable run ids
+            # remain engine-owned and never consult this observational branch.
+            trajectory_id = run_id or f"embedded-{uuid.uuid4().hex}"
+            effective_redactor = redactor or redact_secret_shaped
+            _best_effort(
+                lambda: trajectory_sink.start_run(
+                    TrajectoryRun(
+                        run_id=trajectory_id,
+                        root_run_id=trajectory_id,
+                        backend="memory",
+                        session_id=trajectory_id,
+                        flow_ref=self.artifact_hash,
+                        started_ts=time.time(),
+                    )
+                )
+            )
+            projection_sinks.append(
+                ProjectionTrajectorySink(
+                    trajectory_sink,
+                    run_id=trajectory_id,
+                    root_run_id=trajectory_id,
+                    segment_seq=0,
+                    node_ops={node.id: node.op.value for node in self.flow.walk()},
+                    redactor=effective_redactor,
+                )
+            )
+            recorder = TrajectoryRecorder(
+                sink=trajectory_sink,
+                blob_store=trajectory_blob_store,
+                redactor=effective_redactor,
+            )
+        emitter_store = TeeStore(store, *projection_sinks) if projection_sinks else store
         env = InMemoryEnv(
             self.manifest,
             ProjectionEmitter(emitter_store),
@@ -790,8 +840,27 @@ class Deployment:
             registry=registry,
             principal=principal,
             sleeper=sleeper,
+            root_run_id=trajectory_id,
+            trajectory_recorder=recorder,
+            trajectory_run_id=trajectory_id,
         )
-        return await interpret(self.flow, value, env)
+        try:
+            result = await interpret(self.flow, value, env)
+        except BaseException:
+            if trajectory_sink is not None and trajectory_id is not None:
+                _best_effort(
+                    lambda: trajectory_sink.finish_run(
+                        trajectory_id, "failed", time.time()
+                    )
+                )
+            raise
+        if trajectory_sink is not None and trajectory_id is not None:
+            _best_effort(
+                lambda: trajectory_sink.finish_run(
+                    trajectory_id, "completed", time.time()
+                )
+            )
+        return result
 
     def dry_run(
         self,
@@ -805,6 +874,10 @@ class Deployment:
         max_parallel: Optional[int] = None,
         projection: Optional["InMemoryProjection"] = None,
         sink: Optional["ProjectionSink"] = None,
+        run_id: Optional[str] = None,
+        trajectory_sink: Optional["TrajectorySink"] = None,
+        trajectory_blob_store: Optional["BlobStore"] = None,
+        redactor: Optional["Redactor"] = None,
         sleeper: Optional[Callable[[float], Awaitable[None]]] = asyncio.sleep,
     ) -> "InterpreterResult":
         """Synchronously run this deployment locally via :meth:`adry_run`."""
@@ -819,6 +892,10 @@ class Deployment:
                 max_parallel=max_parallel,
                 projection=projection,
                 sink=sink,
+                run_id=run_id,
+                trajectory_sink=trajectory_sink,
+                trajectory_blob_store=trajectory_blob_store,
+                redactor=redactor,
                 sleeper=sleeper,
             )
         )

--- a/julep/deploy.py
+++ b/julep/deploy.py
@@ -42,7 +42,7 @@ import json
 from dataclasses import dataclass, field
 from datetime import timedelta
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Mapping, Optional, Sequence
 
 from . import __version__
 from .capabilities import CapabilityManifest, check_approval_gates
@@ -63,6 +63,9 @@ from .kinds import EnforcementMode, Op, Shape
 from .purity import is_registered, source_hash_of
 from .registry import DEFAULT_REGISTRY
 from .shapes import surface_shape as _compute_surface_shape
+
+if TYPE_CHECKING:
+    from .projection import InMemoryProjection, ProjectionSink
 from .validate import Diagnostic, blocking, validate
 
 if TYPE_CHECKING:
@@ -742,8 +745,16 @@ class Deployment:
         principal: Optional[dict[str, Any]] = None,
         registry: Optional[Registry] = None,
         max_parallel: Optional[int] = None,
+        projection: Optional["InMemoryProjection"] = None,
+        sink: Optional["ProjectionSink"] = None,
+        sleeper: Optional[Callable[[float], Awaitable[None]]] = asyncio.sleep,
     ) -> "InterpreterResult":
-        """Run locally with injected effects and optional run identity context."""
+        """Run locally, optionally retaining and/or forwarding projection events.
+
+        The interpreter result is returned unchanged. ``projection`` is the queryable
+        primary store, while the synchronous ``sink`` observes events as they happen.
+        Sink exceptions intentionally propagate.
+        """
         mcp_backed = any(isinstance(tool.ref, McpTool) for tool in self.manifest.values())
         if self._tools is None and not mcp_backed:
             raise ValueError(
@@ -757,16 +768,18 @@ class Deployment:
             )
 
         from .execution.interpreter import InMemoryEnv, interpret  # lazy: keeps deploy import-light
-        from .projection import InMemoryProjection, ProjectionEmitter
+        from .projection import InMemoryProjection, ProjectionEmitter, TeeStore
 
         local_tools = {
             native_tool.name: native_tool.bound_tool
             for native_tool in (self._tools or ())
         }
         local_tools.update(tools or {})
+        store = projection if projection is not None else InMemoryProjection()
+        emitter_store = TeeStore(store, sink) if sink is not None else store
         env = InMemoryEnv(
             self.manifest,
-            ProjectionEmitter(InMemoryProjection()),
+            ProjectionEmitter(emitter_store),
             tools=local_tools or None,
             mcp_call=mcp_call,
             reasoners=reasoners,
@@ -776,6 +789,7 @@ class Deployment:
             max_parallel=max_parallel,
             registry=registry,
             principal=principal,
+            sleeper=sleeper,
         )
         return await interpret(self.flow, value, env)
 
@@ -789,6 +803,9 @@ class Deployment:
         principal: Optional[dict[str, Any]] = None,
         registry: Optional[Registry] = None,
         max_parallel: Optional[int] = None,
+        projection: Optional["InMemoryProjection"] = None,
+        sink: Optional["ProjectionSink"] = None,
+        sleeper: Optional[Callable[[float], Awaitable[None]]] = asyncio.sleep,
     ) -> "InterpreterResult":
         """Synchronously run this deployment locally via :meth:`adry_run`."""
         return asyncio.run(
@@ -800,6 +817,9 @@ class Deployment:
                 principal=principal,
                 registry=registry,
                 max_parallel=max_parallel,
+                projection=projection,
+                sink=sink,
+                sleeper=sleeper,
             )
         )
 

--- a/julep/deploy.py
+++ b/julep/deploy.py
@@ -229,6 +229,8 @@ def _reasoner_identity(name: str) -> dict[str, Any]:
         ident["responseFormat"] = reasoner.response_format
     if reasoner.prompt_cache is not None:
         ident["promptCache"] = reasoner.prompt_cache
+    if reasoner.skills:
+        ident["skills"] = list(reasoner.skills)
     return ident
 
 

--- a/julep/dotctx.py
+++ b/julep/dotctx.py
@@ -497,6 +497,20 @@ def reasoner_from_settings(
     scope = ContextScope(settings["context"]) if settings.get("context") else ContextScope.LOCAL
 
     model, effort, output_retries = _model_and_effort(settings)
+    from .skills import load_package_skills, parse_skills_setting
+
+    skill_key_tuple: tuple[str, ...] = ()
+    declared = parse_skills_setting(settings.get("skills"), origin=base_dir or nm)
+    if base_dir is not None:
+        skill_key_tuple = tuple(
+            _registry.register_skill(skill)
+            for skill in load_package_skills(base_dir, declared)
+        )
+    elif declared:
+        raise ValueError(
+            f"reasoner {nm!r} declares skills but was built without a base_dir; "
+            "skills load from <package>/skills/<name>/SKILL.md"
+        )
     reasoner = Reasoner(
         name=nm,
         model=model,
@@ -518,6 +532,7 @@ def reasoner_from_settings(
         require_tool_call=_require_tool_call_setting(settings),
         response_format=_response_format_setting(settings),
         prompt_cache=_prompt_cache_setting(settings),
+        skills=skill_key_tuple,
     )
     return _registry.register_reasoner(reasoner)
 

--- a/julep/dotctx.py
+++ b/julep/dotctx.py
@@ -509,6 +509,12 @@ def reasoner_from_settings(
     from .skills import load_package_skills, parse_skills_setting
 
     skill_key_tuple: tuple[str, ...] = ()
+    if "skills" in settings and settings["skills"] is None:
+        from .skills import SkillError
+
+        raise SkillError(
+            f"settings 'skills' in {base_dir or nm!r} must be a list of skill names"
+        )
     declared = parse_skills_setting(settings.get("skills"), origin=base_dir or nm)
     if base_dir is not None:
         skill_key_tuple = tuple(

--- a/julep/dotctx.py
+++ b/julep/dotctx.py
@@ -59,6 +59,7 @@ _REPLACE_HANDLED_FIELDS = frozenset(
         "max_rounds", "is_agent", "sub_contract", "context_scope",
         "system_render", "user_render", "max_tokens", "reasoning_effort",
         "output_retries", "require_tool_call", "response_format", "prompt_cache",
+        "skills",
     }
 )
 
@@ -198,6 +199,7 @@ class Reasoner:
     require_tool_call: bool = False       # declarative; loop enforcement is Phase 3/4
     response_format: Optional[str] = None  # "json_object"; reply_schema wins at call time
     prompt_cache: Optional[str] = None
+    skills: tuple[str, ...] = ()          # content-addressed skill/<name>@v<hash> keys
 
     def __init__(
         self,
@@ -220,6 +222,7 @@ class Reasoner:
         require_tool_call: bool = False,
         response_format: Optional[str] = None,
         prompt_cache: Optional[str] = None,
+        skills: Sequence[str] = (),
     ) -> None:
         if reply is _REPLY_UNSET or reply is None:
             materialized = None
@@ -252,6 +255,18 @@ class Reasoner:
             )
         object.__setattr__(self, "prompt_cache", prompt_cache)
 
+        from .skills import SKILL_KEY_RE
+
+        skill_keys_tuple = tuple(skills)
+        for key in skill_keys_tuple:
+            if SKILL_KEY_RE.match(key) is None:
+                raise ValueError(
+                    f"malformed skill key {key!r} on reasoner {name!r}; "
+                    "expected 'skill/<name>@v<12 hex chars>' — pass "
+                    "julep.skills.skill_keys([...]) rather than bare names"
+                )
+        object.__setattr__(self, "skills", skill_keys_tuple)
+
     def replace(
         self,
         *,
@@ -273,6 +288,7 @@ class Reasoner:
         require_tool_call: bool = _KEEP,
         response_format: Optional[str] = _KEEP,
         prompt_cache: Optional[str] = _KEEP,
+        skills: Sequence[str] = _KEEP,
     ) -> Reasoner:
         """Return a copy with selected fields replaced.
 
@@ -301,6 +317,7 @@ class Reasoner:
             require_tool_call=_replacement(require_tool_call, self.require_tool_call),
             response_format=_replacement(response_format, self.response_format),
             prompt_cache=_replacement(prompt_cache, self.prompt_cache),
+            skills=_replacement(skills, self.skills),
         )
         # Preserve extension/future fields this version cannot yet override.
         # Declared fields still go through the constructor above for validation.

--- a/julep/dotctx.py
+++ b/julep/dotctx.py
@@ -255,7 +255,7 @@ class Reasoner:
             )
         object.__setattr__(self, "prompt_cache", prompt_cache)
 
-        from .skills import SKILL_KEY_RE
+        from .skills import SKILL_KEY_RE, skill_name_of
 
         skill_keys_tuple = tuple(skills)
         for key in skill_keys_tuple:
@@ -265,6 +265,15 @@ class Reasoner:
                     "expected 'skill/<name>@v<12 hex chars>' — pass "
                     "julep.skills.skill_keys([...]) rather than bare names"
                 )
+        skill_names: set[str] = set()
+        for key in skill_keys_tuple:
+            skill_name = skill_name_of(key)
+            if skill_name in skill_names:
+                raise ValueError(
+                    f"duplicate skill name {skill_name!r} on reasoner {name!r}; "
+                    "each declared skill name must be unique"
+                )
+            skill_names.add(skill_name)
         object.__setattr__(self, "skills", skill_keys_tuple)
 
     def replace(

--- a/julep/dotctx_rich.py
+++ b/julep/dotctx_rich.py
@@ -1136,7 +1136,8 @@ def load_single_file_dotctx(
     else:
         settings, body = {}, content
     _validate_settings_keys(settings, path)
-    if parse_skills_setting(settings.get("skills"), origin=path) is not None:
+    if "skills" in settings:
+        parse_skills_setting(settings["skills"], origin=path)
         raise SkillError(
             f"single-file dotctx {path!r} cannot activate skills; skills load from "
             "<package>.ctx/skills/<name>/SKILL.md, which needs the directory layout"
@@ -1230,6 +1231,10 @@ def load_rich_dotctx(
 
     settings_tools: Sequence[Any] = settings.get("tools") or ()
     tools = tuple(dict.fromkeys([*(str(t) for t in settings_tools), *tool_keys]))
+    if "skills" in settings and settings["skills"] is None:
+        raise SkillError(
+            f"settings 'skills' in {path!r} must be a list of skill names"
+        )
     skills = load_package_skills(
         path, parse_skills_setting(settings.get("skills"), origin=path)
     )

--- a/julep/dotctx_rich.py
+++ b/julep/dotctx_rich.py
@@ -66,6 +66,7 @@ from .registry import (
     RendererDependency,
     ToolSchemaExpectation,
 )
+from .skills import Skill, SkillError, load_package_skills, parse_skills_setting
 
 # Settings keys the rich layout accepts. The prompt lives in template files and
 # the reply schema in schema.pyi, so the minimal layout's system/schema keys are
@@ -93,6 +94,7 @@ _ALLOWED_SETTINGS = frozenset(
         "sub",
         "context",
         "tools",
+        "skills",
     }
 )
 
@@ -126,6 +128,7 @@ class RichDotctx:
     tool_grants: tuple[ToolGrant, ...]
     expected_tool_schemas: Mapping[str, dict[str, Any]]
     expected_tool_descriptions: Mapping[str, str] = field(default_factory=dict)
+    skills: tuple[Skill, ...] = ()
 
 
 # --------------------------------------------------------------------------- #
@@ -1072,6 +1075,7 @@ def _build_reasoner(
     tools: tuple[str, ...],
     system_render: Optional[str],
     user_render: Optional[str],
+    skill_keys_: tuple[str, ...] = (),
 ) -> Reasoner:
     scope = ContextScope(settings["context"]) if settings.get("context") else ContextScope.LOCAL
     model, effort, output_retries = _model_and_effort(dict(settings))
@@ -1096,6 +1100,7 @@ def _build_reasoner(
         require_tool_call=_require_tool_call_setting(settings),
         response_format=_response_format_setting(settings),
         prompt_cache=_prompt_cache_setting(settings),
+        skills=skill_keys_,
     )
 
 
@@ -1131,6 +1136,11 @@ def load_single_file_dotctx(
     else:
         settings, body = {}, content
     _validate_settings_keys(settings, path)
+    if parse_skills_setting(settings.get("skills"), origin=path) is not None:
+        raise SkillError(
+            f"single-file dotctx {path!r} cannot activate skills; skills load from "
+            "<package>.ctx/skills/<name>/SKILL.md, which needs the directory layout"
+        )
 
     raw_name = settings.get("name")
     package = raw_name if isinstance(raw_name, str) and raw_name else _default_name(path)
@@ -1220,6 +1230,10 @@ def load_rich_dotctx(
 
     settings_tools: Sequence[Any] = settings.get("tools") or ()
     tools = tuple(dict.fromkeys([*(str(t) for t in settings_tools), *tool_keys]))
+    skills = load_package_skills(
+        path, parse_skills_setting(settings.get("skills"), origin=path)
+    )
+    skill_key_tuple = tuple(registry.register_skill(skill) for skill in skills)
 
     reasoner = _build_reasoner(
         package,
@@ -1228,6 +1242,7 @@ def load_rich_dotctx(
         tools=tools,
         system_render=renderer_names.get("system"),
         user_render=renderer_names.get("user"),
+        skill_keys_=skill_key_tuple,
     )
     reasoner = registry.register_reasoner(reasoner)
 
@@ -1239,6 +1254,7 @@ def load_rich_dotctx(
         tool_grants=tuple(ToolGrant(name=key) for key in tool_keys),
         expected_tool_schemas=expectations,
         expected_tool_descriptions=descriptions,
+        skills=skills,
     )
 
 

--- a/julep/embedded.py
+++ b/julep/embedded.py
@@ -1,0 +1,66 @@
+"""Public helpers for compiling and running standalone dotctx pipelines."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping, Optional
+
+from .cli.config import McpServerConfig
+from .ctx_pipeline import CtxPipelineConfig, pipeline_spec_from_ctx
+from .execution.effects import WorkerContext
+from .execution.policy import ExecutionPolicy
+from .local import (
+    EmbeddedRun,
+    LocalExecutionUnsupported,
+    LocalPipeline,
+    LocalPipelineNotFound,
+    _local_pipeline_from_spec,
+    prepare_local_pipeline,
+)
+
+
+def load_pipeline(
+    path: str | Path,
+    *,
+    env: Optional[Mapping[str, str]] = None,
+    name: Optional[str] = None,
+    tools: Optional[Mapping[str, str]] = None,
+    policy: Optional[ExecutionPolicy] = None,
+    mcp_servers: Optional[Mapping[str, McpServerConfig]] = None,
+) -> LocalPipeline:
+    """Compile one dotctx package without a project file or control-plane naming.
+
+    ``tools`` maps prompt-visible MCP aliases to ``server:tool`` targets. The
+    resolved package is compiled under the stable application name ``embedded``.
+    """
+    resolved = Path(path).expanduser().resolve()
+    config = CtxPipelineConfig(
+        name=name if name is not None else resolved.stem,
+        ctx=str(resolved),
+        env=dict(env or {}),
+        tools=dict(tools or {}),
+        policy=policy,
+    )
+    spec = pipeline_spec_from_ctx(
+        config,
+        root=resolved.parent,
+        env_vars=env,
+        mcp_servers=mcp_servers,
+    )
+    return _local_pipeline_from_spec(
+        spec,
+        application_name="embedded",
+        environment="embedded",
+        env_vars=dict(env or {}),
+    )
+
+
+__all__ = [
+    "EmbeddedRun",
+    "LocalExecutionUnsupported",
+    "LocalPipeline",
+    "LocalPipelineNotFound",
+    "WorkerContext",
+    "load_pipeline",
+    "prepare_local_pipeline",
+]

--- a/julep/execution/anthropic_batch.py
+++ b/julep/execution/anthropic_batch.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass
 from typing import Any
 
 from ..prompt import rendered_user_for
+from ..registry import DEFAULT_REGISTRY
+from ..skills import batch_system_text
 from .batch_provider import (
     BatchProvider,
     BatchReply,
@@ -70,7 +72,9 @@ class AnthropicBatchProvider(BatchProvider):
         # rides the prompt's own JSON instructions — the same place the sync
         # path lands after its recorded fallback.
         messages = _messages(
-            reasoner.system,
+            batch_system_text(
+                reasoner.system, reasoner.skills, registry=DEFAULT_REGISTRY
+            ),
             value,
             schema_hint=schema,
             user_text=user_text,

--- a/julep/execution/interpreter.py
+++ b/julep/execution/interpreter.py
@@ -443,10 +443,11 @@ async def _eval_prim(node: Node, value: Any, env: Env, cid: str) -> Result:
         reply, attrs = _unwrap_julep_meta(out)
         reported_cost = _reported_reasoner_cost(reply, attrs)
         reasoner_attrs = dict(attrs or {})
-        reasoner_attrs.setdefault(
-            "llm.cost.status",
-            "reported" if reported_cost is not None else "unknown",
-        )
+        if reported_cost is not None:
+            reasoner_attrs["llm.cost.status"] = "reported"
+            reasoner_attrs.setdefault("llm.cost", reported_cost)
+        else:
+            reasoner_attrs.setdefault("llm.cost.status", "unknown")
         return Result(reply, attrs=reasoner_attrs, reported_cost=reported_cost)
     if isinstance(step, SubStep):
         return Result(await env.run_sub(step.ref, step.contract, value, cid, node.id))
@@ -595,7 +596,17 @@ def _reported_reasoner_cost(
 ) -> Optional[float]:
     if attrs is not None:
         meta_cost = attrs.get("llm.cost")
-        if isinstance(meta_cost, (int, float)) and not isinstance(meta_cost, bool):
+        cost_status = attrs.get("llm.cost.status")
+        # AIDEV-NOTE: usage-derived prices are observability metadata, not
+        # replay-stable projection charges. Event.cost remains restricted to a
+        # declared annotation or a price the provider/caller reported.
+        if cost_status == "derived":
+            return None
+        if (
+            cost_status != "unknown"
+            and isinstance(meta_cost, (int, float))
+            and not isinstance(meta_cost, bool)
+        ):
             return float(meta_cost)
 
     if not isinstance(value, dict):

--- a/julep/execution/interpreter.py
+++ b/julep/execution/interpreter.py
@@ -840,6 +840,8 @@ class InMemoryEnv:
         root_run_id: Optional[str] = None,
         segment_seq: int = 0,
         inbound: Optional[dict[str, list[Any]]] = None,
+        trajectory_recorder: Optional[Any] = None,
+        trajectory_run_id: Optional[str] = None,
     ) -> None:
         self.manifest = manifest
         self.emitter = emitter
@@ -875,6 +877,9 @@ class InMemoryEnv:
         }
         self._emitted: dict[str, list[Any]] = {}
         self._cid = 0
+        self._trajectory_cid = 0
+        self._trajectory_recorder = trajectory_recorder
+        self._trajectory_run_id = trajectory_run_id
 
     # --- identity / pures --- #
     def next_cid(self, node_id: str) -> str:
@@ -904,13 +909,55 @@ class InMemoryEnv:
             raise CapabilityDenied(f"tool {tool_key!r} exceeded maxCalls={limit}")
         self.call_counts[tool_key] = count + 1
 
+    async def _capture_trajectory(
+        self,
+        *,
+        node_id: str,
+        cid: str,
+        op: str,
+        kind: str,
+        input_value: Any,
+        output_value: Any,
+    ) -> None:
+        recorder = self._trajectory_recorder
+        run_id = self._trajectory_run_id
+        root_run_id = self.root_run_id
+        if recorder is None or run_id is None or root_run_id is None:
+            return
+        await recorder.capture(
+            step_id=f"{run_id}:s{self.segment_seq}:{cid}",
+            run_id=run_id,
+            root_run_id=root_run_id,
+            cid=cid,
+            node_id=node_id,
+            op=op,
+            kind=kind,
+            input_value=input_value,
+            output_value=output_value,
+        )
+
+    def _next_trajectory_cid(self, node_id: str) -> str:
+        # AIDEV-NOTE: trajectory-only identities must not consume the Env cid
+        # sequence; MCP idempotency keys and projection identities are behavior.
+        self._trajectory_cid += 1
+        return f"{node_id}@trajectory-{self._trajectory_cid}"
+
     # --- effect handlers --- #
     async def run_call(self, node: Node, value: Any, cid: str) -> Any:
         key = call_ref_key(node, self.manifest)
         fn = self._tools.get(key)
         if fn is not None:
             out = fn(value)
-            return await out if inspect.isawaitable(out) else out
+            result = await out if inspect.isawaitable(out) else out
+            await self._capture_trajectory(
+                node_id=node.id,
+                cid=cid,
+                op="call",
+                kind="tool",
+                input_value=value,
+                output_value=result,
+            )
+            return result
 
         step = node.step
         assert isinstance(step, CallStep)
@@ -924,7 +971,7 @@ class InMemoryEnv:
                 if json_schema_error(value, frozen.input_schema) is not None:
                     raise ToolInputValidation(ref.server, ref.tool)
                 input_schema_validated = True
-            return await self._mcp_call(
+            result = await self._mcp_call(
                 ref.server,
                 ref.tool,
                 value,
@@ -933,6 +980,15 @@ class InMemoryEnv:
                 None,
                 input_schema_validated,
             )
+            await self._capture_trajectory(
+                node_id=node.id,
+                cid=cid,
+                op="call",
+                kind="tool",
+                input_value=value,
+                output_value=result,
+            )
+            return result
         raise KeyError(f"no in-memory tool for {key!r}")
 
     async def invoke_reasoner(
@@ -946,7 +1002,17 @@ class InMemoryEnv:
         if reasoner not in self._reasoners:
             raise KeyError(f"no in-memory reasoner for {reasoner!r}")
         out = self._reasoners[reasoner](value)
-        return await out if inspect.isawaitable(out) else out
+        result = await out if inspect.isawaitable(out) else out
+        node_id, separator, _ = cid.rpartition("@")
+        await self._capture_trajectory(
+            node_id=node_id if separator else reasoner,
+            cid=cid,
+            op="think",
+            kind="reasoner",
+            input_value=value,
+            output_value=result,
+        )
+        return result
 
     async def run_sub(
         self,
@@ -1010,8 +1076,19 @@ class InMemoryEnv:
         )
 
         async def invoke_controller(payload: dict[str, Any]) -> Any:
+            controller_node = f"agent:{controller}:think"
+            controller_cid = self._next_trajectory_cid(controller_node)
             out = self._reasoners[controller](payload)
-            return await out if inspect.isawaitable(out) else out
+            result = await out if inspect.isawaitable(out) else out
+            await self._capture_trajectory(
+                node_id=controller_node,
+                cid=controller_cid,
+                op="think",
+                kind="reasoner",
+                input_value=payload,
+                output_value=result,
+            )
+            return result
 
         async def call_tool(
             alias: str,
@@ -1021,21 +1098,42 @@ class InMemoryEnv:
         ) -> Any:
             del call_index
             wire = aliases.get(alias, alias)
+            tool_node = f"agent:{controller}:{alias}"
             fn = self._tools.get(alias) or self._tools.get(wire)
             if fn is not None:
+                tool_cid = self._next_trajectory_cid(tool_node)
                 out = fn(args)
-                return await out if inspect.isawaitable(out) else out
+                result = await out if inspect.isawaitable(out) else out
+                await self._capture_trajectory(
+                    node_id=tool_node,
+                    cid=tool_cid,
+                    op="call",
+                    kind="tool",
+                    input_value=args,
+                    output_value=result,
+                )
+                return result
             if "/" in wire and self._mcp_call is not None:
                 server, tool = wire.split("/", 1)
-                return await self._mcp_call(
+                tool_cid = self.next_cid(tool_node)
+                result = await self._mcp_call(
                     server,
                     tool,
                     args,
-                    self.next_cid(f"agent:{controller}:{alias}"),
+                    tool_cid,
                     self.principal,
                     None,
                     schemas is not None and alias in schemas,
                 )
+                await self._capture_trajectory(
+                    node_id=tool_node,
+                    cid=tool_cid,
+                    op="call",
+                    kind="tool",
+                    input_value=args,
+                    output_value=result,
+                )
+                return result
             raise KeyError(f"no in-memory fake or MCP caller for tool alias {alias!r}")
 
         result = await drive_agent_loop(

--- a/julep/execution/interpreter.py
+++ b/julep/execution/interpreter.py
@@ -600,14 +600,13 @@ def _reported_reasoner_cost(
         # AIDEV-NOTE: usage-derived prices are observability metadata, not
         # replay-stable projection charges. Event.cost remains restricted to a
         # declared annotation or a price the provider/caller reported.
-        if cost_status == "derived":
-            return None
         if (
-            cost_status != "unknown"
+            cost_status == "reported"
             and isinstance(meta_cost, (int, float))
             and not isinstance(meta_cost, bool)
         ):
             return float(meta_cost)
+        return None
 
     if not isinstance(value, dict):
         return None

--- a/julep/execution/interpreter.py
+++ b/julep/execution/interpreter.py
@@ -831,7 +831,7 @@ class InMemoryEnv:
         agents: Optional[dict[str, Callable[[Any], Any]]] = None,
         planners: Optional[dict[str, Callable[[Any], Node]]] = None,
         gate: Optional[Callable[[Any], Any]] = None,
-        sleeper: Optional[Callable[[int], Awaitable[None]]] = None,
+        sleeper: Optional[Callable[[float], Awaitable[None]]] = None,
         max_parallel: Optional[int] = None,
         max_calls: Optional[dict[str, int]] = None,
         mode: EnforcementMode | str = EnforcementMode.STRICT,

--- a/julep/execution/llm.py
+++ b/julep/execution/llm.py
@@ -44,11 +44,11 @@ from collections.abc import Awaitable, Callable, Mapping
 from typing import Any, Optional
 
 from ..agent_loop import FEEDBACK_KEY, NATIVE_TOOLS_KEY, ROUND_NOTE_KEY
-from ..dotctx import Reasoner, get_reasoner
+from ..dotctx import Reasoner
 from ..errors import ResilienceExhausted
 from ..prompt import rendered_reasoner_for, rendered_user_for
 from ..qos import ReasonerDispatch, QoSTier
-from ..registry import DEFAULT_REGISTRY
+from ..registry import DEFAULT_REGISTRY, Registry
 from ..resilience import (
     AttemptRecord,
     CircuitBreaker,
@@ -589,6 +589,7 @@ async def complete_reasoner(
     dispatch: ReasonerDispatch = _DEFAULT_REASONER_DISPATCH,
     tools: Optional[list[dict[str, Any]]] = None,
     parallel_tool_calls: Optional[bool] = None,
+    registry: Optional[Registry] = None,
 ) -> LlmResult:
     """One model call for ``reasoner`` against ``value``, returning its parsed reply.
 
@@ -601,6 +602,7 @@ async def complete_reasoner(
     injected and ``response_format`` is omitted from that request."""
     if dispatch.qos == QoSTier.BATCH:
         raise ValueError("BATCH must not reach complete_reasoner")
+    registry = DEFAULT_REGISTRY if registry is None else registry
 
     # Render named system/user templates here so both seams (activity + facade)
     # see the same strings; already-rendered reasoners pass through unchanged.
@@ -613,8 +615,8 @@ async def complete_reasoner(
         render_value = {key: item for key, item in value.items() if key not in reserved}
     else:
         render_value = value
-    reasoner = rendered_reasoner_for(reasoner, render_value)
-    user_text = rendered_user_for(reasoner, render_value)
+    reasoner = rendered_reasoner_for(reasoner, render_value, registry=registry)
+    user_text = rendered_user_for(reasoner, render_value, registry=registry)
     if transcript is not None and _is_controller_value(value):
         transcript = _render_raw_opening_ask(
             transcript,
@@ -631,7 +633,7 @@ async def complete_reasoner(
         provider_safe_tool_defs(tools) if tools else (tools, {})
     )
     active_skills = (
-        resolve_skill_keys(reasoner.skills, registry=DEFAULT_REGISTRY)
+        resolve_skill_keys(reasoner.skills, registry=registry)
         if reasoner.skills
         else ()
     )
@@ -1012,6 +1014,7 @@ def make_llm_caller(
     default_provider: str = DEFAULT_PROVIDER,
     acompletion: Optional[AnyCompletion] = None,
     aresponses: Optional[AnyResponses] = None,
+    registry: Registry = DEFAULT_REGISTRY,
 ) -> Callable[..., Awaitable[Any]]:
     """Activity-seam ``LlmCaller``: ``(Reasoner, value, principal, transcript, dispatch)``.
 
@@ -1040,6 +1043,7 @@ def make_llm_caller(
             dispatch=dispatch,
             tools=tools,
             parallel_tool_calls=parallel_tool_calls,
+            registry=registry,
         )
 
     return caller
@@ -1050,6 +1054,7 @@ def make_local_reasoner(
     default_provider: str = DEFAULT_PROVIDER,
     acompletion: Optional[AnyCompletion] = None,
     aresponses: Optional[AnyResponses] = None,
+    registry: Registry = DEFAULT_REGISTRY,
 ) -> Callable[[str, Any], Awaitable[Any]]:
     """Facade-seam llm: ``(reasoner_name, payload) -> reply``.
 
@@ -1064,12 +1069,13 @@ def make_local_reasoner(
             tools = payload[NATIVE_TOOLS_KEY]
             value = {key: val for key, val in payload.items() if key != NATIVE_TOOLS_KEY}
         return await complete_reasoner(
-            get_reasoner(reasoner_name),
+            registry.get_reasoner(reasoner_name),
             value,
             acompletion=acompletion,
             aresponses=aresponses,
             default_provider=default_provider,
             tools=tools,
+            registry=registry,
         )
 
     return caller
@@ -1094,6 +1100,7 @@ def make_resilient_llm_caller(
     default_provider: str = DEFAULT_PROVIDER,
     acompletion: Optional[AnyCompletion] = None,
     aresponses: Optional[AnyResponses] = None,
+    registry: Registry = DEFAULT_REGISTRY,
     sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
 ) -> Callable[..., Awaitable[Any]]:
     """An ``LlmCaller`` that survives provider outages deterministically.
@@ -1166,6 +1173,7 @@ def make_resilient_llm_caller(
                         dispatch=dispatch,
                         tools=tools,
                         parallel_tool_calls=parallel_tool_calls,
+                        registry=registry,
                     )
                     reply = result.reply
                 except ResponsesRefusalError as exc:

--- a/julep/execution/llm.py
+++ b/julep/execution/llm.py
@@ -60,6 +60,7 @@ from ..resilience import (
 )
 from ..skills import (
     SKILL_TOOL,
+    disclosed_skills_block,
     load_skill_tool_def,
     resolve_skill_keys,
     skills_prompt_block,
@@ -715,7 +716,19 @@ async def complete_reasoner(
             kwargs["tools"] = offered_tools
             if parallel_tool_calls is not None:
                 kwargs["parallel_tool_calls"] = parallel_tool_calls
-        messages.extend(skill_turns)
+        if skill_tool_open:
+            disclosure_turns = skill_turns
+        elif loaded_skills:
+            loaded = [skill for skill in active_skills if skill.name in loaded_skills]
+            disclosure_turns = [
+                {"role": "user", "content": disclosed_skills_block(loaded)}
+            ]
+        else:
+            disclosure_turns = []
+        disclosure_index = len(messages)
+        while disclosure_index and messages[disclosure_index - 1].get("role") == "system":
+            disclosure_index -= 1
+        messages[disclosure_index:disclosure_index] = disclosure_turns
         if retry_note is not None:
             messages.append({"role": "user", "content": retry_note})
         effort = reasoner.reasoning_effort
@@ -797,25 +810,35 @@ async def complete_reasoner(
         )
         return _restore_tool_calls(parsed), calls
 
-    def _skill_requests(parsed: Any) -> list[tuple[Any, Any]]:
+    def _skill_requests(parsed: Any) -> list[tuple[Any, Optional[str]]]:
         if not isinstance(parsed, dict):
             return []
         calls = parsed.get("tool_calls")
         if not isinstance(calls, list):
             return []
-        return [
-            (call.get("id"), (call.get("input") or {}).get("name"))
-            for call in calls
-            if isinstance(call, dict) and call.get("tool") == SKILL_TOOL
-        ]
+        requests: list[tuple[Any, Optional[str]]] = []
+        for call in calls:
+            if not isinstance(call, dict) or call.get("tool") != SKILL_TOOL:
+                continue
+            call_input = call.get("input")
+            raw_name = call_input.get("name") if isinstance(call_input, dict) else None
+            name = raw_name if isinstance(raw_name, str) and raw_name else None
+            requests.append((call.get("id"), name))
+        return requests
 
-    def _drop_skill_calls(parsed: Any) -> tuple[Any, int]:
+    def _drop_skill_calls(parsed: Any, native_calls: int) -> tuple[Any, int]:
         """Skill calls are resolved here and must never reach the agent loop."""
+        if not active_skills:
+            return parsed, native_calls
         if not isinstance(parsed, dict) or not isinstance(parsed.get("tool_calls"), list):
-            return parsed, 0
-        kept = [call for call in parsed["tool_calls"] if call.get("tool") != SKILL_TOOL]
+            return parsed, native_calls
+        kept = [
+            call
+            for call in parsed["tool_calls"]
+            if not isinstance(call, dict) or call.get("tool") != SKILL_TOOL
+        ]
         if len(kept) == len(parsed["tool_calls"]):
-            return parsed, len(kept)
+            return parsed, native_calls
         remainder = {key: item for key, item in parsed.items() if key != "tool_calls"}
         if kept:
             remainder["tool_calls"] = kept
@@ -833,6 +856,25 @@ async def complete_reasoner(
         if not requests:
             skill_tool_open = False
             break
+        calls = reply.get("tool_calls") if isinstance(reply, dict) else None
+        discarded_tools: list[str] = []
+        for tool_call in calls if isinstance(calls, list) else []:
+            if not isinstance(tool_call, dict):
+                discarded_tools.append(f"<malformed tool call {tool_call!r}>")
+                continue
+            tool = tool_call.get("tool")
+            if tool != SKILL_TOOL:
+                discarded_tools.append(
+                    tool if isinstance(tool, str) and tool else "<unnamed tool>"
+                )
+        if discarded_tools:
+            logger.warning(
+                "reasoner %s issued non-skill tool calls alongside %s; discarding "
+                "%s so they will be re-decided after skill disclosure",
+                reasoner.name,
+                SKILL_TOOL,
+                ", ".join(discarded_tools),
+            )
         by_name = {skill.name: skill for skill in active_skills}
         skill_turns.append(
             {
@@ -855,6 +897,12 @@ async def complete_reasoner(
             if name in loaded_skills:
                 skill_error_budget -= 1
                 content = f"skill {name!r} was already provided above"
+            elif name is None:
+                skill_error_budget -= 1
+                content = (
+                    f"{SKILL_TOOL} needs a `name` string; available skills are: "
+                    + ", ".join(sorted(by_name))
+                )
             elif name not in by_name:
                 skill_error_budget -= 1
                 content = (
@@ -873,7 +921,7 @@ async def complete_reasoner(
         _accumulate(completion)
         reply, native_tool_calls = _parse(completion, expect_json=schema is not None)
 
-    reply, native_tool_calls = _drop_skill_calls(reply)
+    reply, native_tool_calls = _drop_skill_calls(reply, native_tool_calls)
 
     validation_error = _final_output_schema_error(reply, native_tool_calls)
     while schema is not None and validation_error is not None and retries_used < reasoner.output_retries:
@@ -891,7 +939,7 @@ async def complete_reasoner(
         )
         _accumulate(completion)
         reply, native_tool_calls = _parse(completion, expect_json=True)
-        reply, native_tool_calls = _drop_skill_calls(reply)
+        reply, native_tool_calls = _drop_skill_calls(reply, native_tool_calls)
         validation_error = _final_output_schema_error(reply, native_tool_calls)
     ended = time.time()
     pc = reasoner.prompt_cache

--- a/julep/execution/llm.py
+++ b/julep/execution/llm.py
@@ -65,7 +65,13 @@ from ..skills import (
     resolve_skill_keys,
     skills_prompt_block,
 )
-from .llm_result import AttemptMeta, LlmCallMeta, LlmResult
+from .llm_result import (
+    AttemptMeta,
+    LlmCallMeta,
+    LlmCostStatus,
+    LlmResult,
+    LlmUsage,
+)
 from .openai_responses import (
     AnyResponses,
     ResponsesModelBehaviorError,
@@ -111,6 +117,7 @@ def json_schema_error(value: Any, schema: Optional[dict[str, Any]]) -> Optional[
 # any-llm's ``acompletion``-shaped callable: keyword-driven, returns an
 # OpenAI-typed completion (``.choices[0].message.{content,parsed}``).
 AnyCompletion = Callable[..., Awaitable[Any]]
+CompletionCostResolver = Callable[[Any], tuple[float | None, LlmCostStatus]]
 
 DEFAULT_PROVIDER = "anthropic"
 
@@ -565,6 +572,10 @@ def _cache_usage_of(completion: Any) -> tuple[int | None, int | None]:
         if details is not None:
             read = getattr(details, "cached_tokens", None)
     creation = getattr(usage, "cache_creation_input_tokens", None)
+    if creation is None:
+        details = getattr(usage, "prompt_tokens_details", None)
+        if details is not None:
+            creation = getattr(details, "cache_creation_tokens", None)
     return read, creation
 
 
@@ -590,6 +601,7 @@ async def complete_reasoner(
     tools: Optional[list[dict[str, Any]]] = None,
     parallel_tool_calls: Optional[bool] = None,
     registry: Optional[Registry] = None,
+    cost_resolver: Optional[CompletionCostResolver] = None,
 ) -> LlmResult:
     """One model call for ``reasoner`` against ``value``, returning its parsed reply.
 
@@ -795,6 +807,8 @@ async def complete_reasoner(
 
     pt = ct = tt = None
     cache_read = cache_creation = None
+    resolved_costs: list[float | None] = []
+    resolved_cost_statuses: list[LlmCostStatus] = []
 
     def _accumulate(result: Any) -> None:
         nonlocal pt, ct, tt, cache_read, cache_creation
@@ -803,6 +817,10 @@ async def complete_reasoner(
         rcr, rcc = _cache_usage_of(result)
         cache_read = _add_tokens(cache_read, rcr)
         cache_creation = _add_tokens(cache_creation, rcc)
+        if cost_resolver is not None:
+            cost, status = cost_resolver(result)
+            resolved_costs.append(cost)
+            resolved_cost_statuses.append(status)
 
     def _parse(result: Any, *, expect_json: bool) -> tuple[Any, int]:
         parsed, calls = (
@@ -960,6 +978,24 @@ async def complete_reasoner(
         pc_reason = None if pc_marker_placed else "no_cacheable_content"
     else:
         pc_requested, pc_applied, pc_reason = pc, False, "provider_inert"
+    if resolved_cost_statuses and all(
+        status != "unknown" and cost is not None
+        for status, cost in zip(resolved_cost_statuses, resolved_costs, strict=True)
+    ):
+        cost = sum(item for item in resolved_costs if item is not None)
+        cost_status: LlmCostStatus = (
+            "derived" if "derived" in resolved_cost_statuses else "reported"
+        )
+    else:
+        cost = None
+        cost_status = "unknown"
+    usage = LlmUsage(
+        prompt_tokens=pt,
+        completion_tokens=ct,
+        total_tokens=tt,
+        cache_read_tokens=cache_read,
+        cache_creation_tokens=cache_creation,
+    )
     meta = LlmCallMeta(
         served_model=_served_model_of(completion, model),
         provider=provider,
@@ -974,6 +1010,9 @@ async def complete_reasoner(
         prompt_cache_reason=pc_reason,
         cache_read_tokens=cache_read,
         cache_creation_tokens=cache_creation,
+        usage=usage,
+        cost=cost,
+        cost_status=cost_status,
     )
     return LlmResult(reply=reply, meta=meta)
 

--- a/julep/execution/llm.py
+++ b/julep/execution/llm.py
@@ -48,6 +48,7 @@ from ..dotctx import Reasoner, get_reasoner
 from ..errors import ResilienceExhausted
 from ..prompt import rendered_reasoner_for, rendered_user_for
 from ..qos import ReasonerDispatch, QoSTier
+from ..registry import DEFAULT_REGISTRY
 from ..resilience import (
     AttemptRecord,
     CircuitBreaker,
@@ -56,6 +57,12 @@ from ..resilience import (
     ResiliencePolicy,
     classify_error,
     is_auth_error,
+)
+from ..skills import (
+    SKILL_TOOL,
+    load_skill_tool_def,
+    resolve_skill_keys,
+    skills_prompt_block,
 )
 from .llm_result import AttemptMeta, LlmCallMeta, LlmResult
 from .openai_responses import (
@@ -619,10 +626,34 @@ async def complete_reasoner(
     # mem-mcp's declarative json_object mode claims the kwarg only when no
     # reply schema does (the schema path wins; the call never carries both).
     json_object = schema is None and reasoner.response_format == "json_object"
-    has_tools = bool(tools)
     safe_tools, tool_name_reverse = (
         provider_safe_tool_defs(tools) if tools else (tools, {})
     )
+    active_skills = (
+        resolve_skill_keys(reasoner.skills, registry=DEFAULT_REGISTRY)
+        if reasoner.skills
+        else ()
+    )
+    # SKILL_TOOL is already provider-safe, so sanitization cannot hide a collision.
+    if active_skills and any(
+        tool_def.get("function", {}).get("name") == SKILL_TOOL
+        for tool_def in safe_tools or []
+    ):
+        raise ValueError(
+            f"reasoner {reasoner.name!r} grants a tool named {SKILL_TOOL!r}, which is "
+            "reserved for skill disclosure; rename the tool"
+        )
+    system_text = reasoner.system
+    if active_skills:
+        block = skills_prompt_block(active_skills)
+        system_text = f"{block}\n\n{reasoner.system}" if reasoner.system else block
+    loaded_skills: list[str] = []
+    skill_turns: list[dict[str, Any]] = []
+    skill_tool_open = bool(active_skills)
+    skill_error_budget = 2
+
+    def _offering_tools() -> bool:
+        return bool(safe_tools) or skill_tool_open
 
     def _restore_tool_calls(parsed: Any) -> Any:
         if tool_name_reverse and isinstance(parsed, dict):
@@ -652,10 +683,15 @@ async def complete_reasoner(
         nonlocal pc_marker_placed
         # Native tool rounds cannot carry response_format; keep schema guidance
         # in the prompt so FINISH replies can still parse on non-tool rounds.
-        native_response_format = native and not has_tools
+        if skill_tool_open:
+            offered_tools = list(safe_tools or [])
+            offered_tools.append(load_skill_tool_def(active_skills, loaded=loaded_skills))
+        else:
+            offered_tools = safe_tools or []
+        native_response_format = native and not offered_tools
         if native_response_format and schema is not None:
             messages = _messages(
-                reasoner.system, value,
+                system_text, value,
                 schema_hint=None, user_text=user_text, transcript=transcript,
             )
             kwargs: dict[str, Any] = {"response_format": _response_format(schema)}
@@ -665,20 +701,21 @@ async def complete_reasoner(
             # raw text either way — json_object constrains the provider, not
             # CA parsing; callers own parsing (mem-mcp's use parse_llm_json).
             messages = _messages(
-                reasoner.system, value,
+                system_text, value,
                 schema_hint=None, user_text=user_text, transcript=transcript,
             )
             kwargs = {"response_format": {"type": "json_object"}}
         else:
             messages = _messages(
-                reasoner.system, value,
+                system_text, value,
                 schema_hint=schema, user_text=user_text, transcript=transcript,
             )
             kwargs = {}
-        if has_tools:
-            kwargs["tools"] = safe_tools
+        if offered_tools:
+            kwargs["tools"] = offered_tools
             if parallel_tool_calls is not None:
                 kwargs["parallel_tool_calls"] = parallel_tool_calls
+        messages.extend(skill_turns)
         if retry_note is not None:
             messages.append({"role": "user", "content": retry_note})
         effort = reasoner.reasoning_effort
@@ -718,7 +755,7 @@ async def complete_reasoner(
 
     async def dispatch_once(retry_note: Optional[str] = None) -> Any:
         nonlocal fallback_reason, native_ok
-        if not has_tools and (schema is not None or json_object) and native_ok \
+        if not _offering_tools() and (schema is not None or json_object) and native_ok \
                 and provider not in _PROMPT_FALLBACK_PROVIDERS:
             try:
                 return await call(native=True, retry_note=retry_note)
@@ -741,16 +778,103 @@ async def complete_reasoner(
                 )
         return await call(native=False, retry_note=retry_note)
 
+    pt = ct = tt = None
+    cache_read = cache_creation = None
+
+    def _accumulate(result: Any) -> None:
+        nonlocal pt, ct, tt, cache_read, cache_creation
+        apt, act, att = _usage_of(result)
+        pt, ct, tt = _add_tokens(pt, apt), _add_tokens(ct, act), _add_tokens(tt, att)
+        rcr, rcc = _cache_usage_of(result)
+        cache_read = _add_tokens(cache_read, rcr)
+        cache_creation = _add_tokens(cache_creation, rcc)
+
+    def _parse(result: Any, *, expect_json: bool) -> tuple[Any, int]:
+        parsed, calls = (
+            parse_responses_reply(result, expect_json=expect_json)
+            if is_responses_result(result)
+            else _parse_completion_reply(result, expect_json=expect_json)
+        )
+        return _restore_tool_calls(parsed), calls
+
+    def _skill_requests(parsed: Any) -> list[tuple[Any, Any]]:
+        if not isinstance(parsed, dict):
+            return []
+        calls = parsed.get("tool_calls")
+        if not isinstance(calls, list):
+            return []
+        return [
+            (call.get("id"), (call.get("input") or {}).get("name"))
+            for call in calls
+            if isinstance(call, dict) and call.get("tool") == SKILL_TOOL
+        ]
+
+    def _drop_skill_calls(parsed: Any) -> tuple[Any, int]:
+        """Skill calls are resolved here and must never reach the agent loop."""
+        if not isinstance(parsed, dict) or not isinstance(parsed.get("tool_calls"), list):
+            return parsed, 0
+        kept = [call for call in parsed["tool_calls"] if call.get("tool") != SKILL_TOOL]
+        if len(kept) == len(parsed["tool_calls"]):
+            return parsed, len(kept)
+        remainder = {key: item for key, item in parsed.items() if key != "tool_calls"}
+        if kept:
+            remainder["tool_calls"] = kept
+        return (remainder or None), len(kept)
+
     completion = await dispatch_once()
-    # Usage accumulates over every attempt — re-asks cost tokens too.
-    pt, ct, tt = _usage_of(completion)
-    cache_read, cache_creation = _cache_usage_of(completion)
-    reply, native_tool_calls = (
-        parse_responses_reply(completion, expect_json=schema is not None)
-        if is_responses_result(completion)
-        else _parse_completion_reply(completion, expect_json=schema is not None)
-    )
-    reply = _restore_tool_calls(reply)
+    _accumulate(completion)
+    reply, native_tool_calls = _parse(completion, expect_json=schema is not None)
+
+    # Progressive skill disclosure: resolve __load_skill__ from the frozen skill
+    # set and re-ask, inside this one call. The IR never sees these rounds, so a
+    # think leaf stays a think leaf and max_rounds keeps counting task progress.
+    while skill_tool_open:
+        requests = _skill_requests(reply)
+        if not requests:
+            skill_tool_open = False
+            break
+        by_name = {skill.name: skill for skill in active_skills}
+        skill_turns.append(
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": call_id,
+                        "type": "function",
+                        "function": {
+                            "name": SKILL_TOOL,
+                            "arguments": json.dumps({"name": name}),
+                        },
+                    }
+                    for call_id, name in requests
+                ],
+            }
+        )
+        for call_id, name in requests:
+            if name in loaded_skills:
+                skill_error_budget -= 1
+                content = f"skill {name!r} was already provided above"
+            elif name not in by_name:
+                skill_error_budget -= 1
+                content = (
+                    f"unknown skill {name!r}; available skills are: "
+                    + ", ".join(sorted(by_name))
+                )
+            else:
+                loaded_skills.append(str(name))
+                content = by_name[name].body
+            skill_turns.append(
+                {"role": "tool", "tool_call_id": call_id, "content": content}
+            )
+        if len(loaded_skills) >= len(active_skills) or skill_error_budget <= 0:
+            skill_tool_open = False
+        completion = await dispatch_once()
+        _accumulate(completion)
+        reply, native_tool_calls = _parse(completion, expect_json=schema is not None)
+
+    reply, native_tool_calls = _drop_skill_calls(reply)
+
     validation_error = _final_output_schema_error(reply, native_tool_calls)
     while schema is not None and validation_error is not None and retries_used < reasoner.output_retries:
         retries_used += 1
@@ -765,17 +889,9 @@ async def complete_reasoner(
                 "the corrected JSON object."
             )
         )
-        apt, act, att = _usage_of(completion)
-        pt, ct, tt = _add_tokens(pt, apt), _add_tokens(ct, act), _add_tokens(tt, att)
-        rcr, rcc = _cache_usage_of(completion)
-        cache_read = _add_tokens(cache_read, rcr)
-        cache_creation = _add_tokens(cache_creation, rcc)
-        reply, native_tool_calls = (
-            parse_responses_reply(completion, expect_json=True)
-            if is_responses_result(completion)
-            else _parse_completion_reply(completion, expect_json=True)
-        )
-        reply = _restore_tool_calls(reply)
+        _accumulate(completion)
+        reply, native_tool_calls = _parse(completion, expect_json=True)
+        reply, native_tool_calls = _drop_skill_calls(reply)
         validation_error = _final_output_schema_error(reply, native_tool_calls)
     ended = time.time()
     pc = reasoner.prompt_cache
@@ -802,6 +918,7 @@ async def complete_reasoner(
         response_format_fallback=fallback_reason,
         output_retries_used=retries_used,
         native_tool_calls=native_tool_calls,
+        skill_loads=tuple(loaded_skills),
         prompt_cache_requested=pc_requested,
         prompt_cache_applied=pc_applied,
         prompt_cache_reason=pc_reason,

--- a/julep/execution/llm_result.py
+++ b/julep/execution/llm_result.py
@@ -34,6 +34,7 @@ class LlmCallMeta:
     response_format_fallback: str | None = None
     output_retries_used: int = 0
     native_tool_calls: int = 0
+    skill_loads: tuple[str, ...] = ()
     prompt_cache_requested: str | None = None
     prompt_cache_applied: bool | None = None
     prompt_cache_reason: str | None = None
@@ -60,6 +61,8 @@ class LlmCallMeta:
             out["llm.output_retries"] = self.output_retries_used
         if self.native_tool_calls:
             out["llm.tool_calls"] = self.native_tool_calls
+        if self.skill_loads:
+            out["llm.skill_loads"] = list(self.skill_loads)
         cache: dict[str, Any] = {}
         if self.prompt_cache_requested is not None:
             cache["requested"] = self.prompt_cache_requested

--- a/julep/execution/llm_result.py
+++ b/julep/execution/llm_result.py
@@ -7,9 +7,26 @@ vendor-neutral dict that rides the existing ``Result.attrs`` ->
 ``ProjectionEvent.attrs`` seam; the Langfuse exporter maps it to gen_ai/langfuse
 attributes downstream. Pure module: no IO, no engine imports.
 """
+
 from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
+
+
+LlmCostStatus = Literal["reported", "derived", "unknown"]
+
+
+@dataclass(frozen=True)
+class LlmUsage:
+    """Provider-neutral token usage for one or more model calls."""
+
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    total_tokens: int | None = None
+    cache_read_tokens: int | None = None
+    cache_creation_tokens: int | None = None
+
 
 @dataclass(frozen=True)
 class AttemptMeta:
@@ -19,6 +36,7 @@ class AttemptMeta:
     input_tokens: int | None = None
     output_tokens: int | None = None
     ms: float | None = None
+
 
 @dataclass(frozen=True)
 class LlmCallMeta:
@@ -40,14 +58,39 @@ class LlmCallMeta:
     prompt_cache_reason: str | None = None
     cache_read_tokens: int | None = None
     cache_creation_tokens: int | None = None
+    # Additive typed view. The scalar fields above remain for source and
+    # constructor compatibility with callers built against rc5/early rc6.
+    usage: LlmUsage | None = None
+    cost_status: LlmCostStatus | None = None
+
+    def resolved_usage(self) -> LlmUsage:
+        """Return the typed usage, including legacy scalar metadata."""
+
+        if self.usage is not None:
+            return self.usage
+        return LlmUsage(
+            prompt_tokens=self.input_tokens,
+            completion_tokens=self.output_tokens,
+            total_tokens=self.total_tokens,
+            cache_read_tokens=self.cache_read_tokens,
+            cache_creation_tokens=self.cache_creation_tokens,
+        )
+
+    def resolved_cost_status(self) -> LlmCostStatus:
+        """Infer the pre-status contract for backwards-compatible callers."""
+
+        if self.cost_status is not None:
+            return self.cost_status
+        return "reported" if self.cost is not None else "unknown"
 
     def to_attrs(self) -> dict[str, Any]:
         out: dict[str, Any] = {"llm.model": self.served_model, "llm.provider": self.provider}
-        if self.input_tokens is not None or self.output_tokens is not None:
+        usage = self.resolved_usage()
+        if usage.prompt_tokens is not None or usage.completion_tokens is not None:
             out["llm.usage"] = {
-                "input": self.input_tokens,
-                "output": self.output_tokens,
-                "total": self.total_tokens,
+                "input": usage.prompt_tokens,
+                "output": usage.completion_tokens,
+                "total": usage.total_tokens,
             }
         if self.started_at is not None:
             out["llm.started_at"] = self.started_at
@@ -55,6 +98,7 @@ class LlmCallMeta:
             out["llm.ended_at"] = self.ended_at
         if self.cost is not None:
             out["llm.cost"] = self.cost
+        out["llm.cost.status"] = self.resolved_cost_status()
         if self.response_format_fallback is not None:
             out["llm.response_format_fallback"] = self.response_format_fallback
         if self.output_retries_used:
@@ -70,19 +114,26 @@ class LlmCallMeta:
             cache["applied"] = self.prompt_cache_applied
         if self.prompt_cache_reason is not None:
             cache["reason"] = self.prompt_cache_reason
-        if self.cache_read_tokens is not None:
-            cache["read"] = self.cache_read_tokens
-        if self.cache_creation_tokens is not None:
-            cache["creation"] = self.cache_creation_tokens
+        if usage.cache_read_tokens is not None:
+            cache["read"] = usage.cache_read_tokens
+        if usage.cache_creation_tokens is not None:
+            cache["creation"] = usage.cache_creation_tokens
         if cache:
             out["llm.cache"] = cache
         if self.attempts:
             out["llm.attempts"] = [
-                {"model": a.model, "provider": a.provider, "outcome": a.outcome,
-                 "input": a.input_tokens, "output": a.output_tokens, "ms": a.ms}
+                {
+                    "model": a.model,
+                    "provider": a.provider,
+                    "outcome": a.outcome,
+                    "input": a.input_tokens,
+                    "output": a.output_tokens,
+                    "ms": a.ms,
+                }
                 for a in self.attempts
             ]
         return out
+
 
 @dataclass(frozen=True)
 class LlmResult:

--- a/julep/execution/openai_batch.py
+++ b/julep/execution/openai_batch.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass
 from typing import Any
 
 from ..prompt import rendered_user_for
+from ..registry import DEFAULT_REGISTRY
+from ..skills import batch_system_text
 from .batch_provider import (
     BatchProvider,
     BatchReply,
@@ -58,7 +60,9 @@ class OpenAIBatchProvider(BatchProvider):
         body: dict[str, Any] = {
             "model": model,
             "messages": _messages(
-                reasoner.system,
+                batch_system_text(
+                    reasoner.system, reasoner.skills, registry=DEFAULT_REGISTRY
+                ),
                 value,
                 schema_hint=None,
                 user_text=user_text,

--- a/julep/execution/serve.py
+++ b/julep/execution/serve.py
@@ -117,12 +117,20 @@ def _env_float(env: Mapping[str, str], name: str, default: float) -> float:
 
 def payload_encryption_from_env(
     env: Mapping[str, str],
+    *,
+    default_required: bool = False,
 ) -> tuple[Optional[str], Optional[str], bool]:
     """Parse the shared Temporal payload-encryption environment contract.
 
     Every client and worker entrypoint uses this helper so an explicit
     ``TEMPORAL_PAYLOAD_ENCRYPTION_REQUIRED=true`` can never silently fall back
     to Temporal's plaintext data converter.
+
+    ``default_required`` is what an unset ``TEMPORAL_PAYLOAD_ENCRYPTION_REQUIRED``
+    means for the calling entrypoint. Processes that *serve* the durable plane —
+    the control plane (``ServerSettings``) and the worker
+    (:meth:`WorkerServeSettings.from_env`) — pass ``True`` so they fail closed;
+    ad-hoc client connections keep the permissive default.
     """
 
     payload_keys = env.get("TEMPORAL_PAYLOAD_KEYS") or None
@@ -134,7 +142,7 @@ def payload_encryption_from_env(
     required = _env_bool(
         env,
         "TEMPORAL_PAYLOAD_ENCRYPTION_REQUIRED",
-        default=False,
+        default=default_required,
     )
     if required and payload_keys is None:
         raise ValueError(
@@ -155,6 +163,11 @@ class WorkerServeSettings:
     are verified and registered into its context before polling. ``tls``
     defaults to True exactly when ``api_key`` is set (Temporal Cloud);
     self-hosted plaintext stays the default otherwise.
+
+    ``payload_encryption_required`` defaults to True, matching
+    :class:`~julep.server.settings.ServerSettings`: a worker joins the same
+    durable plane the control plane encrypts, so it fails closed unless the
+    operator sets ``TEMPORAL_PAYLOAD_ENCRYPTION_REQUIRED=false``.
     """
 
     context_factory: str
@@ -171,7 +184,7 @@ class WorkerServeSettings:
     use_worker_versioning: bool = False
     payload_keys: Optional[str] = field(default=None, repr=False)
     payload_key_id: Optional[str] = None
-    payload_encryption_required: bool = False
+    payload_encryption_required: bool = True
     application: Optional[str] = None
     runtime_declarations_hash: Optional[str] = None
     redaction: Optional[RedactionConfig] = None
@@ -241,7 +254,7 @@ class WorkerServeSettings:
             payload_keys,
             payload_key_id,
             payload_encryption_required,
-        ) = payload_encryption_from_env(payload_environment)
+        ) = payload_encryption_from_env(payload_environment, default_required=True)
         return cls(
             context_factory=factory,
             application=application,
@@ -528,6 +541,15 @@ async def serve(
             )
             connect_kwargs["header_codec_behavior"] = HeaderCodecBehavior.CODEC
             connect_kwargs["interceptors"] = [WorkflowTraceHeadersInterceptor()]
+        elif settings.payload_encryption_required:
+            # AIDEV-NOTE: mirrors create_temporal_gateway in julep/server/temporal.py.
+            # from_env already rejects this combination, so this catches settings
+            # assembled in code — without it a required-but-keyless worker would
+            # silently poll a plaintext converter.
+            raise JulepError(
+                "Temporal payload encryption is required but payload keys are "
+                "not configured"
+            )
         client = await Client.connect(settings.address, **connect_kwargs)
         if verify_connection:
             healthy = await client.service_client.check_health(

--- a/julep/llm.py
+++ b/julep/llm.py
@@ -20,6 +20,7 @@ from .execution.llm import complete_reasoner
 from .execution.llm_result import AttemptMeta, LlmResult
 from .model_slugs import EFFORT_LEVELS, normalize_model_slug
 from .qos import ReasonerDispatch
+from .registry import DEFAULT_REGISTRY, Registry
 from .resilience import AttemptRecord, ErrorClass, OnAttempt, classify_error
 from .transcript import Transcript
 
@@ -133,6 +134,7 @@ def litellm_caller(
     *,
     request_timeout_s: Optional[float] = None,
     acompletion: Optional[LiteLlmCompletion] = None,
+    registry: Registry = DEFAULT_REGISTRY,
 ) -> LlmCaller:
     """Return Julep's canonical five-argument caller backed by LiteLLM.
 
@@ -195,6 +197,7 @@ def litellm_caller(
             dispatch=dispatch,
             tools=tools,
             parallel_tool_calls=parallel_tool_calls,
+            registry=registry,
         )
 
     return caller

--- a/julep/llm.py
+++ b/julep/llm.py
@@ -140,13 +140,25 @@ def _finite_cost(value: Any) -> Optional[float]:
 
 
 def _litellm_reported_cost(response: Any) -> Optional[float]:
-    """Read prices LiteLLM/provider code attached to the response."""
+    """Read a price explicitly marked as coming from the provider."""
+
+    hidden = getattr(response, "_hidden_params", None)
+    if not isinstance(hidden, Mapping):
+        return None
+    headers = hidden.get("additional_headers")
+    if not isinstance(headers, Mapping):
+        return None
+    return _finite_cost(headers.get("llm_provider-x-litellm-response-cost"))
+
+
+def _litellm_attached_cost(response: Any) -> Optional[float]:
+    """Read an ambiguous price attached by LiteLLM or provider translation."""
 
     usage = getattr(response, "usage", None)
     usage_cost = usage.get("cost") if isinstance(usage, Mapping) else getattr(usage, "cost", None)
-    reported = _finite_cost(usage_cost)
-    if reported is not None:
-        return reported
+    attached = _finite_cost(usage_cost)
+    if attached is not None:
+        return attached
 
     hidden = getattr(response, "_hidden_params", None)
     if isinstance(hidden, Mapping):
@@ -166,6 +178,10 @@ def _litellm_cost_resolver(
         return reported, "reported"
     if not derive_cost:
         return None, "unknown"
+
+    attached = _litellm_attached_cost(response)
+    if attached is not None:
+        return attached, "derived"
 
     calculator = cost_calculator
     if calculator is None:
@@ -382,6 +398,7 @@ def with_model_ladder(
             raise exhausted from last_exc
         raise exhausted
 
+    wrapped.__julep_on_attempt__ = on_attempt  # type: ignore[attr-defined]
     return wrapped
 
 

--- a/julep/llm.py
+++ b/julep/llm.py
@@ -9,6 +9,7 @@ caller.  Imports of LiteLLM remain lazy so the core package stays lightweight.
 from __future__ import annotations
 
 import dataclasses
+import math
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from importlib import import_module
 from typing import Any, Optional, cast
@@ -17,7 +18,7 @@ from .dotctx import Reasoner
 from .errors import ResilienceExhausted
 from .execution.effects import LlmCaller, RunPrincipal
 from .execution.llm import complete_reasoner
-from .execution.llm_result import AttemptMeta, LlmResult
+from .execution.llm_result import AttemptMeta, LlmCostStatus, LlmResult
 from .model_slugs import EFFORT_LEVELS, normalize_model_slug
 from .qos import ReasonerDispatch
 from .registry import DEFAULT_REGISTRY, Registry
@@ -25,6 +26,7 @@ from .resilience import AttemptRecord, ErrorClass, OnAttempt, classify_error
 from .transcript import Transcript
 
 LiteLlmCompletion = Callable[..., Awaitable[Any]]
+LiteLlmCostCalculator = Callable[..., float]
 
 _DEFAULT_DISPATCH = ReasonerDispatch()
 _ANTHROPIC_THINKING_BUDGETS: Mapping[str, int] = {
@@ -130,10 +132,67 @@ def prepare_litellm_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
     return prepared
 
 
+def _finite_cost(value: Any) -> Optional[float]:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    cost = float(value)
+    return cost if math.isfinite(cost) and cost >= 0 else None
+
+
+def _litellm_reported_cost(response: Any) -> Optional[float]:
+    """Read prices LiteLLM/provider code attached to the response."""
+
+    usage = getattr(response, "usage", None)
+    usage_cost = usage.get("cost") if isinstance(usage, Mapping) else getattr(usage, "cost", None)
+    reported = _finite_cost(usage_cost)
+    if reported is not None:
+        return reported
+
+    hidden = getattr(response, "_hidden_params", None)
+    if isinstance(hidden, Mapping):
+        return _finite_cost(hidden.get("response_cost"))
+    return None
+
+
+def _litellm_cost_resolver(
+    response: Any,
+    *,
+    model: str,
+    derive_cost: bool,
+    cost_calculator: Optional[LiteLlmCostCalculator],
+) -> tuple[Optional[float], LlmCostStatus]:
+    reported = _litellm_reported_cost(response)
+    if reported is not None:
+        return reported, "reported"
+    if not derive_cost:
+        return None, "unknown"
+
+    calculator = cost_calculator
+    if calculator is None:
+        try:
+            litellm = import_module("litellm")
+            calculator = cast(
+                LiteLlmCostCalculator,
+                vars(litellm)["completion_cost"],
+            )
+        except (ImportError, KeyError):
+            return None, "unknown"
+    try:
+        derived = calculator(completion_response=response, model=model)
+    except Exception:
+        # A pricing map miss must not turn a successful generation into a
+        # failed run. It is observable as unknown instead.
+        return None, "unknown"
+    cost = _finite_cost(derived)
+    return (cost, "derived") if cost is not None else (None, "unknown")
+
+
 def litellm_caller(
     *,
     request_timeout_s: Optional[float] = None,
     acompletion: Optional[LiteLlmCompletion] = None,
+    derive_cost: bool = True,
+    cost_calculator: Optional[LiteLlmCostCalculator] = None,
     registry: Registry = DEFAULT_REGISTRY,
 ) -> LlmCaller:
     """Return Julep's canonical five-argument caller backed by LiteLLM.
@@ -189,6 +248,18 @@ def litellm_caller(
                 parsed_model.reasoning_effort or reasoner.reasoning_effort
             ),
         )
+        pricing_model = _normalize_litellm_model(normalized_reasoner.model)
+
+        def resolve_cost(response: Any) -> tuple[Optional[float], LlmCostStatus]:
+            return _litellm_cost_resolver(
+                response,
+                model=(
+                    pricing_model if isinstance(pricing_model, str) else normalized_reasoner.model
+                ),
+                derive_cost=derive_cost,
+                cost_calculator=cost_calculator,
+            )
+
         return await complete_reasoner(
             normalized_reasoner,
             value,
@@ -198,6 +269,7 @@ def litellm_caller(
             tools=tools,
             parallel_tool_calls=parallel_tool_calls,
             registry=registry,
+            cost_resolver=resolve_cost,
         )
 
     return caller
@@ -315,6 +387,7 @@ def with_model_ladder(
 
 __all__ = [
     "LiteLlmCompletion",
+    "LiteLlmCostCalculator",
     "litellm_caller",
     "prepare_litellm_payload",
     "with_model_ladder",

--- a/julep/local.py
+++ b/julep/local.py
@@ -15,11 +15,12 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Mapping, Optional, cast
 
-from .app import Application, CompiledPipeline
+from .app import Application, CompiledPipeline, PipelineSpec
 from .dotctx import Reasoner
 from .errors import JulepError
 from .execution.effects import LlmCaller, RunPrincipal, WorkerContext
 from .execution.llm_result import LlmResult
+from .projection import InMemoryProjection, ProjectionSink
 from .ir import (
     EMIT_TOOL,
     HUMAN_GATE_TOOL,
@@ -74,6 +75,15 @@ ReasonerHandler = Callable[[Any], Awaitable[Any]]
 
 
 @dataclass(frozen=True)
+class EmbeddedRun:
+    """One embedded execution: its value, exact projection, and artifact identity."""
+
+    value: Any
+    projection: InMemoryProjection
+    artifact_hash: str
+
+
+@dataclass(frozen=True)
 class LocalPipeline:
     """One compiled configured pipeline reusable across foreground calls."""
 
@@ -81,6 +91,7 @@ class LocalPipeline:
     environment: str
     compiled: CompiledPipeline[Any, Any]
     reasoners: Mapping[str, Reasoner]
+    configured_llm: Optional[LlmCaller] = None
 
     @property
     def artifact_hash(self) -> str:
@@ -95,15 +106,38 @@ class LocalPipeline:
         llm: Optional[LlmCaller] = None,
         context: Optional[WorkerContext] = None,
         principal: Optional[RunPrincipal] = None,
+        sink: Optional[ProjectionSink] = None,
     ) -> Any:
         """Execute in-process and return the interpreter's unwrapped value."""
 
-        worker = context or WorkerContext()
-        caller = llm or worker.llm
+        return (await self.arun_detailed(
+            input, llm=llm, context=context, principal=principal, sink=sink
+        )).value
+
+    async def arun_detailed(
+        self,
+        input: Any = None,
+        *,
+        llm: Optional[LlmCaller] = None,
+        context: Optional[WorkerContext] = None,
+        principal: Optional[RunPrincipal] = None,
+        sink: Optional[ProjectionSink] = None,
+        projection: Optional[InMemoryProjection] = None,
+    ) -> EmbeddedRun:
+        """Execute in-process and return its value, projection, and artifact hash.
+
+        Pass a caller-owned ``projection`` to retain failure events when execution
+        raises. A synchronous ``sink`` receives live events and fails loudly.
+        """
+
+        worker = context if context is not None else WorkerContext()
+        caller = llm if llm is not None else worker.llm
+        if caller is None:
+            caller = self.configured_llm
         if self.reasoners and caller is None:
             raise LocalExecutionConfigurationError(
                 f"pipeline {self.name!r} invokes a reasoner; pass llm= or "
-                "WorkerContext(llm=...)"
+                "WorkerContext(llm=...), or configure [tool.julep] llm_caller"
             )
 
         deployment = self.compiled.deployment
@@ -139,6 +173,7 @@ class LocalPipeline:
             else replace(deployment, _tools=())
         )
         policy = self.compiled.spec.execution_policy
+        run_projection = projection if projection is not None else InMemoryProjection()
         result = await local_deployment.adry_run(
             input,
             mcp_call=worker.mcp_call,
@@ -146,8 +181,10 @@ class LocalPipeline:
             principal=principal,
             registry=worker.registry,
             max_parallel=None if policy is None else policy.max_parallel,
+            projection=run_projection,
+            sink=sink,
         )
-        return result.value
+        return EmbeddedRun(result.value, run_projection, self.artifact_hash)
 
     def run(
         self,
@@ -156,6 +193,7 @@ class LocalPipeline:
         llm: Optional[LlmCaller] = None,
         context: Optional[WorkerContext] = None,
         principal: Optional[RunPrincipal] = None,
+        sink: Optional[ProjectionSink] = None,
     ) -> Any:
         """Synchronous foreground execution; use :meth:`arun` in an event loop."""
 
@@ -169,8 +207,33 @@ class LocalPipeline:
                 "await LocalPipeline.arun() instead"
             )
         return asyncio.run(
-            self.arun(input, llm=llm, context=context, principal=principal)
+            self.arun(input, llm=llm, context=context, principal=principal, sink=sink)
         )
+
+    def run_detailed(
+        self,
+        input: Any = None,
+        *,
+        llm: Optional[LlmCaller] = None,
+        context: Optional[WorkerContext] = None,
+        principal: Optional[RunPrincipal] = None,
+        sink: Optional[ProjectionSink] = None,
+        projection: Optional[InMemoryProjection] = None,
+    ) -> EmbeddedRun:
+        """Synchronous mirror of :meth:`arun_detailed`."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+        else:
+            raise LocalExecutionConfigurationError(
+                "LocalPipeline.run_detailed() cannot run inside an active event loop; "
+                "await LocalPipeline.arun_detailed() instead"
+            )
+        return asyncio.run(self.arun_detailed(
+            input, llm=llm, context=context, principal=principal,
+            sink=sink, projection=projection,
+        ))
 
 
 def prepare_local_pipeline(
@@ -201,17 +264,37 @@ def prepare_local_pipeline(
     # Compile only the selected pipeline.  This preserves its normal application
     # compilation gates while keeping unrelated MCP surfaces off the foreground
     # startup path.
-    selected = Application(application.name, (matches[0],))
-    compiled_application = selected.compile_live(
-        env_vars={**env_config.vars, **env_config.worker_environment}
+    configured_llm = None
+    if cfg.llm_caller is not None:
+        from ._specload import resolve_spec
+
+        configured_llm = cast(LlmCaller, resolve_spec(cfg.llm_caller, what="llm caller"))
+    return _local_pipeline_from_spec(
+        matches[0], application_name=application.name, environment=env,
+        env_vars={**env_config.vars, **env_config.worker_environment},
+        configured_llm=configured_llm,
     )
+
+
+def _local_pipeline_from_spec(
+    spec: PipelineSpec[Any, Any],
+    *,
+    application_name: str,
+    environment: str,
+    env_vars: Mapping[str, str],
+    configured_llm: Optional[LlmCaller] = None,
+) -> LocalPipeline:
+    """Compile one selected spec into the shared embedded execution surface."""
+    selected = Application(application_name, (spec,))
+    compiled_application = selected.compile_live(env_vars=env_vars)
     compiled = compiled_application.pipelines[0]
     reasoners = _resolve_pipeline_reasoners(compiled)
     return LocalPipeline(
-        name=pipeline,
-        environment=env,
+        name=spec.name,
+        environment=environment,
         compiled=compiled,
         reasoners=MappingProxyType(dict(reasoners)),
+        configured_llm=configured_llm,
     )
 
 
@@ -472,6 +555,7 @@ __all__ = [
     "LocalPipeline",
     "LocalPipelineError",
     "LocalPipelineNotFound",
+    "EmbeddedRun",
     "arun_local_pipeline",
     "prepare_local_pipeline",
     "run_local_pipeline",

--- a/julep/local.py
+++ b/julep/local.py
@@ -34,9 +34,11 @@ from .ir import (
     ThinkStep,
 )
 from .kinds import ContextScope, Op
+from .model_slugs import normalize_model_slug
 from .prompt import rendered_reasoner_for
 from .qos import QoSTier, ReasonerDispatch
 from .registry import DEFAULT_REGISTRY
+from .resilience import AttemptRecord, classify_error
 
 if TYPE_CHECKING:
     from .cli.config import JulepConfig
@@ -107,11 +109,17 @@ class LocalPipeline:
         context: Optional[WorkerContext] = None,
         principal: Optional[RunPrincipal] = None,
         sink: Optional[ProjectionSink] = None,
+        run_id: Optional[str] = None,
     ) -> Any:
         """Execute in-process and return the interpreter's unwrapped value."""
 
         return (await self.arun_detailed(
-            input, llm=llm, context=context, principal=principal, sink=sink
+            input,
+            llm=llm,
+            context=context,
+            principal=principal,
+            sink=sink,
+            run_id=run_id,
         )).value
 
     async def arun_detailed(
@@ -123,6 +131,7 @@ class LocalPipeline:
         principal: Optional[RunPrincipal] = None,
         sink: Optional[ProjectionSink] = None,
         projection: Optional[InMemoryProjection] = None,
+        run_id: Optional[str] = None,
     ) -> EmbeddedRun:
         """Execute in-process and return its value, projection, and artifact hash.
 
@@ -183,6 +192,10 @@ class LocalPipeline:
             max_parallel=None if policy is None else policy.max_parallel,
             projection=run_projection,
             sink=sink,
+            run_id=run_id,
+            trajectory_sink=worker.trajectory_sink,
+            trajectory_blob_store=worker.trajectory_blob_store or worker.blob_store,
+            redactor=worker.redactor,
         )
         return EmbeddedRun(result.value, run_projection, self.artifact_hash)
 
@@ -194,6 +207,7 @@ class LocalPipeline:
         context: Optional[WorkerContext] = None,
         principal: Optional[RunPrincipal] = None,
         sink: Optional[ProjectionSink] = None,
+        run_id: Optional[str] = None,
     ) -> Any:
         """Synchronous foreground execution; use :meth:`arun` in an event loop."""
 
@@ -207,7 +221,14 @@ class LocalPipeline:
                 "await LocalPipeline.arun() instead"
             )
         return asyncio.run(
-            self.arun(input, llm=llm, context=context, principal=principal, sink=sink)
+            self.arun(
+                input,
+                llm=llm,
+                context=context,
+                principal=principal,
+                sink=sink,
+                run_id=run_id,
+            )
         )
 
     def run_detailed(
@@ -219,6 +240,7 @@ class LocalPipeline:
         principal: Optional[RunPrincipal] = None,
         sink: Optional[ProjectionSink] = None,
         projection: Optional[InMemoryProjection] = None,
+        run_id: Optional[str] = None,
     ) -> EmbeddedRun:
         """Synchronous mirror of :meth:`arun_detailed`."""
         try:
@@ -232,7 +254,7 @@ class LocalPipeline:
             )
         return asyncio.run(self.arun_detailed(
             input, llm=llm, context=context, principal=principal,
-            sink=sink, projection=projection,
+            sink=sink, projection=projection, run_id=run_id,
         ))
 
 
@@ -308,6 +330,7 @@ async def arun_local_pipeline(
     llm: Optional[LlmCaller] = None,
     context: Optional[WorkerContext] = None,
     principal: Optional[RunPrincipal] = None,
+    run_id: Optional[str] = None,
 ) -> Any:
     """Compile and execute one configured pipeline in the current event loop."""
 
@@ -317,7 +340,9 @@ async def arun_local_pipeline(
         config=config,
         env=env,
     )
-    return await prepared.arun(input, llm=llm, context=context, principal=principal)
+    return await prepared.arun(
+        input, llm=llm, context=context, principal=principal, run_id=run_id
+    )
 
 
 def run_local_pipeline(
@@ -330,6 +355,7 @@ def run_local_pipeline(
     llm: Optional[LlmCaller] = None,
     context: Optional[WorkerContext] = None,
     principal: Optional[RunPrincipal] = None,
+    run_id: Optional[str] = None,
 ) -> Any:
     """Compile and synchronously execute one configured pipeline in-process."""
 
@@ -339,7 +365,9 @@ def run_local_pipeline(
         config=config,
         env=env,
     )
-    return prepared.run(input, llm=llm, context=context, principal=principal)
+    return prepared.run(
+        input, llm=llm, context=context, principal=principal, run_id=run_id
+    )
 
 
 def _resolve_pipeline_reasoners(
@@ -413,6 +441,49 @@ def _assert_foreground_supported(flow: Any) -> None:
             )
 
 
+def _foreground_attempt(
+    reasoner: Reasoner,
+    *,
+    outcome: str,
+    dispatch: ReasonerDispatch,
+    detail: str = "",
+) -> AttemptRecord:
+    normalized = normalize_model_slug(reasoner.model).model
+    provider, separator, _ = normalized.partition(":")
+    return AttemptRecord(
+        model=normalized,
+        provider=provider if separator else "",
+        outcome=outcome,
+        detail=detail,
+        tier=dispatch.qos.value,
+        batch_id=dispatch.batch_id,
+    )
+
+
+def _notify_foreground_attempts(
+    context: WorkerContext,
+    reasoner: Reasoner,
+    raw: Any,
+    dispatch: ReasonerDispatch,
+) -> None:
+    notify = context.on_attempt
+    if notify is None:
+        return
+    if isinstance(raw, LlmResult) and raw.meta.attempts:
+        for attempt in raw.meta.attempts:
+            notify(
+                AttemptRecord(
+                    model=attempt.model,
+                    provider=attempt.provider,
+                    outcome=attempt.outcome,
+                    tier=dispatch.qos.value,
+                    batch_id=dispatch.batch_id,
+                )
+            )
+        return
+    notify(_foreground_attempt(reasoner, outcome="ok", dispatch=dispatch))
+
+
 def _reasoner_handlers(
     flow: Any,
     prepared_reasoners: Mapping[str, Reasoner],
@@ -476,22 +547,35 @@ def _reasoner_handlers(
             )
         rendered = rendered_reasoner_for(reasoner, value)
         dispatch = _foreground_dispatch(rendered, context, principal)
-        if tool_defs:
-            if not _accepts_keyword(caller, "tools"):
-                raise LocalExecutionConfigurationError(
-                    f"pipeline reasoner {name!r} uses native tool calling, but its "
-                    "LlmCaller does not accept the optional tools= keyword extension"
-                )
-            raw = await cast(Any, caller)(
-                rendered,
-                value,
-                principal,
-                None,
-                dispatch,
-                tools=list(tool_defs),
+        if tool_defs and not _accepts_keyword(caller, "tools"):
+            raise LocalExecutionConfigurationError(
+                f"pipeline reasoner {name!r} uses native tool calling, but its "
+                "LlmCaller does not accept the optional tools= keyword extension"
             )
-        else:
-            raw = await caller(rendered, value, principal, None, dispatch)
+        try:
+            if tool_defs:
+                raw = await cast(Any, caller)(
+                    rendered,
+                    value,
+                    principal,
+                    None,
+                    dispatch,
+                    tools=list(tool_defs),
+                )
+            else:
+                raw = await caller(rendered, value, principal, None, dispatch)
+        except Exception as exc:
+            if context.on_attempt is not None:
+                context.on_attempt(
+                    _foreground_attempt(
+                        rendered,
+                        outcome=classify_error(exc).value,
+                        detail=str(exc),
+                        dispatch=dispatch,
+                    )
+                )
+            raise
+        _notify_foreground_attempts(context, rendered, raw, dispatch)
         return _pack_reasoner_result(raw)
 
     handlers: dict[str, ReasonerHandler] = {}

--- a/julep/local.py
+++ b/julep/local.py
@@ -20,8 +20,8 @@ from .app import Application, CompiledPipeline, PipelineSpec
 from .dotctx import Reasoner
 from .errors import JulepError
 from .execution.effects import LlmCaller, RunPrincipal, WorkerContext
-from .execution.llm_result import LlmResult, LlmUsage
-from .projection import EventType, InMemoryProjection, ProjectionSink
+from .execution.llm_result import LlmCallMeta, LlmResult, LlmUsage
+from .projection import InMemoryProjection, ProjectionSink
 from .ir import (
     EMIT_TOOL,
     HUMAN_GATE_TOOL,
@@ -104,20 +104,11 @@ def _price(value: Any) -> Optional[float]:
 
 
 def _embedded_llm_totals(
-    projection: InMemoryProjection,
+    calls: list[LlmCallMeta],
 ) -> tuple[LlmUsage, bool, Optional[float], EmbeddedCostStatus, bool]:
-    """Aggregate only reasoner metadata; projection cost weights stay separate."""
+    """Aggregate model-call metadata observed by one embedded invocation."""
 
-    legs = [
-        event
-        for event in projection.events()
-        if event.type is EventType.DID
-        and any(
-            key in event.attrs
-            for key in ("llm.model", "llm.provider", "llm.usage", "llm.cost.status")
-        )
-    ]
-    if not legs:
+    if not calls:
         return LlmUsage(), False, None, "unknown", False
 
     prompt: list[Optional[int]] = []
@@ -127,27 +118,22 @@ def _embedded_llm_totals(
     cache_creation: list[Optional[int]] = []
     costs: list[Optional[float]] = []
     statuses: list[Literal["reported", "derived", "unknown"]] = []
-    for event in legs:
-        raw_usage = event.attrs.get("llm.usage")
-        usage = raw_usage if isinstance(raw_usage, Mapping) else {}
-        leg_prompt = _token(usage.get("input"))
-        leg_completion = _token(usage.get("output"))
-        leg_total = _token(usage.get("total"))
+    for meta in calls:
+        usage = meta.resolved_usage()
+        leg_prompt = _token(usage.prompt_tokens)
+        leg_completion = _token(usage.completion_tokens)
+        leg_total = _token(usage.total_tokens)
         if leg_total is None and leg_prompt is not None and leg_completion is not None:
             leg_total = leg_prompt + leg_completion
         prompt.append(leg_prompt)
         completion.append(leg_completion)
         total.append(leg_total)
 
-        raw_cache = event.attrs.get("llm.cache")
-        cache = raw_cache if isinstance(raw_cache, Mapping) else {}
-        cache_read.append(_token(cache.get("read")))
-        cache_creation.append(_token(cache.get("creation")))
+        cache_read.append(_token(usage.cache_read_tokens))
+        cache_creation.append(_token(usage.cache_creation_tokens))
 
-        raw_status = event.attrs.get("llm.cost.status")
-        status = raw_status if raw_status in {"reported", "derived", "unknown"} else "unknown"
-        statuses.append(cast(Literal["reported", "derived", "unknown"], status))
-        costs.append(_price(event.attrs.get("llm.cost")))
+        statuses.append(meta.resolved_cost_status())
+        costs.append(_price(meta.cost))
 
     def complete_sum(values: list[Optional[int]]) -> Optional[int]:
         return (
@@ -246,12 +232,14 @@ class LocalPipeline:
         deployment.assert_artifact_integrity()
         _assert_foreground_supported(deployment.flow)
 
+        llm_calls: list[LlmCallMeta] = []
         reasoner_handlers = _reasoner_handlers(
             deployment.flow,
             self.reasoners,
             caller=caller,
             context=worker,
             principal=principal,
+            observed_calls=llm_calls,
         )
         mcp_backed = any(
             isinstance(tool.ref, McpTool) for tool in deployment.manifest.values()
@@ -291,7 +279,7 @@ class LocalPipeline:
             redactor=worker.redactor,
         )
         usage, usage_complete, total_cost, cost_status, cost_complete = _embedded_llm_totals(
-            run_projection
+            llm_calls
         )
         return EmbeddedRun(
             result.value,
@@ -596,11 +584,17 @@ def _reasoner_handlers(
     caller: Optional[LlmCaller],
     context: WorkerContext,
     principal: Optional[RunPrincipal],
+    observed_calls: list[LlmCallMeta],
 ) -> dict[str, ReasonerHandler]:
     if caller is None:
         return {}
 
     reasoners = dict(prepared_reasoners)
+    caller_attempt_sink = getattr(caller, "__julep_on_attempt__", None)
+    caller_owns_attempts = caller_attempt_sink is not None and (
+        caller_attempt_sink is context.on_attempt
+        or caller_attempt_sink == context.on_attempt
+    )
     if context.registry is not None:
         for name, reasoner in reasoners.items():
             override = context.registry.reasoners.get(name)
@@ -670,7 +664,7 @@ def _reasoner_handlers(
             else:
                 raw = await caller(rendered, value, principal, None, dispatch)
         except Exception as exc:
-            if context.on_attempt is not None:
+            if context.on_attempt is not None and not caller_owns_attempts:
                 context.on_attempt(
                     _foreground_attempt(
                         rendered,
@@ -680,7 +674,10 @@ def _reasoner_handlers(
                     )
                 )
             raise
-        _notify_foreground_attempts(context, rendered, raw, dispatch)
+        if isinstance(raw, LlmResult):
+            observed_calls.append(raw.meta)
+        if not caller_owns_attempts:
+            _notify_foreground_attempts(context, rendered, raw, dispatch)
         return _pack_reasoner_result(raw)
 
     handlers: dict[str, ReasonerHandler] = {}

--- a/julep/local.py
+++ b/julep/local.py
@@ -10,17 +10,18 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import math
 from dataclasses import dataclass, replace
 from pathlib import Path
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Mapping, Optional, cast
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Literal, Mapping, Optional, cast
 
 from .app import Application, CompiledPipeline, PipelineSpec
 from .dotctx import Reasoner
 from .errors import JulepError
 from .execution.effects import LlmCaller, RunPrincipal, WorkerContext
-from .execution.llm_result import LlmResult
-from .projection import InMemoryProjection, ProjectionSink
+from .execution.llm_result import LlmResult, LlmUsage
+from .projection import EventType, InMemoryProjection, ProjectionSink
 from .ir import (
     EMIT_TOOL,
     HUMAN_GATE_TOOL,
@@ -72,15 +73,107 @@ class LocalExecutionUnsupported(LocalPipelineError):
 
 
 ReasonerHandler = Callable[[Any], Awaitable[Any]]
+EmbeddedCostStatus = Literal["reported", "derived", "mixed", "unknown"]
 
 
 @dataclass(frozen=True)
 class EmbeddedRun:
-    """One embedded execution: its value, exact projection, and artifact identity."""
+    """One embedded execution with aggregate LLM usage and price metadata."""
 
     value: Any
     projection: InMemoryProjection
     artifact_hash: str
+    usage: LlmUsage = LlmUsage()
+    usage_complete: bool = False
+    total_cost: Optional[float] = None
+    cost_status: EmbeddedCostStatus = "unknown"
+    cost_complete: bool = False
+
+
+def _token(value: Any) -> Optional[int]:
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
+
+
+def _price(value: Any) -> Optional[float]:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    price = float(value)
+    return price if math.isfinite(price) and price >= 0 else None
+
+
+def _embedded_llm_totals(
+    projection: InMemoryProjection,
+) -> tuple[LlmUsage, bool, Optional[float], EmbeddedCostStatus, bool]:
+    """Aggregate only reasoner metadata; projection cost weights stay separate."""
+
+    legs = [
+        event
+        for event in projection.events()
+        if event.type is EventType.DID
+        and any(
+            key in event.attrs
+            for key in ("llm.model", "llm.provider", "llm.usage", "llm.cost.status")
+        )
+    ]
+    if not legs:
+        return LlmUsage(), False, None, "unknown", False
+
+    prompt: list[Optional[int]] = []
+    completion: list[Optional[int]] = []
+    total: list[Optional[int]] = []
+    cache_read: list[Optional[int]] = []
+    cache_creation: list[Optional[int]] = []
+    costs: list[Optional[float]] = []
+    statuses: list[Literal["reported", "derived", "unknown"]] = []
+    for event in legs:
+        raw_usage = event.attrs.get("llm.usage")
+        usage = raw_usage if isinstance(raw_usage, Mapping) else {}
+        leg_prompt = _token(usage.get("input"))
+        leg_completion = _token(usage.get("output"))
+        leg_total = _token(usage.get("total"))
+        if leg_total is None and leg_prompt is not None and leg_completion is not None:
+            leg_total = leg_prompt + leg_completion
+        prompt.append(leg_prompt)
+        completion.append(leg_completion)
+        total.append(leg_total)
+
+        raw_cache = event.attrs.get("llm.cache")
+        cache = raw_cache if isinstance(raw_cache, Mapping) else {}
+        cache_read.append(_token(cache.get("read")))
+        cache_creation.append(_token(cache.get("creation")))
+
+        raw_status = event.attrs.get("llm.cost.status")
+        status = raw_status if raw_status in {"reported", "derived", "unknown"} else "unknown"
+        statuses.append(cast(Literal["reported", "derived", "unknown"], status))
+        costs.append(_price(event.attrs.get("llm.cost")))
+
+    def complete_sum(values: list[Optional[int]]) -> Optional[int]:
+        return (
+            sum(cast(int, value) for value in values)
+            if all(value is not None for value in values)
+            else None
+        )
+
+    aggregate_usage = LlmUsage(
+        prompt_tokens=complete_sum(prompt),
+        completion_tokens=complete_sum(completion),
+        total_tokens=complete_sum(total),
+        cache_read_tokens=complete_sum(cache_read),
+        cache_creation_tokens=complete_sum(cache_creation),
+    )
+    usage_complete = all(
+        value is not None for values in (prompt, completion, total) for value in values
+    )
+    cost_complete = all(
+        status != "unknown" and cost is not None
+        for status, cost in zip(statuses, costs, strict=True)
+    )
+    if len(set(statuses)) == 1:
+        cost_status: EmbeddedCostStatus = statuses[0]
+    else:
+        cost_status = "mixed"
+    total_cost = sum(cast(float, cost) for cost in costs) if cost_complete else None
+    return aggregate_usage, usage_complete, total_cost, cost_status, cost_complete
 
 
 @dataclass(frozen=True)
@@ -184,7 +277,19 @@ class LocalPipeline:
             projection=run_projection,
             sink=sink,
         )
-        return EmbeddedRun(result.value, run_projection, self.artifact_hash)
+        usage, usage_complete, total_cost, cost_status, cost_complete = _embedded_llm_totals(
+            run_projection
+        )
+        return EmbeddedRun(
+            result.value,
+            run_projection,
+            self.artifact_hash,
+            usage=usage,
+            usage_complete=usage_complete,
+            total_cost=total_cost,
+            cost_status=cost_status,
+            cost_complete=cost_complete,
+        )
 
     def run(
         self,

--- a/julep/projection.py
+++ b/julep/projection.py
@@ -158,9 +158,13 @@ class TeeStore:
     def events(self) -> list[ProjectionEvent]:
         return self._primary.events()
 
+    def drop_event(self, event_id: str) -> None:
+        """Delegate cancellation cleanup to the queryable primary store."""
+        self._primary.drop_event(event_id)
+
 
 class InMemoryProjection:
-    """A complete, queryable projection backed by a Python list (tests/dev)."""
+    """A complete, queryable projection backed by an in-memory Python list."""
 
     def __init__(self) -> None:
         self._events: list[ProjectionEvent] = []

--- a/julep/prompt.py
+++ b/julep/prompt.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Optional, Protocol
 
 from .dotctx import Reasoner
-from .registry import DEFAULT_REGISTRY, RendererEntry
+from .registry import DEFAULT_REGISTRY, Registry, RendererEntry
 
 Context = Mapping[str, Any]
 
@@ -62,38 +62,63 @@ def project_context(value: Any) -> dict[str, Any]:
     return projected
 
 
-def render_system(reasoner: Reasoner, ctx: Context) -> str:
+def render_system(
+    reasoner: Reasoner,
+    ctx: Context,
+    *,
+    registry: Optional[Registry] = None,
+) -> str:
     if reasoner.system_render is not None:
-        return DEFAULT_REGISTRY.get_renderer(reasoner.system_render)(ctx)
+        target = DEFAULT_REGISTRY if registry is None else registry
+        return target.get_renderer(reasoner.system_render)(ctx)
     return reasoner.system
 
 
-def render_user(reasoner: Reasoner, ctx: Context) -> Optional[str]:
+def render_user(
+    reasoner: Reasoner,
+    ctx: Context,
+    *,
+    registry: Optional[Registry] = None,
+) -> Optional[str]:
     """The rendered user turn, or ``None`` when the reasoner names no user renderer
     (callers fall back to the value-as-JSON user turn)."""
     if reasoner.user_render is None:
         return None
-    return DEFAULT_REGISTRY.get_renderer(reasoner.user_render)(ctx)
+    target = DEFAULT_REGISTRY if registry is None else registry
+    return target.get_renderer(reasoner.user_render)(ctx)
 
 
-def rendered_user_for(reasoner: Reasoner, value: Any) -> Optional[str]:
+def rendered_user_for(
+    reasoner: Reasoner,
+    value: Any,
+    *,
+    registry: Optional[Registry] = None,
+) -> Optional[str]:
     if reasoner.user_render is None:
         return None
-    return render_user(reasoner, project_context(value))
+    return render_user(reasoner, project_context(value), registry=registry)
 
 
 def _with_rendered_system(reasoner: Reasoner, system: str) -> Reasoner:
     return reasoner.replace(system=system, system_render=None)
 
 
-def rendered_reasoner_for(reasoner: Reasoner, value: Any) -> Reasoner:
+def rendered_reasoner_for(
+    reasoner: Reasoner,
+    value: Any,
+    *,
+    registry: Optional[Registry] = None,
+) -> Reasoner:
     """The invoke seam: a no-renderer reasoner passes through identically; a
     renderer-bearing reasoner becomes a derived reasoner with the rendered system.
     ``user_render`` rides along — the LLM caller renders the user turn via
     :func:`rendered_user_for` against the same value."""
     if reasoner.system_render is None:
         return reasoner
-    return _with_rendered_system(reasoner, render_system(reasoner, project_context(value)))
+    return _with_rendered_system(
+        reasoner,
+        render_system(reasoner, project_context(value), registry=registry),
+    )
 
 
 @dataclass(frozen=True)

--- a/julep/registry.py
+++ b/julep/registry.py
@@ -576,9 +576,9 @@ class Registry:
         """Register a skill under its content key and return that key.
 
         ``Skill`` equality ignores ``source``, so byte-identical sidecars in
-        different packages register once. A genuine mismatch under one key is
-        impossible (the key hashes every compared field) and is treated as a
-        corrupt-input error rather than silently overwritten.
+        different packages register once. The ``"\0"``-joined hash material is
+        not injective across field boundaries, so distinct skills can rarely
+        share a key; the mismatch guard is a real safety net against overwrite.
         """
         key = skill_key(skill)
         existing = self.skills.get(key)

--- a/julep/registry.py
+++ b/julep/registry.py
@@ -19,6 +19,7 @@ from importlib import metadata
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from .deps import parse_pep723
+from .skills import Skill, skill_key
 
 if TYPE_CHECKING:
     from .dotctx import Reasoner
@@ -312,6 +313,9 @@ class Registry:
         self.pures: dict[str, PureEntry] = {}
         self.renderers: dict[str, RendererEntry] = {}
         self.renderer_declarations: dict[str, RendererDeclaration] = {}
+        # Content-addressed agent skills (skill/<name>@v<hash12>). Keys carry
+        # their own content hash, so sharing them process-wide is safe.
+        self.skills: dict[str, Skill] = {}
         self.tool_expectations: dict[str, ToolSchemaExpectation] = {}
         # Compatibility aliases installed by a scoped dotctx package are kept
         # queryable, but must not constrain unrelated top-level native calls
@@ -567,6 +571,32 @@ class Registry:
             return self.renderers[name].fn
         except KeyError as e:
             raise KeyError(f"unknown renderer {name!r}; register it with @renderer({name!r})") from e
+
+    def register_skill(self, skill: Skill) -> str:
+        """Register a skill under its content key and return that key.
+
+        ``Skill`` equality ignores ``source``, so byte-identical sidecars in
+        different packages register once. A genuine mismatch under one key is
+        impossible (the key hashes every compared field) and is treated as a
+        corrupt-input error rather than silently overwritten.
+        """
+        key = skill_key(skill)
+        existing = self.skills.get(key)
+        if existing is not None and existing != skill:
+            raise ValueError(
+                f"skill key {key!r} already registered with different content"
+            )
+        self.skills[key] = skill
+        return key
+
+    def get_skill(self, key: str) -> Skill:
+        try:
+            return self.skills[key]
+        except KeyError as e:
+            raise KeyError(
+                f"unknown skill {key!r}; load its dotctx package or call "
+                "register_skill()"
+            ) from e
 
     def renderer_source_hash_of(self, name: str) -> str:
         return self.renderers[name].source_hash

--- a/julep/skills.py
+++ b/julep/skills.py
@@ -40,6 +40,7 @@ SKILL_TOOL = "__load_skill__"
 
 _HASH_PREFIX_LEN = 12
 SKILL_KEY_RE = re.compile(r"^skill/(?P<name>[^@]+)@v[0-9a-f]{%d}$" % _HASH_PREFIX_LEN)  # noqa: UP031
+SKILL_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 # Same frontmatter shape mem-mcp's loader and the single-file .ctx format use.
 _FRONTMATTER_RE = re.compile(
@@ -109,6 +110,12 @@ def parse_skill_markdown(text: str, *, origin: str) -> Skill:
     raw_name = frontmatter.get("name")
     if not isinstance(raw_name, str) or not raw_name.strip():
         raise SkillError(f"skill {origin!r} frontmatter needs a non-empty name")
+    name = raw_name.strip()
+    if SKILL_NAME_RE.fullmatch(name) is None:
+        raise SkillError(
+            f"skill {origin!r} has invalid name {name!r}; skill names must match "
+            "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+        )
 
     raw_description = frontmatter.get("description", "")
     description = (
@@ -121,7 +128,7 @@ def parse_skill_markdown(text: str, *, origin: str) -> Skill:
             "cannot be disclosed"
         )
     return Skill(
-        name=raw_name.strip(),
+        name=name,
         description=" ".join(description.split()),
         body=body,
         source=origin,
@@ -304,6 +311,15 @@ def inline_skills_block(skills: Sequence[Skill]) -> str:
     ]
     return "# Available skills\n\nUse these skills when they are relevant.\n\n" + "\n\n".join(
         blocks
+    )
+
+
+def disclosed_skills_block(skills: Sequence[Skill]) -> str:
+    """Loaded skill bodies for a tool-free continuation round."""
+    blocks = [f"## {skill.name}\n\n{skill.body}" for skill in skills]
+    return (
+        "You asked for these skills; here are their full instructions:\n\n"
+        + "\n\n".join(blocks)
     )
 
 

--- a/julep/skills.py
+++ b/julep/skills.py
@@ -178,6 +178,12 @@ def load_package_skills(
     skills_dir = os.path.join(pkg_dir, "skills")
     has_dir = os.path.isdir(skills_dir)
 
+    if os.path.islink(skills_dir):
+        raise SkillError(
+            f"dotctx package {pkg_dir!r} has a symlinked skills/ directory; "
+            "skill content must live inside the package"
+        )
+
     if allowlist is None:
         if has_dir:
             warnings.warn(
@@ -199,6 +205,11 @@ def load_package_skills(
     by_name: dict[str, Skill] = {}
     for entry in sorted(os.listdir(skills_dir)):
         entry_path = os.path.join(skills_dir, entry)
+        if os.path.islink(entry_path):
+            raise SkillError(
+                f"skill directory {entry!r} in {pkg_dir!r} is a symlink; "
+                "skill content must live inside the package"
+            )
         if not os.path.isdir(entry_path):
             raise SkillError(
                 f"{os.path.join('skills', entry)!r} in {pkg_dir!r} is not a skill "
@@ -217,6 +228,11 @@ def load_package_skills(
                 "resources are not supported yet)"
             )
         origin = os.path.join(skills_dir, entry, "SKILL.md")
+        if os.path.islink(origin):
+            raise SkillError(
+                f"SKILL.md for skill {entry!r} in {pkg_dir!r} is a symlink; "
+                "skill content must live inside the package"
+            )
         with open(origin, "r", encoding="utf-8") as fh:
             skill = parse_skill_markdown(fh.read(), origin=origin)
         if skill.name != entry:

--- a/julep/skills.py
+++ b/julep/skills.py
@@ -1,0 +1,352 @@
+"""Agent skills for dotctx packages.
+
+A *skill* is a named block of reusable instructions living beside a dotctx
+package as ``skills/<name>/SKILL.md`` — YAML frontmatter (``name``,
+``description``) followed by a markdown body. A package activates skills by
+name through the ``skills:`` setting; activation is explicit, so a ``skills/``
+directory on its own changes nothing.
+
+Disclosure is progressive. Only each activated skill's *name and description*
+reach the system prompt; the body arrives mid-call when the model asks for it
+through the reserved ``__load_skill__`` tool, which
+:mod:`julep.execution.llm` resolves from the frozen release — never from the
+filesystem, so replay is deterministic.
+
+Skills are content-addressed as ``skill/<name>@v<hash12>`` over
+(name, description, body). Byte-identical copies in different packages
+converge on one registry entry and one copy in the deploy artifact, while an
+edited body yields a different key — and because ``Reasoner.skills`` holds
+those keys, an edited skill moves the reasoner identity exactly the way an
+edited template already does.
+
+This module deliberately imports neither jinja2 nor :class:`~julep.dotctx.Reasoner`:
+skills work in the minimal settings-only layout, without the ``[dotctx]`` extra.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import warnings
+from dataclasses import dataclass, field
+from typing import Any, Optional, Sequence
+
+from .errors import JulepError
+
+# Reserved native tool: the LLM caller resolves a call to this from the frozen
+# skill set and re-asks, rather than surfacing it to the agent loop.
+SKILL_TOOL = "__load_skill__"
+
+_HASH_PREFIX_LEN = 12
+SKILL_KEY_RE = re.compile(r"^skill/(?P<name>[^@]+)@v[0-9a-f]{%d}$" % _HASH_PREFIX_LEN)  # noqa: UP031
+
+# Same frontmatter shape mem-mcp's loader and the single-file .ctx format use.
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)$", re.DOTALL)
+
+
+class SkillError(JulepError):
+    """A skill sidecar or ``skills:`` declaration is malformed."""
+
+
+class InertSkillsDirectoryWarning(UserWarning):
+    """A package ships ``skills/`` but activates nothing."""
+
+
+@dataclass(frozen=True)
+class Skill:
+    """One ``SKILL.md`` sidecar.
+
+    ``source`` is diagnostics only: it is excluded from equality and from the
+    content hash so identical skills in different packages are one skill.
+    """
+
+    name: str
+    description: str
+    body: str
+    source: str = field(default="", compare=False)
+
+
+def skill_key(skill: Skill) -> str:
+    """The content-addressed registry key for ``skill``."""
+    material = "\0".join((skill.name, skill.description, skill.body))
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()
+    return f"skill/{skill.name}@v{digest[:_HASH_PREFIX_LEN]}"
+
+
+def skill_name_of(key: str) -> str:
+    """The declared name inside a registry key, for error messages."""
+    match = SKILL_KEY_RE.match(key)
+    if match is None:
+        raise SkillError(
+            f"malformed skill key {key!r}; expected 'skill/<name>@v<12 hex chars>'"
+        )
+    return match.group("name")
+
+
+def parse_skill_markdown(text: str, *, origin: str) -> Skill:
+    """Parse a ``SKILL.md``: YAML frontmatter then a markdown body."""
+    import yaml
+
+    match = _FRONTMATTER_RE.match(text)
+    if match is None:
+        raise SkillError(
+            f"skill {origin!r} has no YAML frontmatter; a SKILL.md must open with "
+            "'---', a mapping with name/description, then '---'"
+        )
+    try:
+        frontmatter = yaml.safe_load(match.group(1)) or {}
+    except Exception as exc:
+        raise SkillError(f"skill {origin!r} frontmatter is not valid YAML: {exc}") from exc
+    if not isinstance(frontmatter, dict):
+        raise SkillError(f"skill {origin!r} frontmatter must be a YAML mapping")
+
+    raw_name = frontmatter.get("name")
+    if not isinstance(raw_name, str) or not raw_name.strip():
+        raise SkillError(f"skill {origin!r} frontmatter needs a non-empty name")
+
+    raw_description = frontmatter.get("description", "")
+    description = (
+        raw_description if isinstance(raw_description, str) else str(raw_description)
+    )
+    body = match.group(2).strip()
+    if not body:
+        raise SkillError(
+            f"skill {origin!r} has an empty body; a skill with no instructions "
+            "cannot be disclosed"
+        )
+    return Skill(
+        name=raw_name.strip(),
+        description=" ".join(description.split()),
+        body=body,
+        source=origin,
+    )
+
+
+def parse_skills_setting(value: Any, *, origin: str) -> Optional[tuple[str, ...]]:
+    """Normalize the ``skills:`` setting.
+
+    ``None`` means the key is absent (activate nothing); ``()`` means an
+    explicit empty list. Mapping items are rejected by name so per-skill
+    options remain an additive change later.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str) or not isinstance(value, (list, tuple)):
+        raise SkillError(
+            f"settings 'skills' in {origin!r} must be a list of skill names"
+        )
+    names: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item.strip():
+            raise SkillError(
+                f"settings 'skills' in {origin!r} must be a list of skill names; "
+                f"got {item!r} (per-skill option mappings are not supported yet)"
+            )
+        names.append(item.strip())
+    duplicates = sorted({n for n in names if names.count(n) > 1})
+    if duplicates:
+        raise SkillError(
+            f"settings 'skills' in {origin!r} has duplicate entries: "
+            + ", ".join(duplicates)
+        )
+    return tuple(names)
+
+
+def load_package_skills(
+    pkg_dir: str, allowlist: Optional[Sequence[str]]
+) -> tuple[Skill, ...]:
+    """Load the skills a package activates, in declaration order.
+
+    ``allowlist`` is ``None`` when the ``skills:`` key is absent — nothing is
+    activated, and a present-but-inert ``skills/`` directory warns. Every
+    configured name must resolve; a skill directory must hold exactly one
+    ``SKILL.md`` (level-3 bundled resources are not supported yet).
+    """
+    skills_dir = os.path.join(pkg_dir, "skills")
+    has_dir = os.path.isdir(skills_dir)
+
+    if allowlist is None:
+        if has_dir:
+            warnings.warn(
+                f"dotctx package {pkg_dir!r} has a skills/ directory but no "
+                "'skills:' setting, so no skill is active; list the names you "
+                "want to activate",
+                InertSkillsDirectoryWarning,
+                stacklevel=3,
+            )
+        return ()
+    if not allowlist:
+        return ()
+    if not has_dir:
+        raise SkillError(
+            f"dotctx package {pkg_dir!r} activates skills "
+            f"({', '.join(allowlist)}) but has no skills/ directory"
+        )
+
+    by_name: dict[str, Skill] = {}
+    origin_of: dict[str, str] = {}
+    for entry in sorted(os.listdir(skills_dir)):
+        entry_path = os.path.join(skills_dir, entry)
+        if not os.path.isdir(entry_path):
+            raise SkillError(
+                f"{os.path.join('skills', entry)!r} in {pkg_dir!r} is not a skill "
+                "directory; skills/ may contain only <name>/SKILL.md directories"
+            )
+        contents = sorted(os.listdir(entry_path))
+        if contents != ["SKILL.md"]:
+            extra = [name for name in contents if name != "SKILL.md"]
+            if not extra:
+                raise SkillError(
+                    f"skill directory {entry!r} in {pkg_dir!r} has no SKILL.md"
+                )
+            raise SkillError(
+                f"skill directory {entry!r} in {pkg_dir!r} contains unsupported "
+                f"files: {', '.join(extra)}; only SKILL.md is read (bundled skill "
+                "resources are not supported yet)"
+            )
+        origin = os.path.join(skills_dir, entry, "SKILL.md")
+        with open(origin, "r", encoding="utf-8") as fh:
+            skill = parse_skill_markdown(fh.read(), origin=origin)
+        if skill.name != entry:
+            raise SkillError(
+                f"skill directory {entry!r} in {pkg_dir!r} declares name "
+                f"{skill.name!r}; the directory name and the frontmatter name "
+                "must match"
+            )
+        if skill.name in by_name:
+            raise SkillError(
+                f"skill {skill.name!r} is declared twice in {pkg_dir!r}: "
+                f"directory {origin_of[skill.name]!r} and directory {entry!r}"
+            )
+        by_name[skill.name] = skill
+        origin_of[skill.name] = entry
+
+    missing = [name for name in allowlist if name not in by_name]
+    if missing:
+        raise SkillError(
+            f"dotctx package {pkg_dir!r} activates unknown skills: "
+            f"{', '.join(missing)} (available: {', '.join(sorted(by_name)) or 'none'})"
+        )
+    return tuple(by_name[name] for name in allowlist)
+
+
+def register_skill(skill: Skill, *, registry: Any = None) -> str:
+    """Register ``skill`` and return its content-addressed key."""
+    from .registry import DEFAULT_REGISTRY
+
+    target = DEFAULT_REGISTRY if registry is None else registry
+    return target.register_skill(skill)
+
+
+def get_skill(key: str, *, registry: Any = None) -> Skill:
+    """Look up a registered skill by key."""
+    from .registry import DEFAULT_REGISTRY
+
+    target = DEFAULT_REGISTRY if registry is None else registry
+    return target.get_skill(key)
+
+
+def skill_keys(items: Sequence[Any], *, registry: Any = None) -> tuple[str, ...]:
+    """Bridge from authored ``Skill`` objects to ``Reasoner.skills`` keys.
+
+    ``Reasoner`` is a pure value type and never touches the registry, so a
+    code-first caller registers here and passes the returned keys in.
+    """
+    keys: list[str] = []
+    for item in items:
+        if isinstance(item, Skill):
+            keys.append(register_skill(item, registry=registry))
+        elif isinstance(item, str):
+            keys.append(item)
+        else:
+            raise SkillError(
+                f"expected a Skill or a skill key string, got {item!r}"
+            )
+    return tuple(keys)
+
+
+def resolve_skill_keys(keys: Sequence[str], *, registry: Any = None) -> tuple[Skill, ...]:
+    """Look up skill content for a reasoner's keys, in declaration order."""
+    from .registry import DEFAULT_REGISTRY
+
+    target = DEFAULT_REGISTRY if registry is None else registry
+    return tuple(target.get_skill(key) for key in keys)
+
+
+def skills_prompt_block(skills: Sequence[Skill]) -> str:
+    """The always-present metadata block: names and descriptions only.
+
+    This is disclosure level 1. It is a stable prefix, so it sits ahead of the
+    authored system prompt where prompt caching can cover it.
+    """
+    lines = [
+        "# Available skills",
+        "",
+        "Each skill below is a set of instructions you may load when it is "
+        f"relevant to the task. Call the `{SKILL_TOOL}` tool with the skill's "
+        "name to read its full instructions before you act on it. Load a skill "
+        "only when it applies; do not mention this mechanism in your reply.",
+        "",
+    ]
+    for skill in skills:
+        lines.append(f"- **{skill.name}** — {skill.description or '(no description)'}")
+    return "\n".join(lines)
+
+
+def inline_skills_block(skills: Sequence[Skill]) -> str:
+    """Every activated skill in full, for single-shot paths that cannot ask.
+
+    Batch submission has no tool round trip, so disclosure collapses to
+    inlining rather than silently dropping the instructions.
+    """
+    blocks = [
+        f"## {skill.name}\nDescription: {skill.description or '(none)'}\n\n{skill.body}".strip()
+        for skill in skills
+    ]
+    return "# Available skills\n\nUse these skills when they are relevant.\n\n" + "\n\n".join(
+        blocks
+    )
+
+
+def load_skill_tool_def(
+    skills: Sequence[Skill], *, loaded: Sequence[str] = ()
+) -> dict[str, Any]:
+    """The provider tool definition for ``__load_skill__``.
+
+    The enum lists only skills that have not been disclosed yet, so a model
+    cannot spend a round re-reading something already in its context.
+    """
+    remaining = [skill.name for skill in skills if skill.name not in set(loaded)]
+    return {
+        "type": "function",
+        "function": {
+            "name": SKILL_TOOL,
+            "description": (
+                "Load the full instructions for one available skill. Call this "
+                "before acting when a skill applies to the task."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The skill to load.",
+                        "enum": remaining,
+                    }
+                },
+                "required": ["name"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+def batch_system_text(
+    system: str, keys: Sequence[str], *, registry: Any = None
+) -> str:
+    """System text for a single-shot batch request: skills inlined, or unchanged."""
+    if not keys:
+        return system
+    block = inline_skills_block(resolve_skill_keys(keys, registry=registry))
+    return f"{block}\n\n{system}" if system else block

--- a/julep/skills.py
+++ b/julep/skills.py
@@ -42,7 +42,9 @@ _HASH_PREFIX_LEN = 12
 SKILL_KEY_RE = re.compile(r"^skill/(?P<name>[^@]+)@v[0-9a-f]{%d}$" % _HASH_PREFIX_LEN)  # noqa: UP031
 
 # Same frontmatter shape mem-mcp's loader and the single-file .ctx format use.
-_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)$", re.DOTALL)
+_FRONTMATTER_RE = re.compile(
+    r"^---[ \t]*\n(.*?)^---[ \t]*\n(.*)$", re.DOTALL | re.MULTILINE
+)
 
 
 class SkillError(JulepError):
@@ -88,6 +90,9 @@ def parse_skill_markdown(text: str, *, origin: str) -> Skill:
     """Parse a ``SKILL.md``: YAML frontmatter then a markdown body."""
     import yaml
 
+    text = text.removeprefix("\ufeff")
+    # Normalize checkout line endings so Windows and Unix content hashes agree.
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
     match = _FRONTMATTER_RE.match(text)
     if match is None:
         raise SkillError(
@@ -185,7 +190,6 @@ def load_package_skills(
         )
 
     by_name: dict[str, Skill] = {}
-    origin_of: dict[str, str] = {}
     for entry in sorted(os.listdir(skills_dir)):
         entry_path = os.path.join(skills_dir, entry)
         if not os.path.isdir(entry_path):
@@ -214,13 +218,7 @@ def load_package_skills(
                 f"{skill.name!r}; the directory name and the frontmatter name "
                 "must match"
             )
-        if skill.name in by_name:
-            raise SkillError(
-                f"skill {skill.name!r} is declared twice in {pkg_dir!r}: "
-                f"directory {origin_of[skill.name]!r} and directory {entry!r}"
-            )
         by_name[skill.name] = skill
-        origin_of[skill.name] = entry
 
     missing = [name for name in allowlist if name not in by_name]
     if missing:

--- a/julep/trajectory.py
+++ b/julep/trajectory.py
@@ -447,7 +447,7 @@ class ProjectionTrajectorySink:
             if event.type not in (EventType.DID, EventType.FAILED):
                 return
             op = self._node_ops.get(event.node)
-            if op is None or op == "prim":
+            if op is None or (op == "prim" and event.type == EventType.DID):
                 return
             status = "did" if event.type == EventType.DID else "failed"
             error = event.error

--- a/julep/trajectory.py
+++ b/julep/trajectory.py
@@ -431,12 +431,14 @@ class ProjectionTrajectorySink:
         root_run_id: str,
         segment_seq: int,
         node_ops: dict[str, str],
+        redactor: Optional[Redactor] = None,
     ) -> None:
         self._sink = sink
         self._run_id = run_id
         self._root_run_id = root_run_id
         self._segment_seq = segment_seq
         self._node_ops = node_ops
+        self._redactor = redactor
 
     def append(self, event: Any) -> None:
         def _append() -> None:
@@ -448,6 +450,19 @@ class ProjectionTrajectorySink:
             if op is None or op == "prim":
                 return
             status = "did" if event.type == EventType.DID else "failed"
+            error = event.error
+            attrs = dict(event.attrs or {})
+            if self._redactor is not None:
+                # AIDEV-NOTE: foreground structural events share the same
+                # fail-closed persistence boundary as TrajectoryRecorder blobs.
+                redacted_error = redact_for_capture(self._redactor, error)
+                redacted_attrs = redact_for_capture(self._redactor, attrs)
+                error = redacted_error if isinstance(redacted_error, str) else None
+                attrs = (
+                    dict(redacted_attrs)
+                    if isinstance(redacted_attrs, Mapping)
+                    else {}
+                )
             step = TrajectoryStep(
                 step_id=f"{self._run_id}:s{self._segment_seq}:{event.cid}",
                 run_id=self._run_id,
@@ -459,8 +474,8 @@ class ProjectionTrajectorySink:
                 causes=tuple(event.causes),
                 status=status,
                 cost=event.cost,
-                error=event.error,
-                attrs=dict(event.attrs or {}),
+                error=error,
+                attrs=attrs,
             )
             _best_effort(lambda: self._sink.append_steps([step]))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "julep"
-version = "3.0.0rc5"
+version = "3.0.0rc6"
 description = "Julep — durable, composable AI agents on Temporal."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/cli/test_application_cmds.py
+++ b/tests/cli/test_application_cmds.py
@@ -6,6 +6,7 @@ from importlib import import_module
 from pathlib import Path
 from types import SimpleNamespace
 
+import httpx
 import pytest
 import yaml
 
@@ -558,7 +559,7 @@ def _apply_with_activate(
 class _RecordingActivationClient:
     """Control-plane stub that records activations and can fail chosen lanes."""
 
-    def __init__(self, failures: dict[str, JulepClientError] | None = None) -> None:
+    def __init__(self, failures: dict[str, BaseException] | None = None) -> None:
         self.failures = failures or {}
         self.activations: list[tuple[str, str]] = []
         self.published: list[bytes] = []
@@ -626,6 +627,29 @@ def test_apply_activate_reports_partial_failure_and_exits_nonzero(
     assert [lane for lane, _ in client.activations] == ["brief-refresh", "summary"]
     assert "error: lane 'digest' activation failed:" in captured.err
     assert "temporal unreachable" in captured.err
+    assert (
+        "traffic   partial: activated brief-refresh, summary; unchanged digest"
+        in captured.out
+    )
+
+
+def test_apply_activate_continues_after_transport_failure(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    release = _multi_lane_release("brief-refresh", "digest", "summary")
+    client = _RecordingActivationClient(
+        failures={"digest": httpx.ReadTimeout("control plane timed out")}
+    )
+
+    code = _apply_with_activate(monkeypatch, release, client)
+
+    captured = capsys.readouterr()
+    assert code == 1
+    assert [lane for lane, _ in client.activations] == ["brief-refresh", "summary"]
+    assert "error: lane 'digest' activation failed: control plane timed out" in captured.err
     assert (
         "traffic   partial: activated brief-refresh, summary; unchanged digest"
         in captured.out

--- a/tests/cli/test_application_cmds.py
+++ b/tests/cli/test_application_cmds.py
@@ -50,6 +50,31 @@ def _publish_only_release() -> ApplicationRelease:
     )
 
 
+def _multi_lane_release(*lanes: str) -> ApplicationRelease:
+    """A publishable release with one pipeline (and therefore lane) per name."""
+    return ApplicationRelease(
+        application="memory",
+        application_artifact_hash="sha256:" + "a" * 64,
+        worker_image=None,
+        pipelines=tuple(
+            PipelineRelease(
+                name=lane,
+                lane=lane,
+                artifact_hash="sha256:" + "a" * 64,
+                flow_json={"id": "root", "op": "IDENT"},
+                manifest_json={},
+                pinned_pures={},
+                bundle_ref=None,
+                eval_packages=(),
+                max_call_limits={},
+                mcp_preflight_policy="pin",
+            )
+            for lane in lanes
+        ),
+        deployment_config={"queues": {lane: lane for lane in lanes}},
+    )
+
+
 def _scaled_object(release_name: str, task_queue: str) -> dict:
     return {
         "apiVersion": "keda.sh/v1alpha1",
@@ -504,6 +529,195 @@ def test_activate_surfaces_non_admin_403(
     err = capsys.readouterr().err
     assert code == 1
     assert err == "error: lane activation requires an admin API key (403)\n"
+
+
+def _apply_with_activate(
+    monkeypatch,
+    release: ApplicationRelease,
+    client,
+    *,
+    extra_args: tuple[str, ...] = (
+        "--api-url",
+        "http://control-plane",
+        "--api-key",
+        "admin-token",
+    ),
+) -> int:
+    main_module = import_module("julep.cli.main")
+
+    def fake_apply(_cfg, _env, *, publish_only=False, mcp_snapshot=False):
+        return release, ()
+
+    monkeypatch.setattr(main_module, "apply_configured_application", fake_apply)
+    monkeypatch.setattr(main_module, "_remote_client", lambda url, key: client)
+    return main(
+        ["apply", "--env", "local", "--publish-only", "--activate", *extra_args]
+    )
+
+
+class _RecordingActivationClient:
+    """Control-plane stub that records activations and can fail chosen lanes."""
+
+    def __init__(self, failures: dict[str, JulepClientError] | None = None) -> None:
+        self.failures = failures or {}
+        self.activations: list[tuple[str, str]] = []
+        self.published: list[bytes] = []
+        self.closed = 0
+
+    def publish_release(self, manifest_bytes):
+        self.published.append(manifest_bytes)
+        return {"release_hash": "ok"}
+
+    def activate_deployment(self, lane, release):
+        failure = self.failures.get(lane)
+        if failure is not None:
+            raise failure
+        self.activations.append((lane, release))
+        return {"lane": lane, "release_hash": release}
+
+    def close(self):
+        self.closed += 1
+
+
+def test_apply_activate_activates_every_lane_inline(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    release = _multi_lane_release("brief-refresh", "summary")
+    client = _RecordingActivationClient()
+
+    code = _apply_with_activate(monkeypatch, release, client)
+
+    out = capsys.readouterr().out
+    assert code == 0
+    assert client.activations == [
+        ("brief-refresh", release.release_hash),
+        ("summary", release.release_hash),
+    ]
+    # One connection context is reused for registration plus every lane.
+    assert client.published == [release.manifest_bytes]
+    assert f"activated {'brief-refresh':24} {release.release_hash}" in out
+    assert f"activated {'summary':24} {release.release_hash}" in out
+    assert "traffic   activated brief-refresh, summary" in out
+    # The unconditional echo and the per-lane hint are gone once --activate ran.
+    assert "traffic   unchanged" not in out
+    assert "activate  julep activate" not in out
+    assert "admin-token" not in out
+
+
+def test_apply_activate_reports_partial_failure_and_exits_nonzero(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    release = _multi_lane_release("brief-refresh", "digest", "summary")
+    client = _RecordingActivationClient(
+        failures={"digest": JulepClientError(500, "temporal unreachable")}
+    )
+
+    code = _apply_with_activate(monkeypatch, release, client)
+
+    captured = capsys.readouterr()
+    assert code == 1
+    # Every lane is attempted even after one fails.
+    assert [lane for lane, _ in client.activations] == ["brief-refresh", "summary"]
+    assert "error: lane 'digest' activation failed:" in captured.err
+    assert "temporal unreachable" in captured.err
+    assert (
+        "traffic   partial: activated brief-refresh, summary; unchanged digest"
+        in captured.out
+    )
+
+
+def test_apply_activate_explains_server_reconciler_conflict(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    release = _multi_lane_release("summary")
+    client = _RecordingActivationClient(
+        failures={
+            "summary": JulepClientError(
+                409, "worker reconciliation failed: lane reconciler configuration"
+            )
+        }
+    )
+
+    code = _apply_with_activate(monkeypatch, release, client)
+
+    captured = capsys.readouterr()
+    assert code == 1
+    assert "ran its own Helm reconciler" in captured.err
+    assert "byte-identically" in captured.err
+    assert "worker reconciliation failed" in captured.err
+
+
+def test_apply_activate_requires_control_plane_context(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    main_module = import_module("julep.cli.main")
+    called: list[str] = []
+
+    def fake_apply(_cfg, _env, *, publish_only=False, mcp_snapshot=False):
+        called.append("apply")
+        return _multi_lane_release("summary"), ()
+
+    monkeypatch.setattr(main_module, "apply_configured_application", fake_apply)
+
+    code = main(["apply", "--env", "local", "--publish-only", "--activate"])
+
+    captured = capsys.readouterr()
+    assert code == 2
+    # Refused before anything was published.
+    assert called == []
+    assert (
+        "error: --activate unavailable: re-run apply with --api-url/--api-key "
+        "to register this release with the control plane before activating"
+        in captured.err
+    )
+
+
+def test_activate_command_explains_server_reconciler_conflict(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    main_module = import_module("julep.cli.main")
+
+    class FakeClient:
+        def activate_deployment(self, lane, release):
+            raise JulepClientError(409, "worker reconciliation failed: mismatch")
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(main_module, "_remote_client", lambda url, key: FakeClient())
+
+    code = main(
+        [
+            "activate",
+            "--env",
+            "local",
+            "--lane",
+            "summary",
+            "--release",
+            "sha256:" + "a" * 64,
+            "--api-key",
+            "admin-token",
+        ]
+    )
+    err = capsys.readouterr().err
+    assert code == 1
+    assert "ran its own Helm reconciler" in err
+    assert "worker reconciliation failed: mismatch" in err
 
 
 def test_deployment_config_preserves_pinned_oci_chart(

--- a/tests/cli/test_cli_smoke.py
+++ b/tests/cli/test_cli_smoke.py
@@ -57,6 +57,9 @@ def test_worker_smoke_command_uses_environment_contract(monkeypatch):
         captured.append((settings.context_factory, poll_seconds))
 
     monkeypatch.setenv("WORKER_CONTEXT_FACTORY", "memory.worker:context")
+    # A hand-run worker fails closed on payload encryption; this smoke test is
+    # about the environment contract, so take the documented plaintext opt-out.
+    monkeypatch.setenv("TEMPORAL_PAYLOAD_ENCRYPTION_REQUIRED", "false")
     monkeypatch.setattr(serve_module, "smoke_test_worker", fake_smoke)
 
     assert main(["worker", "--smoke-test-seconds", "0.25"]) == 0

--- a/tests/cli/test_queue_lanes.py
+++ b/tests/cli/test_queue_lanes.py
@@ -300,6 +300,9 @@ def test_worker_queue_cli_resolves_lanes_and_raw_strings(
         encoding="utf-8",
     )
     monkeypatch.chdir(tmp_path)
+    # A hand-run worker fails closed on payload encryption; this test is about
+    # queue resolution, so take the documented plaintext opt-out.
+    monkeypatch.setenv("TEMPORAL_PAYLOAD_ENCRYPTION_REQUIRED", "false")
     captured: list[str] = []
 
     async def fake_serve(settings: Any) -> None:
@@ -337,6 +340,9 @@ def test_worker_queue_unknown_env_is_loud(
         encoding="utf-8",
     )
     monkeypatch.chdir(tmp_path)
+    # A hand-run worker fails closed on payload encryption; this test is about
+    # queue resolution, so take the documented plaintext opt-out.
+    monkeypatch.setenv("TEMPORAL_PAYLOAD_ENCRYPTION_REQUIRED", "false")
     captured: list[str] = []
 
     async def fake_serve(settings: Any) -> None:

--- a/tests/cli/test_run_ctx.py
+++ b/tests/cli/test_run_ctx.py
@@ -10,6 +10,7 @@ pytest.importorskip("jinja2")
 
 from julep.cli.ctxrun import run_ctx_local
 from julep.cli.main import main
+from julep.cli.runcache import load_run
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
 
@@ -39,6 +40,11 @@ class _SingleShotFake:
         return _Completion([_Choice(_Message(self.reply))])
 
 
+class _FailingFake:
+    async def __call__(self, **kwargs: Any) -> _Completion:
+        raise RuntimeError("local ctx provider failed")
+
+
 def test_run_ctx_local_returns_stable_artifact_and_reply() -> None:
     path = str(FIXTURES / "summarizer.ctx")
     first = run_ctx_local(path, {"audience": "engineers"}, acompletion=_SingleShotFake("ok"))
@@ -49,9 +55,11 @@ def test_run_ctx_local_returns_stable_artifact_and_reply() -> None:
 
 
 def test_run_ctx_command_prints_stable_artifact(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
         "julep.cli.evalrun._resolve_acompletion", lambda _value: _SingleShotFake("fake reply")
     )
@@ -74,5 +82,48 @@ def test_run_ctx_command_prints_stable_artifact(
     assert first_hash == second_hash
 
 
-def test_run_ctx_missing_path_exits_two(tmp_path: Path) -> None:
+def test_run_ctx_missing_path_exits_two(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
     assert main(["run", str(tmp_path / "missing.ctx")]) == 2
+
+
+def test_run_ctx_command_persists_projection_for_trace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "julep.cli.evalrun._resolve_acompletion",
+        lambda _value: _SingleShotFake('{"summary":"persisted"}'),
+    )
+    ctx = str(FIXTURES / "memmcp" / "episode_summary.ctx")
+
+    assert main(["run", ctx, "--input", '{"content":"hello"}', "--run-id", "ctx-r1"]) == 0
+    cached = load_run(str(tmp_path), "ctx-r1")
+    assert cached is not None
+    assert cached["status"] == "done"
+    assert cached["events"]
+
+    capsys.readouterr()
+    assert main(["trace", "ctx-r1"]) == 0
+    assert capsys.readouterr().out.strip()
+
+
+def test_run_ctx_command_persists_error_status(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "julep.cli.evalrun._resolve_acompletion", lambda _value: _FailingFake()
+    )
+    ctx = str(FIXTURES / "memmcp" / "episode_summary.ctx")
+
+    assert main(["run", ctx, "--run-id", "ctx-failed"]) == 1
+    cached = load_run(str(tmp_path), "ctx-failed")
+    assert cached is not None
+    assert cached["status"] == "error"
+    assert any(event["type"] == "Failed" for event in cached["events"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ _REGISTRY_STATE_ATTRS = (
     "pures",
     "renderers",
     "renderer_declarations",
+    "skills",
     "tool_expectations",
     "scoped_tool_fallbacks",
     "agent_specs",

--- a/tests/fixtures/memmcp/brief_draft.ctx/prompt.j2
+++ b/tests/fixtures/memmcp/brief_draft.ctx/prompt.j2
@@ -1,0 +1,4 @@
+<<< role:system >>>
+You draft a living brief.
+<<< role:user >>>
+Draft the brief for {{ title }}.

--- a/tests/fixtures/memmcp/brief_draft.ctx/schema.pyi
+++ b/tests/fixtures/memmcp/brief_draft.ctx/schema.pyi
@@ -1,0 +1,2 @@
+class Output:
+    draft: str

--- a/tests/fixtures/memmcp/brief_draft.ctx/settings.yaml
+++ b/tests/fixtures/memmcp/brief_draft.ctx/settings.yaml
@@ -1,0 +1,7 @@
+# AI-ANCHOR: prompt: living brief draft agent settings
+model: !? $env.get("LIVING_BRIEF_DRAFT_MODEL", "openai:chat-latest")
+temperature: 1.0
+reasoning_effort: medium
+max_rounds: 2
+output_retries: 1
+skills: [natural-writing]

--- a/tests/fixtures/memmcp/brief_draft.ctx/skills/natural-writing/SKILL.md
+++ b/tests/fixtures/memmcp/brief_draft.ctx/skills/natural-writing/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: natural-writing
+description: >
+  Write like a human, not a language model. Use this skill whenever Claude is
+  producing prose meant to be read by people.
+---
+
+# Natural Writing
+
+LLM text is detectable because it regresses to the mean.
+
+## 1. Cut the Significance Inflation
+
+Do not stuff sentences with claims about how pivotal something is.

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -786,7 +787,11 @@ def test_reconcile_one_helm_release_per_lane(tmp_path) -> None:
     smoke_commands = commands[1::2]
     assert all(command[:3] == ["helm", "upgrade", "--install"] for command in upgrade_commands)
     assert all(command[:2] == ["helm", "test"] for command in smoke_commands)
+    # No `helm test --logs`: Helm 3.21 reports a passing Job as failed when it
+    # cannot find a Pod named exactly like the Job. Logs come from a separate
+    # kubectl fetch, on failure only.
     assert all("--logs" not in command for command in smoke_commands)
+    assert all(command[0] != "kubectl" for command in commands)
     assert any(
         item.startswith("temporal.taskQueue=memory-summary-r")
         for command in upgrade_commands
@@ -919,3 +924,156 @@ def test_helm_environment_preserves_comma_values(tmp_path) -> None:
     assert 'worker.environment={"JULEP_BUNDLE_ALLOWED_SIGNERS":"aa,bb"}' in commands[0]
     assert "payloadEncryption.secretName=temporal-payload-codec" in commands[0]
     assert "worker.priorityClassName=" in commands[0]
+
+
+def _smoke_test_release(tmp_path):
+    """A single-lane release whose reconcile reaches `helm test`."""
+    compiled = Application("memory", [_spec("summary")]).compile()
+    return publish_application(
+        compiled,
+        LocalDirArtifactStore(tmp_path / "artifacts"),
+        worker_image="registry.example/memory@sha256:" + "d" * 64,
+        deployment_config=build_lane_deployment_config(
+            chart="infra/helm/julep-worker",
+            namespace="memory",
+            temporal_address="temporal:7233",
+            temporal_namespace="default",
+            worker_context_factory="memory.worker:context",
+            worker_service_account=None,
+            worker_priority_class=None,
+            payload_encryption_secret="temporal-payload-codec",
+            worker_environment={},
+            worker_secret_environment={},
+            lanes=tuple(compiled.lanes),
+        ),
+        signing_key="0" * 64,
+    )
+
+
+def _smoke_test_reconciler(*, runner, log_runner):
+    return HelmLaneReconciler(
+        chart="infra/helm/julep-worker",
+        namespace="memory",
+        temporal_address="temporal:7233",
+        worker_context_factory="memory.worker:context",
+        payload_encryption_secret="temporal-payload-codec",
+        runner=runner,
+        log_runner=log_runner,
+    )
+
+
+def _failing_smoke_runner(commands: list[list[str]]):
+    def runner(args) -> None:
+        commands.append(list(args))
+        if list(args)[:2] == ["helm", "test"]:
+            raise ApplicationReleaseError("Error: pod worker-smoke failed")
+
+    return runner
+
+
+def test_failed_smoke_test_reports_job_logs_by_label_selector(tmp_path) -> None:
+    release = _smoke_test_release(tmp_path)
+    commands: list[list[str]] = []
+    log_commands: list[list[str]] = []
+
+    def log_runner(args) -> str:
+        log_commands.append(list(args))
+        return "Traceback: WORKER_CONTEXT_FACTORY import failed\n"
+
+    reconciler = _smoke_test_reconciler(
+        runner=_failing_smoke_runner(commands),
+        log_runner=log_runner,
+    )
+
+    with pytest.raises(ApplicationReleaseError) as excinfo:
+        reconcile_application(release, reconciler)
+
+    message = str(excinfo.value)
+    # The original smoke-test failure is still what surfaces...
+    assert "smoke test failed for" in message
+    assert "Error: pod worker-smoke failed" in message
+    # ...with the Job's logs appended.
+    assert "Traceback: WORKER_CONTEXT_FACTORY import failed" in message
+    # Logs are fetched out-of-band, never through `helm test --logs`.
+    assert all("--logs" not in command for command in commands)
+    assert len(log_commands) == 1
+    fetch = log_commands[0]
+    release_name = next(
+        command[3] for command in commands if command[:3] == ["helm", "upgrade", "--install"]
+    )
+    assert fetch[:2] == ["kubectl", "logs"]
+    assert "--selector" in fetch
+    assert fetch[fetch.index("--selector") + 1] == f"job-name={release_name}-smoke"
+    assert fetch[fetch.index("--namespace") + 1] == "memory"
+
+
+def test_passing_smoke_test_never_fetches_logs(tmp_path) -> None:
+    release = _smoke_test_release(tmp_path)
+    commands: list[list[str]] = []
+    log_commands: list[list[str]] = []
+
+    def log_runner(args) -> str:
+        log_commands.append(list(args))
+        return ""
+
+    reconciler = _smoke_test_reconciler(
+        runner=lambda args: commands.append(list(args)),
+        log_runner=log_runner,
+    )
+
+    reconcile_application(release, reconciler)
+
+    assert [command[:2] for command in commands] == [
+        ["helm", "upgrade"],
+        ["helm", "test"],
+    ]
+    assert log_commands == []
+
+
+@pytest.mark.parametrize(
+    ("log_runner", "expected"),
+    [
+        (
+            lambda _args: (_ for _ in ()).throw(FileNotFoundError("kubectl")),
+            "kubectl",
+        ),
+        (lambda _args: "   \n", "no output"),
+    ],
+)
+def test_smoke_test_log_retrieval_failure_does_not_mask_the_failure(
+    tmp_path,
+    log_runner,
+    expected,
+) -> None:
+    release = _smoke_test_release(tmp_path)
+    commands: list[list[str]] = []
+    reconciler = _smoke_test_reconciler(
+        runner=_failing_smoke_runner(commands),
+        log_runner=log_runner,
+    )
+
+    with pytest.raises(ApplicationReleaseError) as excinfo:
+        reconcile_application(release, reconciler)
+
+    message = str(excinfo.value)
+    assert "Error: pod worker-smoke failed" in message
+    assert "smoke-test logs unavailable" in message
+    assert expected in message
+
+
+def test_smoke_test_job_is_retained_for_log_retrieval() -> None:
+    """The chart must not delete the failed Job before its logs are read."""
+    template = (
+        Path(__file__).resolve().parents[1]
+        / "infra"
+        / "helm"
+        / "julep-worker"
+        / "templates"
+        / "smoke-test.yaml"
+    ).read_text()
+
+    assert 'name: {{ .Release.Name }}-smoke' in template
+    assert '"helm.sh/hook-delete-policy": before-hook-creation' in template
+    assert "hook-succeeded" not in template
+    assert "hook-failed" not in template
+    assert "ttlSecondsAfterFinished" not in template

--- a/tests/test_dotctx_agent_rfc.py
+++ b/tests/test_dotctx_agent_rfc.py
@@ -374,7 +374,7 @@ def test_declarations_v2_carries_frozen_agent_and_loads_release_scoped() -> None
     reasoner, frozen = _frozen()
     blob = declarations_blob([reasoner], registry=Registry(), flow=frozen.flow)
     payload = json.loads(blob)
-    assert payload["schemaVersion"] == 2
+    assert payload["schemaVersion"] == 3
     spec = payload["agents"]["bound-agent"]
     assert spec["toolAliases"] == {"search": "tracker/search-posts"}
     assert spec["grantedTools"] == ["search"]

--- a/tests/test_litellm_adapter.py
+++ b/tests/test_litellm_adapter.py
@@ -135,21 +135,51 @@ def test_litellm_caller_captures_usage_and_derives_unreported_cost() -> None:
     }
 
 
-def test_litellm_caller_prefers_reported_cost() -> None:
+@pytest.mark.parametrize("location", ["usage", "hidden"])
+def test_litellm_caller_treats_ambiguous_attached_cost_as_derived(
+    location: str,
+) -> None:
     response = _completion()
-    response._hidden_params = {"response_cost": 0.0042}
+    response._hidden_params = {}
+    if location == "usage":
+        response.usage = SimpleNamespace(cost=0.0042)
+    else:
+        response._hidden_params["response_cost"] = 0.0042
+
+    async def fake_acompletion(**_kwargs: Any) -> Any:
+        return response
+
+    result = run(
+        litellm_caller(
+            acompletion=fake_acompletion,
+        )(Reasoner("summary", "openai:gpt-test"), "hello")
+    )
+
+    assert result.meta.cost == pytest.approx(0.0042)
+    assert result.meta.cost_status == "derived"
+    assert result.meta.to_attrs()["llm.cost.status"] == "derived"
+
+
+def test_litellm_caller_preserves_provider_attested_cost_as_reported() -> None:
+    response = _completion()
+    response._hidden_params = {
+        "additional_headers": {
+            "llm_provider-x-litellm-response-cost": 0.0042,
+        },
+        "response_cost": 0.0099,
+    }
 
     async def fake_acompletion(**_kwargs: Any) -> Any:
         return response
 
     def unexpected_cost(**_kwargs: Any) -> float:
-        raise AssertionError("reported cost must skip derivation")
+        raise AssertionError("provider-attested cost must skip derivation")
 
     result = run(
         litellm_caller(
             acompletion=fake_acompletion,
             cost_calculator=unexpected_cost,
-        )(Reasoner("summary", "openai:gpt-test"), "hello")
+        )(Reasoner("summary", "openrouter:openai/gpt-test"), "hello")
     )
 
     assert result.meta.cost == pytest.approx(0.0042)

--- a/tests/test_litellm_adapter.py
+++ b/tests/test_litellm_adapter.py
@@ -8,7 +8,7 @@ import pytest
 from conftest import run
 from julep.dotctx import Reasoner
 from julep.errors import ResilienceExhausted
-from julep.execution.llm_result import LlmCallMeta, LlmResult
+from julep.execution.llm_result import LlmCallMeta, LlmResult, LlmUsage
 from julep.llm import litellm_caller, prepare_litellm_payload, with_model_ladder
 from julep.qos import ReasonerDispatch
 from julep.resilience import AttemptRecord
@@ -94,6 +94,101 @@ def test_litellm_caller_is_canonical_and_injectable() -> None:
     assert seen["timeout"] == 17.0
     assert seen["tools"] == [{"type": "function", "function": {"name": "lookup"}}]
     assert seen["parallel_tool_calls"] is False
+
+
+def test_litellm_caller_captures_usage_and_derives_unreported_cost() -> None:
+    usage = SimpleNamespace(
+        prompt_tokens=13,
+        completion_tokens=5,
+        total_tokens=18,
+        prompt_tokens_details=SimpleNamespace(
+            cached_tokens=4,
+            cache_creation_tokens=2,
+        ),
+    )
+    response = _completion()
+    response.usage = usage
+    response._hidden_params = {}
+    priced: dict[str, Any] = {}
+
+    async def fake_acompletion(**_kwargs: Any) -> Any:
+        return response
+
+    def fake_cost(**kwargs: Any) -> float:
+        priced.update(kwargs)
+        return 0.0125
+
+    result = run(
+        litellm_caller(
+            acompletion=fake_acompletion,
+            cost_calculator=fake_cost,
+        )(Reasoner("summary", "openai:gpt-test"), "hello")
+    )
+
+    assert result.meta.usage == LlmUsage(13, 5, 18, 4, 2)
+    assert result.meta.cost == pytest.approx(0.0125)
+    assert result.meta.cost_status == "derived"
+    assert result.meta.to_attrs()["llm.cost.status"] == "derived"
+    assert priced == {
+        "completion_response": response,
+        "model": "openai/gpt-test",
+    }
+
+
+def test_litellm_caller_prefers_reported_cost() -> None:
+    response = _completion()
+    response._hidden_params = {"response_cost": 0.0042}
+
+    async def fake_acompletion(**_kwargs: Any) -> Any:
+        return response
+
+    def unexpected_cost(**_kwargs: Any) -> float:
+        raise AssertionError("reported cost must skip derivation")
+
+    result = run(
+        litellm_caller(
+            acompletion=fake_acompletion,
+            cost_calculator=unexpected_cost,
+        )(Reasoner("summary", "openai:gpt-test"), "hello")
+    )
+
+    assert result.meta.cost == pytest.approx(0.0042)
+    assert result.meta.cost_status == "reported"
+    assert result.meta.to_attrs()["llm.cost.status"] == "reported"
+
+
+def test_litellm_caller_unpriced_model_is_unknown_and_derivation_can_be_disabled() -> None:
+    response = _completion()
+    response._hidden_params = {}
+    calls = 0
+
+    async def fake_acompletion(**_kwargs: Any) -> Any:
+        return response
+
+    def unpriced(**_kwargs: Any) -> float:
+        nonlocal calls
+        calls += 1
+        raise KeyError("unknown model")
+
+    unknown = run(
+        litellm_caller(
+            acompletion=fake_acompletion,
+            cost_calculator=unpriced,
+        )(Reasoner("summary", "custom:unpriced"), "hello")
+    )
+    disabled = run(
+        litellm_caller(
+            acompletion=fake_acompletion,
+            derive_cost=False,
+            cost_calculator=unpriced,
+        )(Reasoner("summary", "custom:unpriced"), "hello")
+    )
+
+    assert calls == 1
+    assert unknown.meta.cost is None
+    assert unknown.meta.cost_status == "unknown"
+    assert disabled.meta.cost is None
+    assert disabled.meta.cost_status == "unknown"
 
 
 def test_litellm_caller_normalizes_slash_slug_before_provider_dispatch() -> None:

--- a/tests/test_llm_skills.py
+++ b/tests/test_llm_skills.py
@@ -8,7 +8,9 @@ from typing import Any, Optional
 
 import pytest
 
+from conftest import run
 from julep.dotctx import Reasoner
+from julep.execution.llm import complete_reasoner
 from julep.registry import Registry
 from julep.skills import (
     SKILL_TOOL,
@@ -61,3 +63,256 @@ def test_batch_system_text_inlines_and_preserves_the_system() -> None:
 
 def test_batch_system_text_passes_through_without_skills() -> None:
     assert batch_system_text("You draft.", [], registry=Registry()) == "You draft."
+
+
+@dataclass
+class FakeFunction:
+    name: str
+    arguments: str
+
+
+@dataclass
+class FakeToolCall:
+    id: str
+    function: FakeFunction
+
+
+@dataclass
+class FakeMessage:
+    content: Optional[str] = None
+    parsed: Any = None
+    tool_calls: Optional[list[FakeToolCall]] = None
+
+
+@dataclass
+class FakeChoice:
+    message: FakeMessage
+
+
+@dataclass
+class FakeCompletion:
+    choices: list[FakeChoice]
+    usage: Any = None
+    model: str = "m"
+
+
+def _text(content: str) -> FakeCompletion:
+    return FakeCompletion(choices=[FakeChoice(FakeMessage(content=content))])
+
+
+def _skill_call(name: str, call_id: str = "c1") -> FakeCompletion:
+    return FakeCompletion(
+        choices=[
+            FakeChoice(
+                FakeMessage(
+                    tool_calls=[
+                        FakeToolCall(call_id, FakeFunction(SKILL_TOOL, json.dumps({"name": name})))
+                    ]
+                )
+            )
+        ]
+    )
+
+
+def _registry_with(*skills: Skill) -> tuple[Registry, tuple[str, ...]]:
+    reg = Registry()
+    return reg, tuple(reg.register_skill(skill) for skill in skills)
+
+
+def _reasoner(keys: tuple[str, ...], **kwargs: Any) -> Reasoner:
+    return Reasoner(
+        name="skilled",
+        model="gemini:gemini-2.5-flash",   # prompt-fallback provider: one dispatch path
+        system="You draft.",
+        skills=list(keys),
+        **kwargs,
+    )
+
+
+def test_descriptions_are_in_the_system_prompt_and_bodies_are_not(monkeypatch) -> None:
+    reg, keys = _registry_with(ALPHA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+    seen: list[list[dict[str, Any]]] = []
+
+    async def acompletion(**kwargs: Any) -> Any:
+        seen.append(kwargs["messages"])
+        return _text("done")
+
+    run(complete_reasoner(_reasoner(keys), "hi", acompletion=acompletion))
+    system = seen[0][0]["content"]
+    assert "Use for alpha work." in system
+    assert "ALPHA BODY" not in system
+    assert system.rstrip().endswith("You draft.")
+
+
+def test_skill_tool_is_offered_when_skills_are_active(monkeypatch) -> None:
+    reg, keys = _registry_with(ALPHA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+    seen: list[Any] = []
+
+    async def acompletion(**kwargs: Any) -> Any:
+        seen.append(kwargs.get("tools"))
+        return _text("done")
+
+    run(complete_reasoner(_reasoner(keys), "hi", acompletion=acompletion))
+    assert [t["function"]["name"] for t in seen[0]] == [SKILL_TOOL]
+
+
+def test_no_tool_and_no_block_without_skills() -> None:
+    seen: list[Any] = []
+
+    async def acompletion(**kwargs: Any) -> Any:
+        seen.append(kwargs)
+        return _text("done")
+
+    run(complete_reasoner(_reasoner(()), "hi", acompletion=acompletion))
+    assert "tools" not in seen[0]
+    assert "Available skills" not in seen[0]["messages"][0]["content"]
+
+
+def test_loading_a_skill_feeds_the_body_back_and_re_asks(monkeypatch) -> None:
+    reg, keys = _registry_with(ALPHA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+    replies = iter([_skill_call("alpha"), _text("drafted")])
+    seen: list[list[dict[str, Any]]] = []
+
+    async def acompletion(**kwargs: Any) -> Any:
+        seen.append(kwargs["messages"])
+        return next(replies)
+
+    result = run(complete_reasoner(_reasoner(keys), "hi", acompletion=acompletion))
+    assert result.reply == "drafted"
+    assert result.meta.skill_loads == ("alpha",)
+    assert result.meta.to_attrs()["llm.skill_loads"] == ["alpha"]
+    tool_turns = [m for m in seen[1] if m.get("role") == "tool"]
+    assert tool_turns and tool_turns[0]["content"] == "ALPHA BODY"
+
+
+def test_tool_is_withdrawn_after_the_last_skill_loads(monkeypatch) -> None:
+    reg, keys = _registry_with(ALPHA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+    replies = iter([_skill_call("alpha"), _text("drafted")])
+    seen: list[Any] = []
+
+    async def acompletion(**kwargs: Any) -> Any:
+        seen.append(kwargs.get("tools"))
+        return next(replies)
+
+    run(complete_reasoner(_reasoner(keys), "hi", acompletion=acompletion))
+    assert seen[0] is not None and seen[1] is None
+
+
+def test_second_skill_stays_loadable(monkeypatch) -> None:
+    reg, keys = _registry_with(ALPHA, BETA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+    replies = iter([_skill_call("alpha"), _skill_call("beta", "c2"), _text("drafted")])
+
+    async def acompletion(**kwargs: Any) -> Any:
+        return next(replies)
+
+    result = run(complete_reasoner(_reasoner(keys), "hi", acompletion=acompletion))
+    assert result.meta.skill_loads == ("alpha", "beta")
+
+
+def test_unknown_skill_name_is_answered_not_raised(monkeypatch) -> None:
+    reg, keys = _registry_with(ALPHA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+    replies = iter([_skill_call("ghost"), _text("drafted")])
+    seen: list[list[dict[str, Any]]] = []
+
+    async def acompletion(**kwargs: Any) -> Any:
+        seen.append(kwargs["messages"])
+        return next(replies)
+
+    result = run(complete_reasoner(_reasoner(keys), "hi", acompletion=acompletion))
+    assert result.reply == "drafted"
+    assert result.meta.skill_loads == ()
+    tool_turn = [m for m in seen[1] if m.get("role") == "tool"][0]
+    assert "ghost" in tool_turn["content"] and "alpha" in tool_turn["content"]
+
+
+def test_repeated_requests_cannot_spin_forever(monkeypatch) -> None:
+    reg, keys = _registry_with(ALPHA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+    calls = 0
+
+    async def acompletion(**kwargs: Any) -> Any:
+        nonlocal calls
+        calls += 1
+        return _skill_call("ghost", f"c{calls}")
+
+    result = run(complete_reasoner(_reasoner(keys), "hi", acompletion=acompletion))
+    assert calls <= 4
+    assert result.meta.skill_loads == ()
+
+
+def test_skill_calls_never_leak_to_the_agent_loop(monkeypatch) -> None:
+    reg, keys = _registry_with(ALPHA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+
+    async def acompletion(**kwargs: Any) -> Any:
+        return _skill_call("alpha")
+
+    result = run(complete_reasoner(_reasoner(keys), "hi", acompletion=acompletion))
+    calls = result.reply.get("tool_calls", []) if isinstance(result.reply, dict) else []
+    assert all(call["tool"] != SKILL_TOOL for call in calls)
+    assert result.meta.native_tool_calls == 0
+
+
+def test_real_tool_name_colliding_with_the_reserved_name_is_rejected(monkeypatch) -> None:
+    reg, keys = _registry_with(ALPHA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+    tools = [{"type": "function", "function": {"name": SKILL_TOOL, "parameters": {}}}]
+
+    async def acompletion(**kwargs: Any) -> Any:
+        return _text("done")
+
+    with pytest.raises(ValueError, match="reserved"):
+        run(complete_reasoner(_reasoner(keys), "hi", acompletion=acompletion, tools=tools))
+
+
+def test_the_skill_tool_enum_is_never_offered_empty(monkeypatch) -> None:
+    reg, keys = _registry_with(ALPHA, BETA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+    replies = iter([_skill_call("alpha"), _skill_call("beta", "c2"), _text("drafted")])
+    seen: list[Any] = []
+
+    async def acompletion(**kwargs: Any) -> Any:
+        seen.append(kwargs.get("tools"))
+        return next(replies)
+
+    run(complete_reasoner(_reasoner(keys), "hi", acompletion=acompletion))
+
+    observed: list[Any] = []
+    for payload in seen:
+        if payload is None:
+            observed.append(None)
+            continue
+        skill_tool = next(
+            tool for tool in payload if tool["function"]["name"] == SKILL_TOOL
+        )
+        enum = skill_tool["function"]["parameters"]["properties"]["name"]["enum"]
+        assert isinstance(enum, list) and enum
+        observed.append(enum)
+    assert observed == [["alpha", "beta"], ["beta"], None]
+
+
+def test_openai_batch_inlines_skill_bodies(monkeypatch) -> None:
+    from julep.execution.openai_batch import OpenAIBatchProvider
+
+    reg, keys = _registry_with(ALPHA)
+    monkeypatch.setattr("julep.execution.openai_batch.DEFAULT_REGISTRY", reg)
+    reasoner = Reasoner(
+        name="batched", model="openai:gpt-5.5", system="You draft.", skills=list(keys)
+    )
+    request = OpenAIBatchProvider().build_request("cid", reasoner, {"x": 1})
+    system = request["body"]["messages"][0]["content"]
+    assert "ALPHA BODY" in system and system.rstrip().endswith("You draft.")
+
+
+def test_openai_batch_is_unchanged_without_skills(monkeypatch) -> None:
+    from julep.execution.openai_batch import OpenAIBatchProvider
+
+    reasoner = Reasoner(name="plain-batch", model="openai:gpt-5.5", system="You draft.")
+    request = OpenAIBatchProvider().build_request("cid", reasoner, {"x": 1})
+    assert request["body"]["messages"][0]["content"] == "You draft."

--- a/tests/test_llm_skills.py
+++ b/tests/test_llm_skills.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -114,6 +115,26 @@ def _skill_call(name: str, call_id: str = "c1") -> FakeCompletion:
     )
 
 
+def _skill_call_with_arguments(arguments: str, call_id: str = "c1") -> FakeCompletion:
+    return FakeCompletion(
+        choices=[
+            FakeChoice(
+                FakeMessage(
+                    tool_calls=[
+                        FakeToolCall(call_id, FakeFunction(SKILL_TOOL, arguments))
+                    ]
+                )
+            )
+        ]
+    )
+
+
+def _tool_calls(*calls: FakeToolCall) -> FakeCompletion:
+    return FakeCompletion(
+        choices=[FakeChoice(FakeMessage(tool_calls=list(calls)))]
+    )
+
+
 def _registry_with(*skills: Skill) -> tuple[Registry, tuple[str, ...]]:
     reg = Registry()
     return reg, tuple(reg.register_skill(skill) for skill in skills)
@@ -171,7 +192,7 @@ def test_no_tool_and_no_block_without_skills() -> None:
 
 
 def test_loading_a_skill_feeds_the_body_back_and_re_asks(monkeypatch) -> None:
-    reg, keys = _registry_with(ALPHA)
+    reg, keys = _registry_with(ALPHA, BETA)
     monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
     replies = iter([_skill_call("alpha"), _text("drafted")])
     seen: list[list[dict[str, Any]]] = []
@@ -231,6 +252,45 @@ def test_unknown_skill_name_is_answered_not_raised(monkeypatch) -> None:
     assert "ghost" in tool_turn["content"] and "alpha" in tool_turn["content"]
 
 
+def test_non_json_skill_arguments_are_answered_not_raised(monkeypatch) -> None:
+    reg, keys = _registry_with(ALPHA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+    replies = iter([_skill_call_with_arguments('{"name": "al'), _text("drafted")])
+    seen: list[list[dict[str, Any]]] = []
+
+    async def acompletion(**kwargs: Any) -> Any:
+        seen.append(kwargs["messages"])
+        return next(replies)
+
+    result = run(complete_reasoner(_reasoner(keys), "hi", acompletion=acompletion))
+    assert result.reply == "drafted"
+    assert result.meta.skill_loads == ()
+    tool_turn = [m for m in seen[1] if m.get("role") == "tool"][0]
+    assert SKILL_TOOL in tool_turn["content"]
+    assert "name" in tool_turn["content"] and "string" in tool_turn["content"]
+    assert "alpha" in tool_turn["content"]
+
+
+def test_non_string_skill_name_is_answered_not_raised(monkeypatch) -> None:
+    reg, keys = _registry_with(ALPHA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+    arguments = json.dumps({"name": {"a": 1}})
+    replies = iter([_skill_call_with_arguments(arguments), _text("drafted")])
+    seen: list[list[dict[str, Any]]] = []
+
+    async def acompletion(**kwargs: Any) -> Any:
+        seen.append(kwargs["messages"])
+        return next(replies)
+
+    result = run(complete_reasoner(_reasoner(keys), "hi", acompletion=acompletion))
+    assert result.reply == "drafted"
+    assert result.meta.skill_loads == ()
+    tool_turn = [m for m in seen[1] if m.get("role") == "tool"][0]
+    assert SKILL_TOOL in tool_turn["content"]
+    assert "name" in tool_turn["content"] and "string" in tool_turn["content"]
+    assert "alpha" in tool_turn["content"]
+
+
 def test_repeated_requests_cannot_spin_forever(monkeypatch) -> None:
     reg, keys = _registry_with(ALPHA)
     monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
@@ -249,14 +309,159 @@ def test_repeated_requests_cannot_spin_forever(monkeypatch) -> None:
 def test_skill_calls_never_leak_to_the_agent_loop(monkeypatch) -> None:
     reg, keys = _registry_with(ALPHA)
     monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+    replies = iter(
+        [
+            _skill_call("alpha"),
+            _tool_calls(
+                FakeToolCall("c2", FakeFunction(SKILL_TOOL, '{"name": "alpha"}')),
+                FakeToolCall("r1", FakeFunction("lookup", '{"q": "x"}')),
+            ),
+        ]
+    )
 
     async def acompletion(**kwargs: Any) -> Any:
-        return _skill_call("alpha")
+        return next(replies)
 
     result = run(complete_reasoner(_reasoner(keys), "hi", acompletion=acompletion))
-    calls = result.reply.get("tool_calls", []) if isinstance(result.reply, dict) else []
-    assert all(call["tool"] != SKILL_TOOL for call in calls)
+    assert result.reply == {
+        "tool_calls": [{"id": "r1", "tool": "lookup", "input": {"q": "x"}}]
+    }
+    assert result.meta.native_tool_calls == 1
+
+
+def test_mixed_skill_and_real_tool_call_warns_and_reasks(monkeypatch, caplog) -> None:
+    reg, keys = _registry_with(ALPHA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+    replies = iter(
+        [
+            _tool_calls(
+                FakeToolCall("c1", FakeFunction(SKILL_TOOL, '{"name": "alpha"}')),
+                FakeToolCall("r1", FakeFunction("lookup", '{"q": "x"}')),
+            ),
+            _text("drafted"),
+        ]
+    )
+
+    async def acompletion(**kwargs: Any) -> Any:
+        return next(replies)
+
+    with caplog.at_level(logging.WARNING, logger="julep.execution.llm"):
+        result = run(complete_reasoner(_reasoner(keys), "hi", acompletion=acompletion))
+
+    assert result.reply == "drafted"
+    assert "lookup" not in str(result.reply)
+    warning = caplog.text
+    assert "skilled" in warning and "lookup" in warning
+    assert "re-decided after skill disclosure" in warning
+
+
+def test_skillless_json_tool_calls_payload_preserves_pre_feature_meta() -> None:
+    payload = {"tool_calls": [{"tool": "lookup", "input": {"q": "x"}}]}
+
+    async def acompletion(**kwargs: Any) -> Any:
+        return _text(json.dumps(payload))
+
+    result = run(
+        complete_reasoner(
+            _reasoner((), reply={"type": "object"}),
+            "hi",
+            acompletion=acompletion,
+        )
+    )
+    assert result.reply == payload
     assert result.meta.native_tool_calls == 0
+
+
+def test_skillless_json_tool_calls_payload_allows_non_dict_items() -> None:
+    payload = {"tool_calls": ["oops"]}
+
+    async def acompletion(**kwargs: Any) -> Any:
+        return _text(json.dumps(payload))
+
+    result = run(
+        complete_reasoner(
+            _reasoner((), reply={"type": "object"}),
+            "hi",
+            acompletion=acompletion,
+        )
+    )
+    assert result.reply == payload
+    assert result.meta.native_tool_calls == 0
+
+
+def test_withdrawal_round_uses_plain_skill_disclosure(monkeypatch) -> None:
+    reg, keys = _registry_with(ALPHA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+    replies = iter([_skill_call("alpha"), _text("drafted")])
+    seen: list[list[dict[str, Any]]] = []
+
+    async def acompletion(**kwargs: Any) -> Any:
+        seen.append(kwargs["messages"])
+        return next(replies)
+
+    result = run(complete_reasoner(_reasoner(keys), "hi", acompletion=acompletion))
+    assert result.reply == "drafted"
+    assert not any("tool_calls" in message for message in seen[1])
+    assert not any(message.get("role") == "tool" for message in seen[1])
+    assert any("ALPHA BODY" in str(message.get("content")) for message in seen[1])
+
+
+def test_prompt_cache_keeps_round_note_volatile_on_disclosure(monkeypatch) -> None:
+    from julep.agent_loop import ROUND_NOTE_KEY
+
+    reg, keys = _registry_with(ALPHA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+    replies = iter([_skill_call("alpha"), _text("drafted")])
+    seen: list[list[dict[str, Any]]] = []
+
+    async def acompletion(**kwargs: Any) -> Any:
+        seen.append(kwargs["messages"])
+        return next(replies)
+
+    reasoner = Reasoner(
+        name="cached-skilled",
+        model="anthropic:claude-x",
+        system="You draft.",
+        prompt_cache="1h",
+        skills=list(keys),
+    )
+    run(
+        complete_reasoner(
+            reasoner,
+            {"task": "hi", ROUND_NOTE_KEY: "round note"},
+            acompletion=acompletion,
+        )
+    )
+
+    system = [message for message in seen[1] if message.get("role") == "system"]
+    assert len(system) == 1
+    blocks = system[0]["content"]
+    assert blocks[-1] == {"type": "text", "text": "round note"}
+    assert "round note" not in blocks[0]["text"]
+
+
+def test_openai_restores_response_format_after_skill_tool_withdrawal(monkeypatch) -> None:
+    reg, keys = _registry_with(ALPHA)
+    monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)
+    replies = iter([_skill_call("alpha"), _text('{"answer": "drafted"}')])
+    seen: list[dict[str, Any]] = []
+
+    async def acompletion(**kwargs: Any) -> Any:
+        seen.append(kwargs)
+        return next(replies)
+
+    reasoner = Reasoner(
+        name="openai-skilled",
+        model="openai:gpt-5.5",
+        system="You draft.",
+        reply={"type": "object"},
+        skills=list(keys),
+    )
+    result = run(complete_reasoner(reasoner, "hi", acompletion=acompletion))
+
+    assert result.reply == {"answer": "drafted"}
+    assert "tools" in seen[0] and "response_format" not in seen[0]
+    assert "response_format" in seen[1] and "tools" not in seen[1]
 
 
 def test_real_tool_name_colliding_with_the_reserved_name_is_rejected(monkeypatch) -> None:

--- a/tests/test_llm_skills.py
+++ b/tests/test_llm_skills.py
@@ -166,6 +166,25 @@ def test_descriptions_are_in_the_system_prompt_and_bodies_are_not(monkeypatch) -
     assert system.rstrip().endswith("You draft.")
 
 
+def test_skills_resolve_from_the_callers_registry() -> None:
+    reg, keys = _registry_with(ALPHA)
+    seen: list[list[dict[str, Any]]] = []
+
+    async def acompletion(**kwargs: Any) -> Any:
+        seen.append(kwargs["messages"])
+        return _text("done")
+
+    run(
+        complete_reasoner(
+            _reasoner(keys),
+            "hi",
+            acompletion=acompletion,
+            registry=reg,
+        )
+    )
+    assert "Use for alpha work." in seen[0][0]["content"]
+
+
 def test_skill_tool_is_offered_when_skills_are_active(monkeypatch) -> None:
     reg, keys = _registry_with(ALPHA)
     monkeypatch.setattr("julep.execution.llm.DEFAULT_REGISTRY", reg)

--- a/tests/test_llm_skills.py
+++ b/tests/test_llm_skills.py
@@ -1,0 +1,63 @@
+"""Progressive skill disclosure: the prompt block, the tool, and the inner loop."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import pytest
+
+from julep.dotctx import Reasoner
+from julep.registry import Registry
+from julep.skills import (
+    SKILL_TOOL,
+    Skill,
+    batch_system_text,
+    inline_skills_block,
+    load_skill_tool_def,
+    resolve_skill_keys,
+    skills_prompt_block,
+)
+
+ALPHA = Skill(name="alpha", description="Use for alpha work.", body="ALPHA BODY")
+BETA = Skill(name="beta", description="Use for beta work.", body="BETA BODY")
+
+
+def test_prompt_block_lists_names_and_descriptions_but_never_bodies() -> None:
+    block = skills_prompt_block([ALPHA, BETA])
+    assert "alpha" in block and "Use for alpha work." in block
+    assert "beta" in block and "Use for beta work." in block
+    assert "ALPHA BODY" not in block and "BETA BODY" not in block
+    assert SKILL_TOOL in block
+
+
+def test_tool_def_enumerates_only_undisclosed_skills() -> None:
+    definition = load_skill_tool_def([ALPHA, BETA], loaded=["alpha"])
+    assert definition["function"]["name"] == SKILL_TOOL
+    enum = definition["function"]["parameters"]["properties"]["name"]["enum"]
+    assert enum == ["beta"]
+    assert definition["function"]["parameters"]["required"] == ["name"]
+
+
+def test_inline_block_carries_full_bodies() -> None:
+    block = inline_skills_block([ALPHA])
+    assert "ALPHA BODY" in block and "Use for alpha work." in block
+
+
+def test_resolve_skill_keys_reads_the_registry() -> None:
+    reg = Registry()
+    key = reg.register_skill(ALPHA)
+    assert resolve_skill_keys([key], registry=reg) == (ALPHA,)
+
+
+def test_batch_system_text_inlines_and_preserves_the_system() -> None:
+    reg = Registry()
+    key = reg.register_skill(ALPHA)
+    text = batch_system_text("You draft.", [key], registry=reg)
+    assert text.endswith("You draft.")
+    assert "ALPHA BODY" in text
+
+
+def test_batch_system_text_passes_through_without_skills() -> None:
+    assert batch_system_text("You draft.", [], registry=Registry()) == "You draft."

--- a/tests/test_local_pipeline.py
+++ b/tests/test_local_pipeline.py
@@ -44,6 +44,7 @@ from julep.local import (
     prepare_local_pipeline,
     run_local_pipeline,
 )
+from julep.llm import with_model_ladder
 from julep.qos import QoSTier
 from julep.projection import EventType
 from julep.registry import Registry
@@ -1015,6 +1016,26 @@ def test_embedded_worker_context_records_trajectory_and_attempts(
     assert stored_output["secret"] == "[local-redacted]"
 
 
+def test_embedded_model_ladder_attempt_callback_fires_once(tmp_path: Path) -> None:
+    _reasoner_project(tmp_path)
+    attempts = []
+    callback = attempts.append
+
+    async def base(reasoner: Reasoner, *_args: Any, **_kwargs: Any) -> LlmResult:
+        return LlmResult(
+            reply={"answer": "ok"},
+            meta=LlmCallMeta(served_model=reasoner.model, provider="test"),
+        )
+
+    caller = with_model_ladder(base, models=[], on_attempt=callback)
+    prepare_local_pipeline("summary", project_root=tmp_path).run_detailed(
+        {"text": "hello"},
+        context=WorkerContext(llm=caller, on_attempt=callback),
+    )
+
+    assert [attempt.outcome for attempt in attempts] == ["ok"]
+
+
 def test_embedded_llm_result_usage_and_unknown_cost_are_projected(
     tmp_path: Path,
 ) -> None:
@@ -1092,6 +1113,105 @@ def test_embedded_run_aggregates_usage_and_mixed_cost_without_charging_derived()
     # Only the reported leg remains a projection charge. The pricing-map
     # derivation is metadata, so durable Event.cost semantics do not change.
     assert sum(detailed.projection.cost_by_shape().values()) == pytest.approx(0.01)
+
+
+def test_embedded_run_totals_are_scoped_to_reused_projection_invocation() -> None:
+    reasoner = Reasoner("metered", "test:metered")
+    flow = think(reasoner.name)
+    prepared = LocalPipeline(
+        name="metered",
+        environment="local",
+        compiled=CompiledPipeline(
+            spec=PipelineSpec(name="metered", flow=flow, reasoners=(reasoner,)),
+            deployment=deploy(flow, tools=(), reasoners=(reasoner,)),
+            declared_schema_hash="test",
+            compiled_schema_hash="test",
+        ),
+        reasoners={reasoner.name: reasoner},
+    )
+
+    async def llm(*_args: Any, **_kwargs: Any) -> LlmResult:
+        return LlmResult(
+            reply="ok",
+            meta=LlmCallMeta(
+                served_model=reasoner.model,
+                provider="test",
+                usage=LlmUsage(8, 2, 10),
+                cost=0.01,
+                cost_status="reported",
+            ),
+        )
+
+    projection = InMemoryProjection()
+    prepared.run_detailed("first", llm=llm, projection=projection)
+    second = prepared.run_detailed("second", llm=llm, projection=projection)
+
+    assert second.usage == LlmUsage(8, 2, 10)
+    assert second.total_cost == pytest.approx(0.01)
+
+
+def test_embedded_run_totals_include_unattributed_agent_controller_calls() -> None:
+    reasoner = Reasoner("controller", "test:controller")
+    flow = app(reasoner.name, max_rounds=1)
+    spec = PipelineSpec(name="agent", flow=flow, reasoners=(reasoner,))
+    prepared = LocalPipeline(
+        name=spec.name,
+        environment="local",
+        compiled=CompiledPipeline(
+            spec=spec,
+            deployment=deploy(flow, tools=(), reasoners=(reasoner,)),
+            declared_schema_hash="test",
+            compiled_schema_hash="test",
+        ),
+        reasoners={reasoner.name: reasoner},
+    )
+
+    async def llm(*_args: Any, **_kwargs: Any) -> LlmResult:
+        return LlmResult(
+            reply={"done": True, "output": "done"},
+            meta=LlmCallMeta(
+                served_model=reasoner.model,
+                provider="test",
+                usage=LlmUsage(12, 3, 15),
+                cost=0.02,
+                cost_status="reported",
+            ),
+        )
+
+    detailed = prepared.run_detailed({}, llm=llm)
+
+    assert not any("llm.usage" in event.attrs for event in detailed.projection.events())
+    assert detailed.usage == LlmUsage(12, 3, 15)
+    assert detailed.total_cost == pytest.approx(0.02)
+
+
+def test_failed_foreground_primitive_is_retained_in_trajectory() -> None:
+    flow = call(native(_raise_tool.name))
+    spec = PipelineSpec(name="failing", flow=flow, tools=(_raise_tool,))
+    prepared = LocalPipeline(
+        name=spec.name,
+        environment="local",
+        compiled=CompiledPipeline(
+            spec=spec,
+            deployment=deploy(flow, tools=(_raise_tool,)),
+            declared_schema_hash="test",
+            compiled_schema_hash="test",
+        ),
+        reasoners={},
+    )
+    trajectory = InMemoryTrajectoryStore()
+
+    with pytest.raises(RuntimeError, match="batch-e-boom"):
+        prepared.run_detailed(
+            None,
+            context=WorkerContext(trajectory_sink=trajectory),
+            run_id="failed-primitive",
+        )
+
+    [step] = trajectory.list_trajectory_steps("failed-primitive")
+    assert step.op == "prim"
+    assert step.status == "failed"
+    assert step.error == "RuntimeError('batch-e-boom')"
 
 
 def test_deployment_retry_uses_injected_backoff_and_none_sleeper() -> None:

--- a/tests/test_local_pipeline.py
+++ b/tests/test_local_pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import shutil
 from pathlib import Path
 from typing import Any
 
@@ -8,15 +9,25 @@ import pytest
 
 from conftest import run
 from julep import (
+    AttemptMeta,
     CapabilityManifest,
     CompiledPipeline,
+    EmbeddedRun,
+    InMemoryProjection,
+    LlmCallMeta,
+    LlmResult,
     LocalPipeline,
     PipelineSpec,
+    ProjectionEvent,
+    Ann,
     app,
+    call,
     deploy,
     seq,
     think,
+    tool,
 )
+from julep.dsl import native
 from julep.contracts import McpAnnotations
 from julep.dotctx import Reasoner
 from julep.execution.effects import WorkerContext
@@ -31,7 +42,37 @@ from julep.local import (
     run_local_pipeline,
 )
 from julep.qos import QoSTier
+from julep.projection import EventType
 from julep.registry import Registry
+from julep.typed import seq as typed_seq
+
+
+@tool(effect="read", idempotent=True, name="batch_e_increment")
+def _increment(value: int) -> int:
+    return value + 1
+
+
+@tool(effect="read", idempotent=True, name="batch_e_raise")
+def _raise_tool(_value: Any) -> Any:
+    raise RuntimeError("batch-e-boom")
+
+
+async def configured_test_llm(
+    _reasoner: Any,
+    value: Any,
+    _principal: Any,
+    _transcript: Any,
+    _dispatch: Any,
+) -> Any:
+    return {"answer": f"configured:{value['source']}"}
+
+
+class _EventSink:
+    def __init__(self) -> None:
+        self.events: list[ProjectionEvent] = []
+
+    def append(self, event: ProjectionEvent) -> None:
+        self.events.append(event)
 
 
 def _reasoner_project(root: Path) -> None:
@@ -840,3 +881,197 @@ application = "foreground_app:application"
     with pytest.raises(LocalExecutionUnsupported, match="transcript-scoped"):
         prepared.run({}, llm=llm)
     assert called is False
+
+
+def test_embedded_value_envelope_projection_and_sync_parity() -> None:
+    flow = typed_seq(_increment, _increment).to_ir()
+    prepared = LocalPipeline(
+        name="two-step",
+        environment="local",
+        compiled=CompiledPipeline(
+            spec=PipelineSpec(name="two-step", flow=flow, tools=(_increment,)),
+            deployment=deploy(flow, tools=(_increment,)),
+            declared_schema_hash="test",
+            compiled_schema_hash="test",
+        ),
+        reasoners={},
+    )
+    projection = InMemoryProjection()
+
+    assert run(prepared.arun(1)) == 3
+    detailed = run(prepared.arun_detailed(1, projection=projection))
+    sync_detailed = prepared.run_detailed(1)
+
+    assert isinstance(detailed, EmbeddedRun)
+    assert detailed.value == sync_detailed.value == 3
+    assert detailed.projection is projection
+    assert detailed.artifact_hash == prepared.artifact_hash
+    assert sync_detailed.artifact_hash == prepared.artifact_hash
+
+    async def inside_loop() -> None:
+        with pytest.raises(LocalExecutionConfigurationError, match="active event loop"):
+            prepared.run_detailed(1)
+
+    asyncio.run(inside_loop())
+
+
+def test_embedded_sink_order_and_failure_projection() -> None:
+    successful = deploy(typed_seq(_increment, _increment).to_ir(), tools=(_increment,))
+    sink = _EventSink()
+
+    assert run(successful.adry_run(1, sink=sink)).value == 3
+    assert [event.type for event in sink.events] == [
+        EventType.PLANNED,
+        EventType.PLANNED,
+        EventType.DID,
+        EventType.PLANNED,
+        EventType.DID,
+        EventType.DID,
+    ]
+
+    failing_flow = call(native(_raise_tool.name))
+    failing_spec = PipelineSpec(name="failing", flow=failing_flow, tools=(_raise_tool,))
+    failing = LocalPipeline(
+        name="failing",
+        environment="local",
+        compiled=CompiledPipeline(
+            spec=failing_spec,
+            deployment=deploy(failing_flow, tools=(_raise_tool,)),
+            declared_schema_hash="test",
+            compiled_schema_hash="test",
+        ),
+        reasoners={},
+    )
+    failure_sink = _EventSink()
+    projection = InMemoryProjection()
+    with pytest.raises(RuntimeError, match="batch-e-boom"):
+        run(failing.arun_detailed(None, sink=failure_sink, projection=projection))
+
+    assert [event.type for event in failure_sink.events] == [
+        EventType.PLANNED,
+        EventType.FAILED,
+    ]
+    assert projection.failures()[0].error == "RuntimeError('batch-e-boom')"
+
+
+def test_embedded_llm_result_usage_and_unknown_cost_are_projected(
+    tmp_path: Path,
+) -> None:
+    _reasoner_project(tmp_path)
+
+    async def llm(*_args: Any, **_kwargs: Any) -> LlmResult:
+        return LlmResult(
+            reply={"answer": "ok"},
+            meta=LlmCallMeta(
+                served_model="test:served",
+                provider="unknown-provider",
+                input_tokens=11,
+                output_tokens=7,
+                total_tokens=18,
+                attempts=(AttemptMeta("test:served", "unknown-provider", "ok", 11, 7),),
+            ),
+        )
+
+    detailed = prepare_local_pipeline("summary", project_root=tmp_path).run_detailed(
+        {"text": "hello"}, llm=llm
+    )
+    [did] = [event for event in detailed.projection.events() if event.type is EventType.DID]
+
+    assert did.attrs["llm.usage"] == {"input": 11, "output": 7, "total": 18}
+    assert did.attrs["llm.cost.status"] == "unknown"
+    assert detailed.projection.cost_by_shape() == {}
+
+
+def test_deployment_retry_uses_injected_backoff_and_none_sleeper() -> None:
+    flow = call(
+        native(_raise_tool.name),
+        ann=Ann(max_attempts=3, retry_interval_s=0.25, backoff_rate=2.0),
+    )
+    deployment = deploy(flow, tools=(_raise_tool,))
+    sleeps: list[float] = []
+
+    async def sleeper(interval: float) -> None:
+        sleeps.append(interval)
+
+    with pytest.raises(RuntimeError, match="batch-e-boom"):
+        run(deployment.adry_run(None, sleeper=sleeper))
+    assert sleeps == [0.25, 0.5]
+
+    with pytest.raises(RuntimeError, match="batch-e-boom"):
+        run(deployment.adry_run(None, sleeper=None))
+
+
+def test_load_pipeline_fixture_names_env_exports_and_kubernetes_name_escape(
+    tmp_path: Path,
+) -> None:
+    import julep
+    import julep.embedded as embedded
+
+    fixture = Path(__file__).parent / "fixtures/memmcp/episode_summary.ctx"
+    seen: list[tuple[str, str]] = []
+
+    async def llm(reasoner: Any, value: Any, *_args: Any) -> Any:
+        seen.append((reasoner.model, value["episode_id"]))
+        return "summary"
+
+    default = embedded.load_pipeline(fixture, env={"SUMMARY_MODEL": "test:env"})
+    explicit = embedded.load_pipeline(
+        fixture, name="custom-summary", env={"SUMMARY_MODEL": "test:env"}
+    )
+    assert default.name == "episode_summary"
+    assert explicit.name == "custom-summary"
+    assert default.run({"episode_id": "42"}, llm=llm) == "summary"
+    assert seen == [("test:env", "42")]
+
+    invalid_root = tmp_path / "---"
+    copied_ctx = invalid_root / "episode_summary.ctx"
+    shutil.copytree(fixture, copied_ctx)
+    (invalid_root / "pyproject.toml").write_text(
+        '[tool.julep]\n\n[tool.julep.pipeline.summary]\nctx = "episode_summary.ctx"\n'
+        '\n[tool.julep.env.local.vars]\nSUMMARY_MODEL = "test:env"\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="application name|Kubernetes|label"):
+        prepare_local_pipeline("summary", project_root=invalid_root)
+    assert embedded.load_pipeline(copied_ctx, env={"SUMMARY_MODEL": "test:env"}).run(
+        {"episode_id": "43"}, llm=llm
+    ) == "summary"
+
+    assert julep.EmbeddedRun is embedded.EmbeddedRun
+    assert julep.LlmResult is LlmResult
+    assert embedded.WorkerContext is WorkerContext
+
+
+def test_configured_llm_precedence_and_prepare_time_resolution(tmp_path: Path) -> None:
+    _reasoner_project(tmp_path)
+    config_path = tmp_path / "pyproject.toml"
+    config_path.write_text(
+        config_path.read_text(encoding="utf-8").replace(
+            "[tool.julep]\n", f'[tool.julep]\nllm_caller = "{__name__}:configured_test_llm"\n'
+        ),
+        encoding="utf-8",
+    )
+    prepared = prepare_local_pipeline("summary", project_root=tmp_path)
+
+    async def context_llm(*_args: Any, **_kwargs: Any) -> Any:
+        return {"answer": "context"}
+
+    async def explicit_llm(*_args: Any, **_kwargs: Any) -> Any:
+        return {"answer": "explicit"}
+
+    assert prepared.run({"source": "cfg"}) == {"answer": "configured:cfg"}
+    assert prepared.run({"source": "ctx"}, context=WorkerContext(llm=context_llm)) == {
+        "answer": "context"
+    }
+    assert prepared.run(
+        {"source": "explicit"},
+        llm=explicit_llm,
+        context=WorkerContext(llm=context_llm),
+    ) == {"answer": "explicit"}
+    assert prepared.configured_llm is configured_test_llm
+
+    unconfigured_root = tmp_path / "unconfigured"
+    unconfigured_root.mkdir()
+    _reasoner_project(unconfigured_root)
+    with pytest.raises(LocalExecutionConfigurationError, match=r"\[tool\.julep\] llm_caller"):
+        prepare_local_pipeline("summary", project_root=unconfigured_root).run({})

--- a/tests/test_local_pipeline.py
+++ b/tests/test_local_pipeline.py
@@ -16,6 +16,7 @@ from julep import (
     InMemoryProjection,
     LlmCallMeta,
     LlmResult,
+    LlmUsage,
     LocalPipeline,
     PipelineSpec,
     ProjectionEvent,
@@ -980,6 +981,57 @@ def test_embedded_llm_result_usage_and_unknown_cost_are_projected(
     assert did.attrs["llm.usage"] == {"input": 11, "output": 7, "total": 18}
     assert did.attrs["llm.cost.status"] == "unknown"
     assert detailed.projection.cost_by_shape() == {}
+
+
+def test_embedded_run_aggregates_usage_and_mixed_cost_without_charging_derived() -> None:
+    flow = seq(think("first"), think("second"))
+    first = Reasoner("first", "test:first")
+    second = Reasoner("second", "test:second")
+    prepared = LocalPipeline(
+        name="metered",
+        environment="local",
+        compiled=CompiledPipeline(
+            spec=PipelineSpec(name="metered", flow=flow, reasoners=(first, second)),
+            deployment=deploy(flow, tools=(), reasoners=(first, second)),
+            declared_schema_hash="test",
+            compiled_schema_hash="test",
+        ),
+        reasoners={
+            "first": first,
+            "second": second,
+        },
+    )
+
+    async def llm(reasoner: Reasoner, *_args: Any, **_kwargs: Any) -> LlmResult:
+        first = reasoner.name == "first"
+        usage = LlmUsage(
+            prompt_tokens=10 if first else 20,
+            completion_tokens=2 if first else 3,
+            total_tokens=12 if first else 23,
+            cache_read_tokens=1 if first else 4,
+            cache_creation_tokens=0,
+        )
+        return LlmResult(
+            reply=f"{reasoner.name}-reply",
+            meta=LlmCallMeta(
+                served_model=reasoner.model,
+                provider="test",
+                usage=usage,
+                cost=0.01 if first else 0.02,
+                cost_status="reported" if first else "derived",
+            ),
+        )
+
+    detailed = prepared.run_detailed("hello", llm=llm)
+
+    assert detailed.usage == LlmUsage(30, 5, 35, 5, 0)
+    assert detailed.usage_complete is True
+    assert detailed.total_cost == pytest.approx(0.03)
+    assert detailed.cost_status == "mixed"
+    assert detailed.cost_complete is True
+    # Only the reported leg remains a projection charge. The pricing-map
+    # derivation is metadata, so durable Event.cost semantics do not change.
+    assert sum(detailed.projection.cost_by_shape().values()) == pytest.approx(0.01)
 
 
 def test_deployment_retry_uses_injected_backoff_and_none_sleeper() -> None:

--- a/tests/test_local_pipeline.py
+++ b/tests/test_local_pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import shutil
 from pathlib import Path
 from typing import Any
@@ -31,6 +32,7 @@ from julep.dsl import native
 from julep.contracts import McpAnnotations
 from julep.dotctx import Reasoner
 from julep.execution.effects import WorkerContext
+from julep.execution.blobstore import InMemoryBlobStore
 from julep.errors import AgentTerminalError, ToolInputValidation
 from julep.freeze import McpServerSnapshot, McpSnapshot, McpToolSpec
 from julep.local import (
@@ -44,6 +46,7 @@ from julep.local import (
 from julep.qos import QoSTier
 from julep.projection import EventType
 from julep.registry import Registry
+from julep.trajectory import InMemoryTrajectoryStore
 from julep.typed import seq as typed_seq
 
 
@@ -952,6 +955,63 @@ def test_embedded_sink_order_and_failure_projection() -> None:
         EventType.FAILED,
     ]
     assert projection.failures()[0].error == "RuntimeError('batch-e-boom')"
+
+
+def test_embedded_worker_context_records_trajectory_and_attempts(
+    tmp_path: Path,
+) -> None:
+    _reasoner_project(tmp_path)
+    trajectory = InMemoryTrajectoryStore()
+    blobs = InMemoryBlobStore()
+    attempts = []
+
+    def redact(value: Any) -> Any:
+        if isinstance(value, dict):
+            return {
+                key: "[local-redacted]" if key == "secret" else child
+                for key, child in value.items()
+            }
+        return value
+
+    async def llm(
+        _reasoner: Any,
+        value: Any,
+        _principal: Any,
+        _transcript: Any,
+        _dispatch: Any,
+    ) -> Any:
+        return {"answer": value["text"], "secret": "model-secret"}
+
+    context = WorkerContext(
+        llm=llm,
+        on_attempt=attempts.append,
+        trajectory_sink=trajectory,
+        trajectory_blob_store=blobs,
+        redactor=redact,
+    )
+    result = prepare_local_pipeline("summary", project_root=tmp_path).run_detailed(
+        {"text": "hello", "secret": "input-secret"},
+        context=context,
+        run_id="embedded-observed",
+    )
+
+    assert result.value["answer"] == "hello"
+    assert [attempt.outcome for attempt in attempts] == ["ok"]
+    run_record = trajectory.get_trajectory_run("embedded-observed")
+    assert run_record is not None
+    assert run_record.status == "completed"
+    [step] = trajectory.list_trajectory_steps("embedded-observed")
+    assert step.op == "think"
+    assert step.input_ref is not None
+    assert step.output_ref is not None
+    stored_input = json.loads(
+        run(blobs.get("embedded-observed", step.input_ref)).decode()
+    )
+    stored_output = json.loads(
+        run(blobs.get("embedded-observed", step.output_ref)).decode()
+    )
+    assert stored_input["secret"] == "[local-redacted]"
+    assert stored_output["secret"] == "[local-redacted]"
 
 
 def test_embedded_llm_result_usage_and_unknown_cost_are_projected(

--- a/tests/test_memmcp_compat.py
+++ b/tests/test_memmcp_compat.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import json
 import os
 import sys
-import warnings
 from pathlib import Path
 
 import pytest
@@ -33,7 +32,6 @@ from julep.dotctx_evals import Sample, load_ctx_evals
 from julep.dotctx_rich import load_rich_dotctx
 from julep.prompt import get_renderer
 from julep.registry import Registry
-from julep.skills import InertSkillsDirectoryWarning
 
 FIXTURES = Path(__file__).parent / "fixtures" / "memmcp"
 
@@ -178,11 +176,11 @@ def test_load_ctx_evals_execute_eval_yaml() -> None:
 @pytest.mark.skipif(
     not os.path.isdir(_MEM_MCP_REPO), reason="sibling mem-mcp repo not checked out"
 )
+@pytest.mark.filterwarnings("ignore::julep.skills.InertSkillsDirectoryWarning")
 def test_sibling_repo_supported_prompts_all_load() -> None:
     # plan_sections.ctx ships skills/ with no skills: key. Under Julep's
     # explicit-activation rule that is inert and warns; the sweep only cares
     # that every package still loads.
-    warnings.filterwarnings("ignore", category=InertSkillsDirectoryWarning)
     ctx_paths = sorted(Path(_MEM_MCP_PROMPTS).rglob("*.ctx"))
     # Directories holding only a stale __pycache__ (leftovers of deleted
     # prompts) carry no settings.yaml and are not loadable packages.

--- a/tests/test_memmcp_compat.py
+++ b/tests/test_memmcp_compat.py
@@ -6,8 +6,11 @@ comment header, role markers, Input-only schema.pyi, tagged model, eval.py),
 ``execute.ctx`` (require_tool_call + tagged max_rounds + tools.pyi + eval.yaml),
 ``cluster_label.ctx`` (``response_format: {type: json_object}`` and a bare
 ``#`` header line before the first role marker), and ``anchor_choose.ctx``
-(mem-mcp's single-file frontmatter format). ``{% include %}`` partials are
-trimmed out — CA renders templates without a filesystem loader.
+(mem-mcp's single-file frontmatter format), and ``brief_draft.ctx`` (the
+``skills:`` setting activates one sidecar skill from
+``skills/natural-writing/SKILL.md`` with progressive disclosure). ``{% include
+%}`` partials are trimmed out — CA renders templates without a filesystem
+loader.
 
 The sweep test loads every supported ``.ctx`` under the sibling mem-mcp
 checkout's ``apps/memory-api/prompts`` and is skipped when that repo is absent.
@@ -18,6 +21,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import warnings
 from pathlib import Path
 
 import pytest
@@ -29,6 +33,7 @@ from julep.dotctx_evals import Sample, load_ctx_evals
 from julep.dotctx_rich import load_rich_dotctx
 from julep.prompt import get_renderer
 from julep.registry import Registry
+from julep.skills import InertSkillsDirectoryWarning
 
 FIXTURES = Path(__file__).parent / "fixtures" / "memmcp"
 
@@ -174,6 +179,10 @@ def test_load_ctx_evals_execute_eval_yaml() -> None:
     not os.path.isdir(_MEM_MCP_REPO), reason="sibling mem-mcp repo not checked out"
 )
 def test_sibling_repo_supported_prompts_all_load() -> None:
+    # plan_sections.ctx ships skills/ with no skills: key. Under Julep's
+    # explicit-activation rule that is inert and warns; the sweep only cares
+    # that every package still loads.
+    warnings.filterwarnings("ignore", category=InertSkillsDirectoryWarning)
     ctx_paths = sorted(Path(_MEM_MCP_PROMPTS).rglob("*.ctx"))
     # Directories holding only a stale __pycache__ (leftovers of deleted
     # prompts) carry no settings.yaml and are not loadable packages.
@@ -193,12 +202,6 @@ def test_sibling_repo_supported_prompts_all_load() -> None:
         try:
             rich = load_rich_dotctx(str(path), registry=Registry(), env={})
         except Exception as exc:
-            # AIDEV-NOTE: live mem-mcp may add settings keys after this compatibility
-            # snapshot. `skills` is unrelated to tagged env evaluation and is not
-            # represented by Julep's Reasoner yet; keep checking every supported
-            # package while the dedicated settings sweep still parses these files.
-            if "unknown settings keys" in str(exc) and ": skills (allowed:" in str(exc):
-                continue
             failures.append(f"{path.relative_to(_MEM_MCP_PROMPTS)}: {exc}")
             continue
         b = rich.reasoner
@@ -207,3 +210,23 @@ def test_sibling_repo_supported_prompts_all_load() -> None:
         assert "@" not in b.model               # effort suffix extracted, never leaks
 
     assert not failures, "mem-mcp prompts failed to load:\n" + "\n".join(failures)
+
+
+# --------------------------------------------------------------------------- #
+# brief_draft.ctx: the skills: setting with progressive disclosure.
+# --------------------------------------------------------------------------- #
+def test_brief_draft_activates_one_skill_without_inlining_it() -> None:
+    from julep.registry import Registry
+
+    # Fresh registry: renderers land on it, so resolve the system template through
+    # it rather than through the module-level DEFAULT_REGISTRY helper.
+    registry = Registry()
+    rich = load_rich_dotctx(
+        str(FIXTURES / "brief_draft.ctx"), registry=registry, env={}
+    )
+    assert [s.name for s in rich.skills] == ["natural-writing"]
+    assert rich.reasoner.skills[0].startswith("skill/natural-writing@v")
+    # Disclosure is progressive: the body is not in the rendered system prompt.
+    system = registry.get_renderer(rich.reasoner.system_render)({})
+    assert "Significance Inflation" not in system
+    assert system.startswith("You draft a living brief.")

--- a/tests/test_projection_tee.py
+++ b/tests/test_projection_tee.py
@@ -41,3 +41,15 @@ def test_tee_exposes_primary_value_store() -> None:
     [did] = [e for e in primary.events() if e.type.value == "Did"]
     assert did.value_ref is not None
     assert primary.values.get(did.value_ref) == {"big": "payload"}
+
+
+def test_tee_delegates_cancel_cleanup_to_primary() -> None:
+    primary = InMemoryProjection()
+    sink = _ListSink()
+    emitter = ProjectionEmitter(TeeStore(primary, sink))
+
+    event_id = emitter.plan("n1", "n1@1")
+    emitter.cancel("n1", "n1@1", event_id)
+
+    assert primary.events() == []
+    assert [event.event_id for event in sink.events] == [event_id]

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -42,6 +42,12 @@ from julep.trajectory import REDACTED_PLACEHOLDER, RedactionConfig
 from conftest import run
 
 
+# AIDEV-NOTE: a worker fails closed on Temporal payload encryption, matching
+# ServerSettings. Tests that are not about encryption take the documented
+# opt-out exactly as a hand-run plaintext worker must.
+_PLAINTEXT_WORKER = {"TEMPORAL_PAYLOAD_ENCRYPTION_REQUIRED": "false"}
+
+
 # --------------------------------------------------------------------------- #
 # Settings from the environment.
 # --------------------------------------------------------------------------- #
@@ -51,7 +57,9 @@ def test_from_env_requires_context_factory():
 
 
 def test_from_env_defaults():
-    s = WorkerServeSettings.from_env({"WORKER_CONTEXT_FACTORY": "m:f"})
+    s = WorkerServeSettings.from_env(
+        {"WORKER_CONTEXT_FACTORY": "m:f", **_PLAINTEXT_WORKER}
+    )
     assert s.context_factory == "m:f"
     assert s.application is None
     assert s.runtime_declarations_hash is None
@@ -74,6 +82,7 @@ def test_from_env_parses_blob_store_url() -> None:
         {
             "WORKER_CONTEXT_FACTORY": "m:f",
             "JULEP_BLOB_STORE_URL": "file:///var/lib/julep/blobs",
+            **_PLAINTEXT_WORKER,
         }
     )
     assert settings.blob_store_url == "file:///var/lib/julep/blobs"
@@ -108,6 +117,7 @@ def test_from_env_parses_redaction_config() -> None:
                 '{"key_patterns":["^private$"],'
                 '"path_patterns":["items.*.note"]}'
             ),
+            **_PLAINTEXT_WORKER,
         }
     )
     assert settings.redaction == RedactionConfig(
@@ -117,7 +127,11 @@ def test_from_env_parses_redaction_config() -> None:
 
     with pytest.raises(ValueError, match="invalid redaction JSON"):
         WorkerServeSettings.from_env(
-            {"WORKER_CONTEXT_FACTORY": "m:f", "JULEP_REDACTION": "{"}
+            {
+                "WORKER_CONTEXT_FACTORY": "m:f",
+                "JULEP_REDACTION": "{",
+                **_PLAINTEXT_WORKER,
+            }
         )
 
 
@@ -224,6 +238,7 @@ def test_from_env_full_parse():
         "WORKER_MAX_CONCURRENT_ACTIVITIES": "16",
         "WORKER_MAX_CONCURRENT_WORKFLOW_TASKS": "8",
         "WORKER_HEALTH_PORT": "8080",
+        **_PLAINTEXT_WORKER,
     })
     assert s.address == "temporal-frontend.temporal.svc:7233"
     assert s.application == "pkg.application:application"
@@ -241,17 +256,24 @@ def test_from_env_parses_versioning():
         "WORKER_CONTEXT_FACTORY": "m:f",
         "JULEP_WORKER_BUILD_ID": "build-42",
         "JULEP_WORKER_VERSIONING": "1",
+        **_PLAINTEXT_WORKER,
     })
     assert s.build_id == "build-42"
     assert s.use_worker_versioning is True
 
 
 def test_api_key_implies_tls_unless_overridden():
-    base = {"WORKER_CONTEXT_FACTORY": "m:f", "TEMPORAL_API_KEY": "k"}
+    base = {
+        "WORKER_CONTEXT_FACTORY": "m:f",
+        "TEMPORAL_API_KEY": "k",
+        **_PLAINTEXT_WORKER,
+    }
     assert WorkerServeSettings.from_env(base).tls is True
     s = WorkerServeSettings.from_env({**base, "TEMPORAL_TLS": "false"})
     assert s.tls is False and s.api_key == "k"
-    s = WorkerServeSettings.from_env({"WORKER_CONTEXT_FACTORY": "m:f", "TEMPORAL_TLS": "ON"})
+    s = WorkerServeSettings.from_env(
+        {"WORKER_CONTEXT_FACTORY": "m:f", "TEMPORAL_TLS": "ON", **_PLAINTEXT_WORKER}
+    )
     assert s.tls is True
 
 
@@ -276,7 +298,7 @@ def test_worker_settings_resolve_startup_secret_references() -> None:
 
 
 def test_bad_env_values_fail_loudly():
-    base = {"WORKER_CONTEXT_FACTORY": "m:f"}
+    base = {"WORKER_CONTEXT_FACTORY": "m:f", **_PLAINTEXT_WORKER}
     with pytest.raises(ValueError, match="TEMPORAL_TLS"):
         WorkerServeSettings.from_env({**base, "TEMPORAL_TLS": "banana"})
     with pytest.raises(ValueError, match="WORKER_HEALTH_PORT"):
@@ -303,6 +325,48 @@ def test_required_payload_encryption_rejects_missing_keys():
                 "TEMPORAL_PAYLOAD_ENCRYPTION_REQUIRED": "true",
             }
         )
+
+
+def test_worker_payload_encryption_defaults_to_required_like_the_server():
+    """An unset TEMPORAL_PAYLOAD_ENCRYPTION_REQUIRED fails a keyless worker."""
+    from julep.server.settings import ServerSettings
+
+    assert WorkerServeSettings.payload_encryption_required is True
+    assert (
+        WorkerServeSettings.payload_encryption_required
+        == ServerSettings.payload_encryption_required
+    )
+    with pytest.raises(ValueError, match="payload encryption is required"):
+        WorkerServeSettings.from_env({"WORKER_CONTEXT_FACTORY": "m:f"})
+
+
+def test_worker_payload_encryption_default_honors_documented_opt_out():
+    settings = WorkerServeSettings.from_env(
+        {"WORKER_CONTEXT_FACTORY": "m:f", **_PLAINTEXT_WORKER}
+    )
+    assert settings.payload_encryption_required is False
+    assert settings.payload_keys is None
+
+
+def test_worker_payload_encryption_default_accepts_a_keyring():
+    settings = WorkerServeSettings.from_env(
+        {
+            "WORKER_CONTEXT_FACTORY": "m:f",
+            "TEMPORAL_PAYLOAD_KEYS": "primary=" + "11" * 32,
+            "TEMPORAL_PAYLOAD_KEY_ID": "primary",
+        }
+    )
+    assert settings.payload_encryption_required is True
+    assert settings.payload_key_id == "primary"
+
+
+def test_ad_hoc_client_connections_keep_the_permissive_default():
+    """`julep run` against Temporal is a client, not a durable-plane server."""
+    from julep.execution.serve import payload_encryption_from_env
+
+    assert payload_encryption_from_env({}) == (None, None, False)
+    with pytest.raises(ValueError, match="payload encryption is required"):
+        payload_encryption_from_env({}, default_required=True)
 
 
 @pytest.mark.skipif(not HAVE_TEMPORAL, reason="temporal extra not installed")
@@ -366,6 +430,7 @@ def test_from_env_versioning_bad_bool():
         WorkerServeSettings.from_env({
             "WORKER_CONTEXT_FACTORY": "m:f",
             "JULEP_WORKER_VERSIONING": "banana",
+            **_PLAINTEXT_WORKER,
         })
 
 
@@ -638,6 +703,24 @@ def test_health_server_probes():
 
 
 @pytest.mark.skipif(not HAVE_TEMPORAL, reason="temporalio not installed")
+def test_serve_refuses_to_poll_plaintext_when_encryption_is_required(monkeypatch):
+    """Settings built in code get the same fail-closed check as from_env."""
+    from temporalio.client import Client
+
+    async def fake_connect(target, **kwargs):  # pragma: no cover - must not run
+        raise AssertionError("connected without a payload codec")
+
+    monkeypatch.setattr(Client, "connect", staticmethod(fake_connect))
+    settings = WorkerServeSettings(
+        context_factory=f"{__name__}:make_context",
+        payload_encryption_required=True,
+    )
+
+    with pytest.raises(JulepError, match="payload encryption is required"):
+        run(serve(settings))
+
+
+@pytest.mark.skipif(not HAVE_TEMPORAL, reason="temporalio not installed")
 def test_build_worker_forwards_versioning_kwargs(monkeypatch):
     from julep.execution import worker as worker_mod
     from julep.execution.worker import build_worker
@@ -703,6 +786,7 @@ def test_serve_forwards_versioning_kwargs_to_build_worker(monkeypatch, tmp_path:
         build_id="serve-bid",
         use_worker_versioning=True,
         blob_store_url=(tmp_path / "blobs").as_uri(),
+        payload_encryption_required=False,
     )
 
     async def _drive() -> None:
@@ -749,6 +833,7 @@ async def _serve_lifecycle():
             address=env.client.service_client.config.target_host,
             task_queue="julep-serve",
             graceful_shutdown_s=5.0,
+            payload_encryption_required=False,
         )
         stop = asyncio.Event()
         serve_task = asyncio.create_task(serve(settings, shutdown_event=stop))
@@ -770,6 +855,9 @@ def test_serve_lifecycle_end_to_end():
 
 @pytest.mark.skipif(HAVE_TEMPORAL, reason="exercises the missing-extra error")
 def test_serve_without_temporalio_fails_explicitly():
-    settings = WorkerServeSettings(context_factory=f"{__name__}:make_context")
+    settings = WorkerServeSettings(
+        context_factory=f"{__name__}:make_context",
+        payload_encryption_required=False,
+    )
     with pytest.raises(JulepError, match="julep\\[temporal\\]"):
         run(serve(settings))

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,0 +1,244 @@
+"""Skill value type, SKILL.md parsing, package loading, and registration."""
+
+from __future__ import annotations
+
+import pytest
+
+from julep.skills import (
+    SKILL_TOOL,
+    Skill,
+    SkillError,
+    parse_skill_markdown,
+    skill_key,
+)
+
+SKILL_MD = """\
+---
+name: natural-writing
+description: >
+  Write like a human, not a language model.
+---
+
+# Natural Writing
+
+Cut the significance inflation.
+"""
+
+
+def test_parse_skill_markdown_splits_frontmatter_from_body() -> None:
+    skill = parse_skill_markdown(SKILL_MD, origin="skills/natural-writing/SKILL.md")
+    assert skill.name == "natural-writing"
+    assert skill.description == "Write like a human, not a language model."
+    assert skill.body.startswith("# Natural Writing")
+    assert "significance inflation" in skill.body
+    assert skill.source == "skills/natural-writing/SKILL.md"
+
+
+def test_key_is_content_addressed_and_ignores_source() -> None:
+    a = parse_skill_markdown(SKILL_MD, origin="pkg_a/skills/natural-writing/SKILL.md")
+    b = parse_skill_markdown(SKILL_MD, origin="pkg_b/skills/natural-writing/SKILL.md")
+    assert skill_key(a) == skill_key(b)
+    assert a == b                       # source is excluded from equality
+    assert skill_key(a).startswith("skill/natural-writing@v")
+    assert len(skill_key(a).rsplit("@v", 1)[1]) == 12
+
+
+def test_key_changes_when_body_changes() -> None:
+    a = parse_skill_markdown(SKILL_MD, origin="x")
+    b = parse_skill_markdown(SKILL_MD.replace("inflation", "deflation"), origin="x")
+    assert skill_key(a) != skill_key(b)
+
+
+def test_key_changes_when_description_changes() -> None:
+    a = parse_skill_markdown(SKILL_MD, origin="x")
+    b = parse_skill_markdown(SKILL_MD.replace("a language model", "an LLM"), origin="x")
+    assert skill_key(a) != skill_key(b)
+
+
+def test_missing_frontmatter_is_a_loud_error() -> None:
+    with pytest.raises(SkillError, match="frontmatter"):
+        parse_skill_markdown("# Just a heading\n", origin="skills/x/SKILL.md")
+
+
+def test_missing_name_is_a_loud_error() -> None:
+    text = "---\ndescription: no name here\n---\n\nbody\n"
+    with pytest.raises(SkillError, match="non-empty name"):
+        parse_skill_markdown(text, origin="skills/x/SKILL.md")
+
+
+def test_non_mapping_frontmatter_is_a_loud_error() -> None:
+    with pytest.raises(SkillError, match="YAML mapping"):
+        parse_skill_markdown("---\n- a\n- b\n---\n\nbody\n", origin="skills/x/SKILL.md")
+
+
+def test_empty_body_is_a_loud_error() -> None:
+    text = "---\nname: x\ndescription: d\n---\n\n   \n"
+    with pytest.raises(SkillError, match="empty body"):
+        parse_skill_markdown(text, origin="skills/x/SKILL.md")
+
+
+def test_skill_tool_name_is_provider_safe() -> None:
+    from julep.execution.llm import provider_safe_tool_name
+
+    assert provider_safe_tool_name(SKILL_TOOL) == SKILL_TOOL
+
+
+import os
+
+from julep.skills import (
+    InertSkillsDirectoryWarning,
+    load_package_skills,
+    parse_skills_setting,
+)
+
+
+def _write_skill(pkg: str, dirname: str, *, name: str, body: str = "Do the thing.") -> None:
+    path = os.path.join(pkg, "skills", dirname)
+    os.makedirs(path, exist_ok=True)
+    with open(os.path.join(path, "SKILL.md"), "w", encoding="utf-8") as fh:
+        fh.write(f"---\nname: {name}\ndescription: describes {name}\n---\n\n{body}\n")
+
+
+def test_allowlist_selects_and_orders_by_declaration(tmp_path) -> None:
+    pkg = str(tmp_path)
+    _write_skill(pkg, "alpha", name="alpha")
+    _write_skill(pkg, "beta", name="beta")
+    skills = load_package_skills(pkg, ["beta", "alpha"])
+    assert [s.name for s in skills] == ["beta", "alpha"]
+
+
+def test_absent_key_activates_nothing_and_warns_when_dir_exists(tmp_path) -> None:
+    pkg = str(tmp_path)
+    _write_skill(pkg, "alpha", name="alpha")
+    with pytest.warns(InertSkillsDirectoryWarning, match="skills/"):
+        assert load_package_skills(pkg, None) == ()
+
+
+def test_empty_list_activates_nothing_without_warning(tmp_path, recwarn) -> None:
+    pkg = str(tmp_path)
+    _write_skill(pkg, "alpha", name="alpha")
+    assert load_package_skills(pkg, []) == ()
+    assert not [w for w in recwarn if w.category is InertSkillsDirectoryWarning]
+
+
+def test_no_skills_dir_and_no_allowlist_is_silent(tmp_path, recwarn) -> None:
+    assert load_package_skills(str(tmp_path), None) == ()
+    assert not [w for w in recwarn if w.category is InertSkillsDirectoryWarning]
+
+
+def test_configured_name_without_a_sidecar_fails_closed(tmp_path) -> None:
+    pkg = str(tmp_path)
+    _write_skill(pkg, "alpha", name="alpha")
+    with pytest.raises(SkillError, match="ghost.*available.*alpha"):
+        load_package_skills(pkg, ["ghost"])
+
+
+def test_allowlist_without_a_skills_dir_fails_closed(tmp_path) -> None:
+    with pytest.raises(SkillError, match="no skills/ directory"):
+        load_package_skills(str(tmp_path), ["alpha"])
+
+
+def test_extra_file_in_a_skill_directory_is_rejected(tmp_path) -> None:
+    pkg = str(tmp_path)
+    _write_skill(pkg, "alpha", name="alpha")
+    with open(os.path.join(pkg, "skills", "alpha", "references.md"), "w") as fh:
+        fh.write("more")
+    with pytest.raises(SkillError, match="references.md"):
+        load_package_skills(pkg, ["alpha"])
+
+
+def test_loose_file_directly_under_skills_is_rejected(tmp_path) -> None:
+    pkg = str(tmp_path)
+    _write_skill(pkg, "alpha", name="alpha")
+    with open(os.path.join(pkg, "skills", "README.md"), "w") as fh:
+        fh.write("hi")
+    with pytest.raises(SkillError, match="README.md"):
+        load_package_skills(pkg, ["alpha"])
+
+
+def test_directory_name_must_match_frontmatter_name(tmp_path) -> None:
+    pkg = str(tmp_path)
+    _write_skill(pkg, "alpha", name="not-alpha")
+    with pytest.raises(SkillError, match="directory 'alpha'.*'not-alpha'"):
+        load_package_skills(pkg, ["not-alpha"])
+
+
+def test_duplicate_names_are_unresolvable(tmp_path) -> None:
+    pkg = str(tmp_path)
+    _write_skill(pkg, "alpha", name="alpha")
+    os.makedirs(os.path.join(pkg, "skills", "alpha-copy"))
+    with open(os.path.join(pkg, "skills", "alpha-copy", "SKILL.md"), "w") as fh:
+        fh.write("---\nname: alpha\ndescription: dupe\n---\n\nbody\n")
+    with pytest.raises(SkillError, match="directory 'alpha-copy'"):
+        load_package_skills(pkg, ["alpha"])
+
+
+def test_duplicate_allowlist_entries_are_rejected() -> None:
+    with pytest.raises(SkillError, match="duplicate"):
+        parse_skills_setting(["a", "a"], origin="settings.yaml")
+
+
+def test_parse_skills_setting_forms() -> None:
+    assert parse_skills_setting(None, origin="s") is None
+    assert parse_skills_setting([], origin="s") == ()
+    assert parse_skills_setting(["a", "b"], origin="s") == ("a", "b")
+
+
+def test_mapping_items_reserved_for_future_options() -> None:
+    with pytest.raises(SkillError, match="list of skill names"):
+        parse_skills_setting([{"name": "a", "mode": "inline"}], origin="s")
+
+
+def test_non_list_setting_is_rejected() -> None:
+    with pytest.raises(SkillError, match="list of skill names"):
+        parse_skills_setting("natural-writing", origin="s")
+
+
+from julep.registry import Registry
+from julep.skills import get_skill, register_skill, skill_keys
+
+
+def _skill(name: str, body: str = "body") -> Skill:
+    return Skill(name=name, description=f"describes {name}", body=body)
+
+
+def test_register_returns_the_content_key_and_round_trips() -> None:
+    reg = Registry()
+    key = reg.register_skill(_skill("alpha"))
+    assert key == skill_key(_skill("alpha"))
+    assert reg.get_skill(key).body == "body"
+
+
+def test_identical_skills_from_different_sources_converge() -> None:
+    reg = Registry()
+    a = Skill(name="alpha", description="describes alpha", body="body", source="pkg_a")
+    b = Skill(name="alpha", description="describes alpha", body="body", source="pkg_b")
+    assert reg.register_skill(a) == reg.register_skill(b)
+    assert len(reg.skills) == 1
+
+
+def test_edited_copies_coexist_under_distinct_keys() -> None:
+    reg = Registry()
+    first = reg.register_skill(_skill("alpha", body="one"))
+    second = reg.register_skill(_skill("alpha", body="two"))
+    assert first != second
+    assert len(reg.skills) == 2
+
+
+def test_unknown_key_teaches() -> None:
+    reg = Registry()
+    with pytest.raises(KeyError, match="unknown skill"):
+        reg.get_skill("skill/ghost@v000000000000")
+
+
+def test_skill_keys_registers_objects_and_passes_strings_through() -> None:
+    reg = Registry()
+    existing = reg.register_skill(_skill("beta"))
+    keys = skill_keys([_skill("alpha"), existing], registry=reg)
+    assert keys == (skill_key(_skill("alpha")), existing)
+    assert set(reg.skills) == set(keys)
+
+
+def test_module_level_helpers_use_the_default_registry() -> None:
+    key = register_skill(_skill("gamma-unique-to-this-test"))
+    assert get_skill(key).name == "gamma-unique-to-this-test"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -303,3 +303,37 @@ def test_default_registry_skills_are_restored_between_tests() -> None:
     key = skill_key(_skill("gamma-unique-to-this-test"))
     with pytest.raises(KeyError, match="unknown skill"):
         get_skill(key)
+
+
+def test_public_exports() -> None:
+    import julep
+
+    assert julep.Skill is Skill
+    assert julep.SKILL_TOOL == SKILL_TOOL
+    for name in (
+        "Skill",
+        "SkillError",
+        "SKILL_TOOL",
+        "register_skill",
+        "get_skill",
+        "skill_keys",
+        "load_package_skills",
+    ):
+        assert name in julep.__all__, name
+
+
+def test_code_first_authoring_round_trip() -> None:
+    from julep.dotctx import Reasoner
+    from julep.registry import Registry
+
+    reg = Registry()
+    written = Skill(
+        name="house-style", description="How we write.", body="Short sentences."
+    )
+    reasoner = Reasoner(
+        name="code-first",
+        model="openai:gpt-5.5",
+        system="You write.",
+        skills=skill_keys([written], registry=reg),
+    )
+    assert reg.get_skill(reasoner.skills[0]).body == "Short sentences."

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -96,6 +96,17 @@ def test_missing_name_is_a_loud_error() -> None:
         parse_skill_markdown(text, origin="skills/x/SKILL.md")
 
 
+def test_invalid_skill_name_charset_names_file_and_name() -> None:
+    origin = "skills/bad/SKILL.md"
+    text = "---\nname: bad@name\ndescription: invalid name\n---\n\nbody\n"
+    with pytest.raises(SkillError) as exc_info:
+        parse_skill_markdown(text, origin=origin)
+    message = str(exc_info.value)
+    assert origin in message
+    assert "bad@name" in message
+    assert "^[A-Za-z0-9][A-Za-z0-9._-]*$" in message
+
+
 def test_non_mapping_frontmatter_is_a_loud_error() -> None:
     with pytest.raises(SkillError, match="YAML mapping"):
         parse_skill_markdown("---\n- a\n- b\n---\n\nbody\n", origin="skills/x/SKILL.md")

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -56,8 +56,38 @@ def test_key_changes_when_description_changes() -> None:
 
 
 def test_missing_frontmatter_is_a_loud_error() -> None:
-    with pytest.raises(SkillError, match="frontmatter"):
+    with pytest.raises(SkillError, match="has no YAML frontmatter"):
         parse_skill_markdown("# Just a heading\n", origin="skills/x/SKILL.md")
+
+
+def test_crlf_document_matches_lf_skill_key() -> None:
+    lf_skill = parse_skill_markdown(SKILL_MD, origin="skills/natural-writing/SKILL.md")
+    crlf_skill = parse_skill_markdown(
+        SKILL_MD.replace("\n", "\r\n"),
+        origin="skills/natural-writing/SKILL.md",
+    )
+    assert crlf_skill == lf_skill
+    assert skill_key(crlf_skill) == skill_key(lf_skill)
+
+
+def test_delimiter_trailing_whitespace_is_accepted() -> None:
+    text = SKILL_MD.replace("---\n", "--- \n", 1).replace("\n---\n", "\n---\t\n", 1)
+    skill = parse_skill_markdown(text, origin="skills/natural-writing/SKILL.md")
+    assert skill.name == "natural-writing"
+    assert skill.body.startswith("# Natural Writing")
+
+
+def test_utf8_bom_is_accepted() -> None:
+    skill = parse_skill_markdown(
+        "\ufeff" + SKILL_MD,
+        origin="skills/natural-writing/SKILL.md",
+    )
+    assert skill.name == "natural-writing"
+
+
+def test_empty_frontmatter_reports_missing_name() -> None:
+    with pytest.raises(SkillError, match="frontmatter needs a non-empty name"):
+        parse_skill_markdown("---\n---\n\nbody\n", origin="skills/x/SKILL.md")
 
 
 def test_missing_name_is_a_loud_error() -> None:
@@ -159,17 +189,31 @@ def test_loose_file_directly_under_skills_is_rejected(tmp_path) -> None:
 def test_directory_name_must_match_frontmatter_name(tmp_path) -> None:
     pkg = str(tmp_path)
     _write_skill(pkg, "alpha", name="not-alpha")
-    with pytest.raises(SkillError, match="directory 'alpha'.*'not-alpha'"):
+    with pytest.raises(
+        SkillError,
+        match=(
+            "directory 'alpha'.*declares name 'not-alpha'.*"
+            "directory name and the frontmatter name must match"
+        ),
+    ):
         load_package_skills(pkg, ["not-alpha"])
 
 
-def test_duplicate_names_are_unresolvable(tmp_path) -> None:
+def test_mismatched_directory_is_rejected_when_name_has_a_legitimate_owner(
+    tmp_path,
+) -> None:
     pkg = str(tmp_path)
     _write_skill(pkg, "alpha", name="alpha")
     os.makedirs(os.path.join(pkg, "skills", "alpha-copy"))
     with open(os.path.join(pkg, "skills", "alpha-copy", "SKILL.md"), "w") as fh:
         fh.write("---\nname: alpha\ndescription: dupe\n---\n\nbody\n")
-    with pytest.raises(SkillError, match="directory 'alpha-copy'"):
+    with pytest.raises(
+        SkillError,
+        match=(
+            "directory 'alpha-copy'.*declares name 'alpha'.*"
+            "directory name and the frontmatter name must match"
+        ),
+    ):
         load_package_skills(pkg, ["alpha"])
 
 
@@ -225,6 +269,17 @@ def test_edited_copies_coexist_under_distinct_keys() -> None:
     assert len(reg.skills) == 2
 
 
+def test_register_rejects_nul_boundary_key_collision() -> None:
+    reg = Registry()
+    first = Skill(name="a", description="x\0y", body="z")
+    second = Skill(name="a", description="x", body="y\0z")
+    assert skill_key(first) == skill_key(second)
+    assert first != second
+    reg.register_skill(first)
+    with pytest.raises(ValueError, match="already registered with different content"):
+        reg.register_skill(second)
+
+
 def test_unknown_key_teaches() -> None:
     reg = Registry()
     with pytest.raises(KeyError, match="unknown skill"):
@@ -242,3 +297,9 @@ def test_skill_keys_registers_objects_and_passes_strings_through() -> None:
 def test_module_level_helpers_use_the_default_registry() -> None:
     key = register_skill(_skill("gamma-unique-to-this-test"))
     assert get_skill(key).name == "gamma-unique-to-this-test"
+
+
+def test_default_registry_skills_are_restored_between_tests() -> None:
+    key = skill_key(_skill("gamma-unique-to-this-test"))
+    with pytest.raises(KeyError, match="unknown skill"):
+        get_skill(key)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -197,6 +197,33 @@ def test_loose_file_directly_under_skills_is_rejected(tmp_path) -> None:
         load_package_skills(pkg, ["alpha"])
 
 
+def test_symlinked_skill_directory_is_rejected(tmp_path) -> None:
+    pkg = tmp_path / "pkg"
+    external = tmp_path / "external"
+    pkg.mkdir()
+    _write_skill(str(external), "alpha", name="alpha")
+    (pkg / "skills").mkdir()
+    (pkg / "skills" / "alpha").symlink_to(external / "skills" / "alpha")
+
+    with pytest.raises(SkillError, match="skill directory 'alpha'.*symlink"):
+        load_package_skills(str(pkg), ["alpha"])
+
+
+def test_symlinked_skill_markdown_is_rejected(tmp_path) -> None:
+    pkg = tmp_path / "pkg"
+    skill_dir = pkg / "skills" / "alpha"
+    skill_dir.mkdir(parents=True)
+    external = tmp_path / "external-skill.md"
+    external.write_text(
+        "---\nname: alpha\ndescription: external\n---\n\nDo not load.\n",
+        encoding="utf-8",
+    )
+    (skill_dir / "SKILL.md").symlink_to(external)
+
+    with pytest.raises(SkillError, match="SKILL.md.*symlink"):
+        load_package_skills(str(pkg), ["alpha"])
+
+
 def test_directory_name_must_match_frontmatter_name(tmp_path) -> None:
     pkg = str(tmp_path)
     _write_skill(pkg, "alpha", name="not-alpha")

--- a/tests/test_skills_declarations.py
+++ b/tests/test_skills_declarations.py
@@ -125,6 +125,33 @@ def test_blob_carries_skill_bodies_and_round_trips() -> None:
     assert target.get_skill(key).body == "Do alpha."
 
 
+def test_release_load_rejects_a_global_skill_key_collision() -> None:
+    from julep.app import ApplicationDefinitionError
+    from julep.declarations import declarations_blob, load_declarations
+    from julep.registry import DEFAULT_REGISTRY, Registry
+
+    first = Skill(name="a", description="x\0y", body="z")
+    second = Skill(name="a", description="x", body="y\0z")
+    assert skill_key(first) == skill_key(second)
+    DEFAULT_REGISTRY.register_skill(first)
+
+    source = Registry()
+    key = source.register_skill(second)
+    blob = declarations_blob(
+        [Reasoner(name="colliding-skill", model="openai:gpt-5.5", skills=[key])],
+        registry=source,
+    )
+    target = Registry()
+    with pytest.raises(ApplicationDefinitionError, match="loaded release declaration"):
+        load_declarations(
+            blob,
+            expected_hash="sha256:" + hashlib.sha256(blob).hexdigest(),
+            registry=target,
+            release_scoped=True,
+        )
+    assert target.skills == {}
+
+
 def test_blob_rejects_a_skill_key_that_does_not_match_its_content() -> None:
     from julep.declarations import DeclarationError, load_declarations
     from julep.registry import Registry

--- a/tests/test_skills_declarations.py
+++ b/tests/test_skills_declarations.py
@@ -30,6 +30,24 @@ def test_malformed_skill_key_is_rejected_at_construction() -> None:
         Reasoner(name="r", model="openai:gpt-5.5", skills=["natural-writing"])
 
 
+def test_duplicate_skill_names_are_rejected_at_construction() -> None:
+    first = Skill(name="alpha", description="first", body="Do alpha first.")
+    second = Skill(name="alpha", description="second", body="Do alpha second.")
+    first_key = skill_key(first)
+    second_key = skill_key(second)
+    assert first_key != second_key
+
+    with pytest.raises(
+        ValueError,
+        match="duplicate skill name 'alpha'.*reasoner 'duplicate-skills'",
+    ):
+        Reasoner(
+            name="duplicate-skills",
+            model="openai:gpt-5.5",
+            skills=[first_key, second_key],
+        )
+
+
 def test_replace_preserves_and_overrides_skills() -> None:
     r = Reasoner(name="r", model="openai:gpt-5.5", skills=[ALPHA_KEY])
     assert r.replace(temperature=0.5).skills == (ALPHA_KEY,)
@@ -48,6 +66,20 @@ def test_identity_omits_skills_when_absent_and_includes_them_when_set() -> None:
     skilled = Reasoner(name="ident-skilled", model="openai:gpt-5.5", skills=[ALPHA_KEY])
     DEFAULT_REGISTRY.register_reasoner(skilled)
     assert _reasoner_identity("ident-skilled")["skills"] == [ALPHA_KEY]
+
+
+def test_runtime_declaration_omits_skills_when_absent_and_includes_them_when_set() -> None:
+    from julep.app import _reasoner_runtime_declaration
+
+    plain = Reasoner(name="runtime-plain", model="openai:gpt-5.5")
+    assert "skills" not in _reasoner_runtime_declaration(plain)
+
+    skilled = Reasoner(
+        name="runtime-skilled",
+        model="openai:gpt-5.5",
+        skills=[ALPHA_KEY],
+    )
+    assert _reasoner_runtime_declaration(skilled)["skills"] == [ALPHA_KEY]
 
 
 def test_editing_a_skill_body_moves_the_reasoner_identity() -> None:

--- a/tests/test_skills_declarations.py
+++ b/tests/test_skills_declarations.py
@@ -1,0 +1,62 @@
+"""Reasoner.skills: identity, replace(), and the declarations blob round trip."""
+
+from __future__ import annotations
+
+import pytest
+
+from julep.dotctx import Reasoner
+from julep.skills import Skill, skill_key
+
+ALPHA = Skill(name="alpha", description="describes alpha", body="Do alpha.")
+BETA = Skill(name="beta", description="describes beta", body="Do beta.")
+ALPHA_KEY = skill_key(ALPHA)
+BETA_KEY = skill_key(BETA)
+
+
+def test_reasoner_defaults_to_no_skills() -> None:
+    assert Reasoner(name="r", model="openai:gpt-5.5").skills == ()
+
+
+def test_reasoner_stores_skill_keys_in_order() -> None:
+    r = Reasoner(name="r", model="openai:gpt-5.5", skills=[BETA_KEY, ALPHA_KEY])
+    assert r.skills == (BETA_KEY, ALPHA_KEY)
+
+
+def test_malformed_skill_key_is_rejected_at_construction() -> None:
+    with pytest.raises(ValueError, match="malformed skill key"):
+        Reasoner(name="r", model="openai:gpt-5.5", skills=["natural-writing"])
+
+
+def test_replace_preserves_and_overrides_skills() -> None:
+    r = Reasoner(name="r", model="openai:gpt-5.5", skills=[ALPHA_KEY])
+    assert r.replace(temperature=0.5).skills == (ALPHA_KEY,)
+    assert r.replace(skills=()).skills == ()
+    assert r.replace(skills=[BETA_KEY]).skills == (BETA_KEY,)
+
+
+def test_identity_omits_skills_when_absent_and_includes_them_when_set() -> None:
+    from julep.deploy import _reasoner_identity
+    from julep.registry import DEFAULT_REGISTRY
+
+    plain = Reasoner(name="ident-plain", model="openai:gpt-5.5")
+    DEFAULT_REGISTRY.register_reasoner(plain)
+    assert "skills" not in _reasoner_identity("ident-plain")
+
+    skilled = Reasoner(name="ident-skilled", model="openai:gpt-5.5", skills=[ALPHA_KEY])
+    DEFAULT_REGISTRY.register_reasoner(skilled)
+    assert _reasoner_identity("ident-skilled")["skills"] == [ALPHA_KEY]
+
+
+def test_editing_a_skill_body_moves_the_reasoner_identity() -> None:
+    from julep.deploy import _reasoner_identity
+    from julep.registry import DEFAULT_REGISTRY
+
+    edited = Skill(name="alpha", description="describes alpha", body="Do alpha DIFFERENTLY.")
+    before = Reasoner(name="ident-drift", model="openai:gpt-5.5", skills=[ALPHA_KEY])
+    DEFAULT_REGISTRY.register_reasoner(before)
+    first = _reasoner_identity("ident-drift")
+
+    DEFAULT_REGISTRY.reasoners.pop("ident-drift")
+    after = Reasoner(name="ident-drift", model="openai:gpt-5.5", skills=[skill_key(edited)])
+    DEFAULT_REGISTRY.register_reasoner(after)
+    assert _reasoner_identity("ident-drift") != first

--- a/tests/test_skills_declarations.py
+++ b/tests/test_skills_declarations.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
+
 import pytest
 
 from julep.dotctx import Reasoner
@@ -60,3 +63,110 @@ def test_editing_a_skill_body_moves_the_reasoner_identity() -> None:
     after = Reasoner(name="ident-drift", model="openai:gpt-5.5", skills=[skill_key(edited)])
     DEFAULT_REGISTRY.register_reasoner(after)
     assert _reasoner_identity("ident-drift") != first
+
+
+def test_blob_carries_skill_bodies_and_round_trips() -> None:
+    from julep.declarations import declarations_blob, load_declarations
+    from julep.registry import Registry
+
+    source = Registry()
+    key = source.register_skill(ALPHA)
+    reasoner = Reasoner(name="blob-r", model="openai:gpt-5.5", skills=[key])
+    blob = declarations_blob([reasoner], registry=source)
+
+    payload = json.loads(blob)
+    assert payload["schemaVersion"] == 3
+    assert payload["skills"][key] == {
+        "name": "alpha",
+        "description": "describes alpha",
+        "body": "Do alpha.",
+    }
+    assert payload["reasoners"]["blob-r"]["skills"] == [key]
+
+    target = Registry()
+    load_declarations(
+        blob,
+        expected_hash="sha256:" + hashlib.sha256(blob).hexdigest(),
+        registry=target,
+    )
+    assert target.get_reasoner("blob-r").skills == (key,)
+    assert target.get_skill(key).body == "Do alpha."
+
+
+def test_blob_rejects_a_skill_key_that_does_not_match_its_content() -> None:
+    from julep.declarations import DeclarationError, load_declarations
+    from julep.registry import Registry
+
+    payload = {
+        "schemaVersion": 3,
+        "reasoners": {},
+        "renderers": {},
+        "agents": {},
+        "skills": {
+            "skill/alpha@v000000000000": {
+                "name": "alpha",
+                "description": "describes alpha",
+                "body": "Do alpha.",
+            }
+        },
+    }
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    with pytest.raises(DeclarationError, match="content hash"):
+        load_declarations(
+            blob,
+            expected_hash="sha256:" + hashlib.sha256(blob).hexdigest(),
+            registry=Registry(),
+        )
+
+
+def test_blob_rejects_a_reasoner_referencing_an_undeclared_skill() -> None:
+    from julep.declarations import DeclarationError, load_declarations
+    from julep.registry import Registry
+
+    payload = {
+        "schemaVersion": 3,
+        "reasoners": {
+            "orphan": {
+                "name": "orphan",
+                "model": "openai:gpt-5.5",
+                "system": "",
+                "replySchema": None,
+                "tools": [],
+                "temperature": None,
+                "maxRounds": None,
+                "isAgent": False,
+                "subContract": None,
+                "contextScope": "local",
+                "systemRender": None,
+                "userRender": None,
+                "maxTokens": None,
+                "reasoningEffort": None,
+                "outputRetries": 0,
+                "requireToolCall": False,
+                "responseFormat": None,
+                "promptCache": None,
+                "skills": [ALPHA_KEY],
+                "rendererSourceHashes": {},
+            }
+        },
+        "renderers": {},
+        "agents": {},
+        "skills": {},
+    }
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    with pytest.raises(DeclarationError, match="undeclared skill"):
+        load_declarations(
+            blob,
+            expected_hash="sha256:" + hashlib.sha256(blob).hexdigest(),
+            registry=Registry(),
+        )
+
+
+def test_blob_fails_when_the_source_registry_lacks_a_referenced_skill() -> None:
+    from julep.app import ApplicationDefinitionError
+    from julep.declarations import declarations_blob
+    from julep.registry import Registry
+
+    reasoner = Reasoner(name="missing-skill", model="openai:gpt-5.5", skills=[BETA_KEY])
+    with pytest.raises(ApplicationDefinitionError, match="no registered content"):
+        declarations_blob([reasoner], registry=Registry())

--- a/tests/test_skills_dotctx.py
+++ b/tests/test_skills_dotctx.py
@@ -1,0 +1,93 @@
+"""The skills: setting across the minimal, rich, and single-file layouts."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytest.importorskip("jinja2")
+
+from julep.dotctx import load_dotctx
+from julep.dotctx_rich import load_rich_dotctx
+from julep.registry import Registry
+from julep.skills import InertSkillsDirectoryWarning, SkillError, skill_key
+
+
+def _skill_dir(pkg, name: str, body: str = "Do the thing.") -> None:
+    path = pkg / "skills" / name
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: describes {name}\n---\n\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def _rich_pkg(tmp_path, settings: str):
+    pkg = tmp_path / "draft.ctx"
+    pkg.mkdir()
+    (pkg / "settings.yaml").write_text(settings, encoding="utf-8")
+    (pkg / "prompt.j2").write_text(
+        "<<< role:system >>>\nYou draft.\n<<< role:user >>>\nGo.\n", encoding="utf-8"
+    )
+    return pkg
+
+
+def test_rich_package_activates_a_skill(tmp_path) -> None:
+    pkg = _rich_pkg(tmp_path, "model: openai:gpt-5.5\nskills: [alpha]\n")
+    _skill_dir(pkg, "alpha")
+    _skill_dir(pkg, "beta")
+    registry = Registry()
+    rich = load_rich_dotctx(str(pkg), registry=registry, env={})
+    assert [s.name for s in rich.skills] == ["alpha"]
+    assert rich.reasoner.skills == (skill_key(rich.skills[0]),)
+    assert rich.reasoner.skills[0] in registry.skills
+
+
+def test_rich_package_with_empty_list_activates_nothing(tmp_path) -> None:
+    pkg = _rich_pkg(tmp_path, "model: openai:gpt-5.5\nskills: []\n")
+    _skill_dir(pkg, "alpha")
+    rich = load_rich_dotctx(str(pkg), registry=Registry(), env={})
+    assert rich.skills == () and rich.reasoner.skills == ()
+
+
+def test_rich_package_warns_on_an_inert_skills_dir(tmp_path) -> None:
+    pkg = _rich_pkg(tmp_path, "model: openai:gpt-5.5\n")
+    _skill_dir(pkg, "alpha")
+    with pytest.warns(InertSkillsDirectoryWarning):
+        rich = load_rich_dotctx(str(pkg), registry=Registry(), env={})
+    assert rich.reasoner.skills == ()
+
+
+def test_rich_package_missing_skill_fails_closed(tmp_path) -> None:
+    pkg = _rich_pkg(tmp_path, "model: openai:gpt-5.5\nskills: [ghost]\n")
+    _skill_dir(pkg, "alpha")
+    with pytest.raises(SkillError, match="ghost"):
+        load_rich_dotctx(str(pkg), registry=Registry(), env={})
+
+
+def test_skills_is_an_accepted_settings_key(tmp_path) -> None:
+    pkg = _rich_pkg(tmp_path, "model: openai:gpt-5.5\nskills: [alpha]\n")
+    _skill_dir(pkg, "alpha")
+    load_rich_dotctx(str(pkg), registry=Registry(), env={})  # no unknown-key error
+
+
+def test_minimal_layout_supports_skills(tmp_path) -> None:
+    pkg = tmp_path / "planner"
+    pkg.mkdir()
+    (pkg / "settings.yaml").write_text(
+        "model: openai:gpt-5.5\nsystem: You plan.\nskills: [alpha]\n", encoding="utf-8"
+    )
+    _skill_dir(pkg, "alpha")
+    reasoner = load_dotctx(str(pkg), env={}, _registry=Registry())
+    assert len(reasoner.skills) == 1
+    assert reasoner.skills[0].startswith("skill/alpha@v")
+
+
+def test_single_file_ctx_rejects_skills(tmp_path) -> None:
+    path = tmp_path / "solo.ctx"
+    path.write_text(
+        "---\nmodel: openai:gpt-5.5\nskills: [alpha]\n---\nBody.\n", encoding="utf-8"
+    )
+    with pytest.raises(SkillError, match="single-file"):
+        load_rich_dotctx(str(path), registry=Registry(), env={})

--- a/tests/test_skills_dotctx.py
+++ b/tests/test_skills_dotctx.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import os
-
 import pytest
 
 pytest.importorskip("jinja2")
@@ -91,3 +89,28 @@ def test_single_file_ctx_rejects_skills(tmp_path) -> None:
     )
     with pytest.raises(SkillError, match="single-file"):
         load_rich_dotctx(str(path), registry=Registry(), env={})
+
+
+def test_single_file_ctx_rejects_null_skills(tmp_path) -> None:
+    path = tmp_path / "solo.ctx"
+    path.write_text(
+        "---\nmodel: openai:gpt-5.5\nskills:\n---\nBody.\n", encoding="utf-8"
+    )
+    with pytest.raises(SkillError, match="single-file"):
+        load_rich_dotctx(str(path), registry=Registry(), env={})
+
+
+def test_rich_package_rejects_null_skills(tmp_path) -> None:
+    pkg = _rich_pkg(tmp_path, "model: openai:gpt-5.5\nskills:\n")
+    with pytest.raises(SkillError, match="must be a list of skill names"):
+        load_rich_dotctx(str(pkg), registry=Registry(), env={})
+
+
+def test_minimal_package_rejects_null_skills(tmp_path) -> None:
+    pkg = tmp_path / "planner"
+    pkg.mkdir()
+    (pkg / "settings.yaml").write_text(
+        "model: openai:gpt-5.5\nsystem: You plan.\nskills:\n", encoding="utf-8"
+    )
+    with pytest.raises(SkillError, match="must be a list of skill names"):
+        load_dotctx(str(pkg), env={}, _registry=Registry())


### PR DESCRIPTION
## Summary

Teaches dotctx packages the `skills:` setting: a package ships Anthropic-format `skills/<name>/SKILL.md` sidecars and activates them by name. Disclosure is **progressive** — only each activated skill's name and description reach the system prompt, and the model pulls a body mid-call through a reserved `__load_skill__` tool that the LLM caller resolves from the frozen release.

This closes the gap that made two live mem-mcp packages unloadable and forced a narrow `AIDEV-NOTE`-marked tolerance in `tests/test_memmcp_compat.py`. That tolerance is now gone and the sibling sweep loads all 35 real packages with none tolerated.

## Design decisions

- **Explicit activation.** `skills:` absent activates nothing; `skills: []` activates nothing silently; a present-but-inert `skills/` directory warns. This deliberately diverges from mem-mcp, which activates *all* skills when the key is absent — under that rule `briefs/plan_sections.ctx` silently pays ~11k tokens per call for skills it never named.
- **Progressive disclosure over inlining.** `natural-writing` is ~3.4k tokens and `office-hours` ~7.5k; inlining both unconditionally is the cost this avoids.
- **The disclosure loop lives inside `complete_reasoner`, not the IR.** It mirrors the existing `output_retries` inner re-ask loop, so a `think` leaf stays a `think` leaf, `max_rounds` keeps meaning rounds of *task progress*, and adding a skill never changes a prompt's execution topology. Skill tool calls are stripped before the reply returns, so they never reach the agent loop.
- **Package-local resolution, content-addressed keys** (`skill/<name>@v<hash12>` over name+description+body). Packages stay standalone; byte-identical copies across packages converge on one artifact entry. Because `Reasoner.skills` holds those keys, editing a skill body moves the reasoner identity by the same mechanism an edited template already does — drift detection comes free.
- **`SKILL.md` only.** Any other file in a skill directory is a load-time error; Anthropic's level-3 bundled resources (`references/`, `scripts/`) are reserved and remain a purely additive change later.

## Breaking change

The declarations blob schema bumps **2 → 3**. rc5 blobs are hard-rejected with `unsupported declarations blob schema version 2; expected 3`, so **workers and releases must roll forward together**. Deploy-manifest reasoner identity is unaffected for skill-less reasoners (`skills` is emitted only when set), and the golden corpus confirms pre-existing artifacts hash unchanged.

## Accepted tradeoff

Offering any tool disables provider-native `response_format` in this codebase, so a skill-bearing reasoner's first call uses prompt-injected schema guidance. The two-phase design withdraws the tool once disclosure finishes, restoring native structured output on the final call — verified by test. Relaxing the blanket `not has_tools` rule for providers that support tools alongside structured outputs is a real follow-up but was scoped out: it changes behavior for every tool-bearing reasoner, not just skill users.

## Verification

- Full suite **2607 passed, 31 skipped, 0 failed**; `ruff check julep` clean; `mypy --no-incremental julep` clean (147 files).
- Golden corpus and `test_agent_and_deploy.py` green — frozen-artifact stability gate.
- mem-mcp sibling sweep: 35 packages, zero tolerated failures.
- `julep/skills.py` imports without jinja2, so skills work in the minimal layout without the `[dotctx]` extra.

A whole-branch review found 1 Critical (malformed `__load_skill__` arguments crashed the call when a reply was truncated at `max_tokens`), 5 Important (two rc5-parity breaks, a reachable empty `enum`, an Anthropic-rejecting request shape) and 7 Minor. All 12 are fixed in `e288e23e`; a scoped re-review verified each by reverting the fix and confirming the covering test goes red.

## Migration note for mem-mcp

`briefs/plan_sections.ctx` ships a `skills/` directory with no `skills:` key. It loads clean and warns, but activates nothing — it needs an explicit `skills: [...]` list to keep the two skills it silently receives today.

## Known follow-ups

- Relax `native_response_format` per-provider (above).
- `eval.yaml` cannot pin disclosure behavior, so an eval over a skill-bearing package varies with the model's load decisions.
- Disclosure round trips surface in `LlmCallMeta.skill_loads` rather than as trajectory nodes — the accepted cost of keeping skills out of the IR.
- The tool-free round emits two consecutive `user` messages (precedented by the existing `retry_note` path). Verified structurally; no live provider call was made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/julep-ai/julep/pull/1625">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
## Embedded execution surface (Batch E)

This branch now also promotes foreground execution into a supported embedded product surface:

- `LocalPipeline.arun_detailed` / `run_detailed` return an `EmbeddedRun` containing the value, queryable in-memory projection, and artifact identity, while existing `arun` / `run` remain value-only.
- Projection sinks receive live PLANNED/DID/FAILED events; caller-owned projections remain inspectable when execution raises.
- `julep.embedded.load_pipeline` compiles standalone `.ctx` packages without project configuration or Kubernetes-derived naming.
- Configured `llm_caller` values now participate in local caller precedence, and LLM usage metadata types are root-public.
- Embedded retries now honor declared exponential backoff, with injectable sleepers for deterministic tests.

Batch E verification: full suite **2614 passed, 31 skipped, 10 deselected**; `ruff check` and `mypy` clean.